### PR TITLE
fix: test reliability (#3, #5, #32) + podGC defaults

### DIFF
--- a/manifests/workflow-controller-configmap.yaml
+++ b/manifests/workflow-controller-configmap.yaml
@@ -17,3 +17,8 @@ data:
         secondsAfterCompletion: 604800
         secondsAfterSuccess: 604800
         secondsAfterFailure: 2592000
+      # podGC.OnWorkflowSuccess: succeeded pods deleted immediately on workflow
+      # success; on failure, pods persist for the TTL window above so `argo
+      # logs` can fetch them. Bounded pod count → predictable scheduler load.
+      podGC:
+        strategy: OnWorkflowSuccess

--- a/tests/smoke/features/environment.py
+++ b/tests/smoke/features/environment.py
@@ -10,21 +10,20 @@ qecore-headless (invoked by the Argo runner) handles:
   - gnome-ponytail-daemon activation
   - AT-SPI bus bridge
 """
+import re
+import subprocess
 import sys
+import time
 import traceback
 
+from dogtail.config import config as dogtail_config
 from qecore.sandbox import TestSandbox
 from qecore.common_steps import *  # noqa: F401,F403 — registers all common @step definitions
 
 
 def before_all(context) -> None:
-    import re
-    import time
-    import subprocess
-
     # searchShowingOnly=True: all dogtail searches implicitly filter to .showing
     # nodes — removes need for redundant `.showing` predicates in step code.
-    from dogtail.config import config as dogtail_config
     dogtail_config.searchShowingOnly = True
 
     # Give GDM/GNOME Shell time to start the session
@@ -47,7 +46,7 @@ def before_all(context) -> None:
             if r.returncode == 0:
                 print(f"unsafe_mode set (attempt {attempt+1})", flush=True)
                 break
-            last_err = f"exit {r.returncode}: {r.stderr.decode()[:200]}"
+            last_err = f"exit {r.returncode}: {r.stderr.decode('utf-8', errors='replace')[:200]}"
             print(f"unsafe_mode attempt {attempt+1} failed ({last_err})", flush=True)
             time.sleep(2)
         except Exception as e:  # noqa: BLE001
@@ -74,7 +73,7 @@ def before_all(context) -> None:
                 toggles = panels[0].findChildren(
                     lambda n: n.roleName == 'toggle button')
                 toggle_names = [t.name for t in toggles]
-                if any(time_re.search(n or '') for n in toggle_names):
+                if any(n and time_re.search(n) for n in toggle_names):
                     print(f"Panel toggles ready: {toggle_names}", flush=True)
                     break
         except Exception as e:  # noqa: BLE001

--- a/tests/smoke/features/environment.py
+++ b/tests/smoke/features/environment.py
@@ -18,13 +18,22 @@ from qecore.common_steps import *  # noqa: F401,F403 — registers all common @s
 
 
 def before_all(context) -> None:
+    import re
     import time
     import subprocess
+
+    # searchShowingOnly=True: all dogtail searches implicitly filter to .showing
+    # nodes — removes need for redundant `.showing` predicates in step code.
+    from dogtail.config import config as dogtail_config
+    dogtail_config.searchShowingOnly = True
 
     # Give GDM/GNOME Shell time to start the session
     time.sleep(5)
 
-    # Enable unsafe_mode to expose clock and system-status in AT-SPI tree
+    # Enable unsafe_mode to expose clock and system-status in AT-SPI tree.
+    # Hard-fail if all attempts fail — tests downstream depend on this and
+    # silently proceeding hides the real cause of later AT-SPI lookup failures.
+    last_err = "unknown"
     for attempt in range(3):
         try:
             r = subprocess.run(
@@ -38,14 +47,24 @@ def before_all(context) -> None:
             if r.returncode == 0:
                 print(f"unsafe_mode set (attempt {attempt+1})", flush=True)
                 break
-            print(f"unsafe_mode attempt {attempt+1} failed (exit {r.returncode}): {r.stderr.decode()[:200]}", flush=True)
+            last_err = f"exit {r.returncode}: {r.stderr.decode()[:200]}"
+            print(f"unsafe_mode attempt {attempt+1} failed ({last_err})", flush=True)
             time.sleep(2)
         except Exception as e:  # noqa: BLE001
+            last_err = str(e)
             print(f"unsafe_mode attempt {attempt+1} failed: {e}", flush=True)
             time.sleep(2)
+    else:
+        raise RuntimeError(
+            f"unsafe_mode activation failed after 3 attempts ({last_err}). "
+            "Clock and system-menu toggles will not be reachable via AT-SPI."
+        )
 
-    # Poll until clock + system toggles appear in AT-SPI (up to 15s)
+    # Poll until a clock-like toggle (time string in name) appears in AT-SPI.
+    # Accepting "any non-Activities toggle" silently masked a broken shell setup
+    # where unsafe_mode hadn't taken effect — see issue #5.
     from dogtail import tree as dtree
+    time_re = re.compile(r'\d{1,2}:\d{2}|clock', re.IGNORECASE)
     deadline = time.time() + 15
     while time.time() < deadline:
         try:
@@ -53,19 +72,18 @@ def before_all(context) -> None:
             panels = shell.findChildren(lambda n: n.roleName == 'panel')
             if panels:
                 toggles = panels[0].findChildren(
-                    lambda n: n.roleName == 'toggle button' and n.showing)
+                    lambda n: n.roleName == 'toggle button')
                 toggle_names = [t.name for t in toggles]
-                print(f"Panel toggles: {toggle_names}", flush=True)
-                # Need more than just Activities + Show Apps
-                non_activities = [t for t in toggles if t.name != 'Activities']
-                if len(non_activities) >= 1:
-                    print("Clock/System toggles visible — proceeding", flush=True)
+                if any(time_re.search(n or '') for n in toggle_names):
+                    print(f"Panel toggles ready: {toggle_names}", flush=True)
                     break
         except Exception as e:  # noqa: BLE001
             print(f"AT-SPI poll: {e}", flush=True)
         time.sleep(1)
     else:
-        print("WARNING: clock/system toggles not found after 15s — proceeding anyway", flush=True)
+        # Do not raise — some sessions are slow to populate the panel and the
+        # individual @step checks will surface the failure with proper context.
+        print("WARNING: clock toggle not visible after 15s — step-level checks will diagnose", flush=True)
 
     # Initialize sandbox
     try:

--- a/tests/smoke/features/steps/steps.py
+++ b/tests/smoke/features/steps/steps.py
@@ -125,7 +125,7 @@ def clock_toggle_visible(context) -> None:
     time_re = re.compile(r'\d{1,2}:\d{2}|clock', re.IGNORECASE)
     clock = next(
         (t for t in toggles
-         if t.name not in SYSTEM_NAMES and time_re.search(t.name or '')),
+         if t.name and t.name not in SYSTEM_NAMES and time_re.search(t.name)),
         None,
     )
     # No lax fallback: accepting "any non-system toggle" caused silent false

--- a/tests/smoke/features/steps/steps.py
+++ b/tests/smoke/features/steps/steps.py
@@ -118,23 +118,25 @@ def clock_toggle_visible(context) -> None:
     panels = shell.findChildren(lambda n: n.roleName == "panel")
     assert panels, "Panel not found"
     panel = panels[0]
-    toggles = panel.findChildren(lambda n: n.roleName == "toggle button" and n.showing)
-    # Clock names: time string (digits + colon), 'clock', or a formatted date
+    # dogtail.config.searchShowingOnly = True (set in before_all) makes the
+    # implicit `.showing` filter redundant here.
+    toggles = panel.findChildren(lambda n: n.roleName == "toggle button")
     SYSTEM_NAMES = {"Activities", "System", "System Menu", "System menu"}
     time_re = re.compile(r'\d{1,2}:\d{2}|clock', re.IGNORECASE)
     clock = next(
         (t for t in toggles
-         if t.name not in SYSTEM_NAMES and time_re.search(t.name)),
+         if t.name not in SYSTEM_NAMES and time_re.search(t.name or '')),
         None,
     )
+    # No lax fallback: accepting "any non-system toggle" caused silent false
+    # passes when the actual clock was missing — see issue #5. If the time
+    # pattern is absent, fail with full toggle inventory for diagnosis.
     if clock is None:
-        # Fallback: accept any non-Activities, non-System toggle in the panel
-        candidates = [t for t in toggles if t.name not in SYSTEM_NAMES]
         toggle_info = [(t.name, t.roleName) for t in toggles]
-        assert len(candidates) > 0, (
-            f"No clock-like toggle button found in panel.\nAll panel toggles: {toggle_info}"
+        raise AssertionError(
+            f"Clock toggle (time-pattern in accessible-name) not found.\n"
+            f"All panel toggles: {toggle_info}"
         )
-        clock = candidates[0]  # first non-system toggle is likely the clock
     context.clock_toggle = clock
     print(f"Clock toggle found: name={clock.name!r}", flush=True)
 
@@ -151,19 +153,16 @@ def system_menu_toggle_visible(context) -> None:
     assert panels, "Panel not found"
     panel = panels[0]
     CANDIDATE_NAMES = {"System", "System menu", "System Menu"}
-    toggles = panel.findChildren(lambda n: n.roleName == "toggle button" and n.showing)
+    toggles = panel.findChildren(lambda n: n.roleName == "toggle button")
     system = next((t for t in toggles if t.name in CANDIDATE_NAMES), None)
+    # No "first non-clock toggle" fallback: it accepted unrelated buttons
+    # (e.g. notification indicator) and produced silent false passes — issue #5.
     if system is None:
-        # Fallback: look for a toggle that is NOT Activities and NOT a clock
-        import re
-        time_re = re.compile(r'\d{1,2}:\d{2}|clock', re.IGNORECASE)
-        non_clock = [t for t in toggles
-                     if t.name != "Activities" and not time_re.search(t.name)]
         toggle_info = [(t.name, t.roleName) for t in toggles]
-        assert len(non_clock) > 0, (
-            f"System menu toggle not found.\nPanel toggles: {toggle_info}"
+        raise AssertionError(
+            f"System menu toggle not found (looked for {sorted(CANDIDATE_NAMES)}).\n"
+            f"All panel toggles: {toggle_info}"
         )
-        system = non_clock[0]
     context.system_toggle = system
     print(f"System menu toggle found: name={system.name!r}", flush=True)
 


### PR DESCRIPTION
## Summary
- Hard-fail when `unsafe_mode` activation fails instead of silently continuing — closes #3
- Remove the lax "any non-system toggle" / "any non-clock toggle" fallbacks that produced silent false passes in `clock_toggle_visible` and `system_menu_toggle_visible` — closes #5
- Set `dogtail.config.searchShowingOnly = True` once in `before_all`; drop redundant `n.showing` predicates at callsites — closes #32
- Tighten the `before_all` panel-readiness probe to require a time-pattern toggle (same root cause as #5)
- Add `podGC.OnWorkflowSuccess` to `workflow-controller-configmap` so succeeded pods are GC'd immediately while failed-run pods stay around for the 7d/30d TTL window

## Test plan
- [ ] ArgoCD syncs `testing-lab-infra` Application; new `podGC` strategy visible on next workflow
- [ ] Submit `bluefin-qa-pipeline` against `latest` titan VM; verify run still passes
- [ ] Force a missing-clock scenario (kill the panel or test on a stripped session) and confirm the step now fails with full toggle inventory instead of false-passing
- [ ] Confirm successful workflow pods are GC'd; failed-workflow pods persist

Assisted-by: Claude Opus 4.7 via pi