### PR TITLE
feat(workflows): branch parameter for run-gnome-tests (#17)

### DIFF
--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -30,6 +30,10 @@ spec:
         value: "bluefin"
       - name: ssh-key-secret
         value: "bluefin-test-ssh-key"
+      # git ref the test runner clones (test code + step defs). Default `main`;
+      # override to test a PR branch end-to-end without merging.
+      - name: branch
+        value: "main"
 
   # ── pipeline DAG ─────────────────────────────────────────────────────────────
   templates:
@@ -80,6 +84,8 @@ spec:
                   value: "{{workflow.parameters.variant}}"
                 - name: ssh-key-secret
                   value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
 
           # 3b. Phase 2 — developer tools (sequential after smoke)
           - name: run-developer
@@ -98,6 +104,8 @@ spec:
                   value: "{{workflow.parameters.variant}}"
                 - name: ssh-key-secret
                   value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
 
           # 3c. Phase 3 — software management (sequential, only if in suites list)
           - name: run-software
@@ -116,6 +124,8 @@ spec:
                   value: "{{workflow.parameters.variant}}"
                 - name: ssh-key-secret
                   value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
 
     # ── onExit handler: stop VM → wait VMI gone → delete hostDisk ──────────────
     - name: teardown

--- a/argo/workflow-templates/bluefin-titan-smoke.yaml
+++ b/argo/workflow-templates/bluefin-titan-smoke.yaml
@@ -23,6 +23,10 @@ spec:
         value: "bluefin-test-ssh-key"
       - name: issue-title
         value: "titan smoke run"
+      # git ref the test runner clones. Default `main`; override to test a PR
+      # branch against persistent titan VMs without merging.
+      - name: branch
+        value: "main"
 
   serviceAccountName: argo
   entrypoint: run-smoke
@@ -68,6 +72,8 @@ spec:
                   value: "{{workflow.parameters.ssh-key-secret}}"
                 - name: issue-title
                   value: "{{workflow.parameters.issue-title}} - titan-bluefin"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
 
           - name: smoke-lts
             templateRef:
@@ -85,6 +91,8 @@ spec:
                   value: "{{workflow.parameters.ssh-key-secret}}"
                 - name: issue-title
                   value: "{{workflow.parameters.issue-title}} - titan-lts"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
 
     - name: preflight
       inputs:

--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -39,6 +39,11 @@ spec:
           - name: behave-tags
             # optional: "--tags @smoke" or "--tags @regression"
             value: ""
+          - name: branch
+            # git ref (branch or commit SHA) the runner clones for test code
+            # and step defs. Defaults to main; set per-run to test a PR branch
+            # without merging — e.g. `-p branch=fix/test-reliability-and-podgc`
+            value: "main"
       # 60-minute ceiling: SSH wait (10min) + dnf install (10min) + test run (30min)
       activeDeadlineSeconds: 3600
       # hostNetwork: KubeVirt masquerade only routes from the host network namespace
@@ -55,15 +60,28 @@ spec:
       initContainers:
         - name: git-sync
           image: quay.io/fedora/fedora:latest
+          env:
+            - name: BRANCH
+              value: "{{inputs.parameters.branch}}"
           command: [bash, -c]
           args:
             - |
               for attempt in 1 2 3; do
                 dnf install -y --quiet git 2>&1 | tail -2
-                if git clone --depth 1 --branch main \
+                # --branch accepts both branch names and tags; for commit SHAs
+                # we fall back to clone + checkout.
+                if git clone --depth 1 --branch "${BRANCH}" \
                     https://github.com/castrojo/testing-lab \
                     /workspace/bluefin-test-suite 2>&1; then
-                  echo "Synced testing-lab (attempt ${attempt})"
+                  echo "Synced testing-lab @ ${BRANCH} (attempt ${attempt})"
+                  exit 0
+                fi
+                # Commit-SHA fallback: full clone + checkout
+                rm -rf /workspace/bluefin-test-suite
+                if git clone https://github.com/castrojo/testing-lab \
+                    /workspace/bluefin-test-suite 2>&1 && \
+                   git -C /workspace/bluefin-test-suite checkout "${BRANCH}" 2>&1; then
+                  echo "Synced testing-lab @ ${BRANCH} via SHA fallback (attempt ${attempt})"
                   exit 0
                 fi
                 echo "Attempt ${attempt} failed, retrying in 15s..."

--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -67,16 +67,19 @@ spec:
           args:
             - |
               for attempt in 1 2 3; do
+                # Clear any partial clone from a previous attempt — git clone
+                # refuses to write into a non-empty directory and would skip
+                # both the primary and the SHA-fallback path otherwise.
+                rm -rf /workspace/bluefin-test-suite
                 dnf install -y --quiet git 2>&1 | tail -2
-                # --branch accepts both branch names and tags; for commit SHAs
-                # we fall back to clone + checkout.
+                # --branch accepts branch names and tags; for commit SHAs we
+                # fall back to a full clone + checkout.
                 if git clone --depth 1 --branch "${BRANCH}" \
                     https://github.com/castrojo/testing-lab \
                     /workspace/bluefin-test-suite 2>&1; then
                   echo "Synced testing-lab @ ${BRANCH} (attempt ${attempt})"
                   exit 0
                 fi
-                # Commit-SHA fallback: full clone + checkout
                 rm -rf /workspace/bluefin-test-suite
                 if git clone https://github.com/castrojo/testing-lab \
                     /workspace/bluefin-test-suite 2>&1 && \


### PR DESCRIPTION
## Summary
- \`run-gnome-tests\` gets a \`branch\` input parameter (default \`main\`) that the \`git-sync\` initContainer uses when cloning testing-lab
- \`bluefin-qa-pipeline\` and \`bluefin-titan-smoke\` both expose the same parameter at the top level and pass it through
- \`git-sync\` falls back to full-clone + checkout when \`--branch\` rejects the ref (commit SHAs)

Closes #17. Default is \`main\` so existing callers are unaffected.

## Test plan
- [ ] Submit titan-smoke with \`-p branch=feat/branch-param-for-pr-testing\` once merged; verify git-sync logs \"Synced testing-lab @ feat/branch-param-for-pr-testing\"
- [ ] Submit with a commit SHA; verify the SHA-fallback path runs
- [ ] Omit \`branch\`; verify it still clones \`main\`

Assisted-by: Claude Opus 4.7 via pi