### PR TITLE
docs: agent contract (WORKFLOWS.md) + ADR-0001 + pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Pre-commit lint. Activate per-clone with:
+#   git config core.hooksPath .githooks
+#
+# Checks:
+#   1. `argo lint` on argo/ (if argo CLI is available)
+#   2. No plain `kind: Secret` in manifests/ — use kubectl-managed secrets
+#      or a SealedSecret. Per SECURITY.md, mutable `:latest` image tags are
+#      ACCEPTED; we do not lint for digest-pinning.
+set -e
+
+# Limit checks to staged changes touching argo/ or manifests/
+CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(argo|manifests)/.+\.ya?ml$' || true)
+[ -z "$CHANGED" ] && exit 0
+
+if command -v argo >/dev/null 2>&1; then
+    argo lint --offline argo/workflow-templates/ 1>&2
+else
+    echo "pre-commit: argo CLI not found — skipping argo lint" 1>&2
+fi
+
+if grep -rE '^kind:[[:space:]]*Secret([[:space:]]|$)' manifests/ 2>/dev/null; then
+    echo "pre-commit error: plain k8s Secret committed in manifests/." 1>&2
+    echo "Use kubectl-managed secrets or a SealedSecret instead." 1>&2
+    exit 1
+fi
+
+exit 0

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -1,0 +1,142 @@
+# WorkflowTemplates — Agent Contract
+
+This is the canonical interface for driving the lab. Every supported
+operation is a single `argo submit --from workflowtemplate/<name> [-p k=v]`
+invocation. No bash, no `kubectl apply`, no SSH.
+
+Conventions:
+
+- All templates live in `argo/workflow-templates/*.yaml` and are reconciled
+  to namespace `argo` by the ArgoCD `testing-lab` Application.
+- Workflow-level parameters listed below are passed via `-p name=value`.
+- Wall-clock targets are warm-cache numbers; cold-cache figures (BIB build
+  on a missing golden disk) add ~5–10 min.
+- The agent contract: prefer the **top-level** templates (`bluefin-qa-pipeline`,
+  `bluefin-titan-smoke`). The supporting templates (provision, run, teardown)
+  are called as `templateRef` and rarely submitted directly.
+
+---
+
+## Top-level entry points
+
+### `bluefin-qa-pipeline`
+
+Full pipeline: ensure golden disk → reflink + boot a fresh KubeVirt VM →
+run test suites → teardown VM on exit.
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `image` | `ghcr.io/ublue-os/bluefin` | Source image. Tag is appended from `image-tag` for some callers; pass with tag if invoking directly. |
+| `image-tag` | `latest` | `latest`, `lts`, etc. Also used as the golden-disk dir name. |
+| `namespace` | `bluefin-test` | KubeVirt VM namespace. Use `bluefin-lts-test` for LTS. |
+| `suites` | `smoke,developer` | Comma list; valid: `smoke`, `developer`, `software`. |
+| `variant` | `bluefin` | Selects test fixtures (e.g. `dakota` for Ghostty). |
+| `ssh-key-secret` | `bluefin-test-ssh-key` | Secret in `argo` ns with `id_ed25519`. |
+
+Wall-clock: ~5 min (warm), ~10–14 min (cold BIB rebuild).
+
+```
+argo submit --from workflowtemplate/bluefin-qa-pipeline \
+  -p image-tag=latest -p suites=smoke --wait
+```
+
+### `bluefin-titan-smoke`
+
+Runs smoke tests against the **persistent** titan VMs (`titan-bluefin`,
+`titan-lts`). Skips BIB and VM provisioning entirely. Use when iterating on
+tests or when BIB is slow/broken.
+
+Prerequisites: both titan VMs running. Fetch IPs:
+
+```
+kubectl get vmi titan-bluefin -n bluefin-test -o jsonpath='{.status.interfaces[0].ipAddress}'
+kubectl get vmi titan-lts    -n bluefin-lts-test -o jsonpath='{.status.interfaces[0].ipAddress}'
+```
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `vm-ip-latest` | *(required)* | titan-bluefin IP |
+| `vm-ip-lts` | *(required)* | titan-lts IP |
+| `suite` | `smoke` | Single suite name. |
+| `ssh-key-secret` | `bluefin-test-ssh-key` | |
+| `issue-title` | `titan smoke run` | Free-text label, appears in pod annotation. |
+
+Wall-clock: ~3 min (test-only, no provisioning).
+
+```
+argo submit --from workflowtemplate/bluefin-titan-smoke \
+  -p vm-ip-latest=10.42.x.y -p vm-ip-lts=10.42.x.z --wait
+```
+
+### `patch-golden-disk`
+
+One-shot maintenance: re-runs the disk configuration step (SSH key,
+selinux=0, sudoers) on an existing golden disk without rebuilding it.
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `image-tag` | `latest` | Disk dir under `/var/tmp/bluefin-golden/`. |
+
+---
+
+## Supporting templates (called via `templateRef`)
+
+These are exposed only because they are referenced by the entry points;
+submit them directly only for diagnosis.
+
+### `bib-build-and-push` (template: `ensure-disk`)
+
+Builds the golden raw disk via `bootc-image-builder` if missing or stale.
+Stale detection compares the upstream image digest (via skopeo) against the
+`source-digest` marker written next to the disk on hostPath.
+
+Outputs: no `outputs.parameters`; side effect is
+`/var/tmp/bluefin-golden/<image-tag>/disk.raw` and `source-digest` on ghost.
+
+### `provision-bluefin-vm` (template: `provision-vm`)
+
+btrfs `cp --reflink=auto` from the golden disk, applies SVirt label, creates
+a KubeVirt VM, waits for SSH/IP, emits `vm-ip` as an output parameter.
+
+### `provision-flatcar-vm` (template: `provision-vm`)
+
+Same shape for Flatcar — accepts an `ssh-pubkey` parameter directly instead
+of relying on the bluefin-test secret for cloud-init injection.
+
+### `run-gnome-tests` (template: `run-gnome-tests`)
+
+`git-sync` initContainer clones testing-lab → main container SSHes to the VM
+IP → installs deps (skipped if present) → runs qecore-headless + behave →
+captures `results.json` to pod stdout (Loki + `argo logs`).
+
+Resource limits and `hostNetwork: true` are set on the pod (KubeVirt
+masquerade only routes from host netns).
+
+### `run-flatcar-tests` (template: `run-flatcar-tests`)
+
+Same shape for Flatcar; uses `core` as the SSH user and runs pytest+dogtail
+fixtures from `tests/flatcar/`.
+
+### `teardown-bluefin-vm` / `teardown-flatcar-vm`
+
+Delete the VM, wait for the VMI object to drain, then `rm` the per-run
+hostDisk clone. Invoked as `onExit` from the pipeline templates.
+
+---
+
+## CronWorkflows
+
+Lives in `manifests/`, applied via the `testing-lab-infra` ArgoCD app:
+
+| Schedule | Cron | Template called | Purpose |
+|---|---|---|---|
+| `nightly-smoke` | 02:00 UTC | `bluefin-qa-pipeline` (latest) | Catch upstream regressions |
+| `nightly-smoke-lts` | 02:30 UTC | `bluefin-qa-pipeline` (lts)    | Same, for LTS branch; first fire builds the missing golden disk |
+| `orphan-vm-cleanup` | hourly | inline | GC stale per-run hostDisks |
+
+---
+
+## Editing this contract
+
+When you add or rename a template, update this file in the same PR. Drift
+between templates and this doc is what breaks autonomous agents.

--- a/docs/adr/0001-homelab-scale-cncf-minimalism.md
+++ b/docs/adr/0001-homelab-scale-cncf-minimalism.md
@@ -1,0 +1,101 @@
+# ADR 0001 — Homelab-scale CNCF minimalism
+
+Status: Accepted
+Date: 2026-05-25
+
+## Context
+
+The testing-lab is a single-user, single-cluster homelab on `ghost`
+(one k3s node). It is not multi-tenant, not internet-exposed, not on a
+compliance schedule, and never grows past three nodes by design.
+
+CNCF best practices were written for cloud-native production. Applying them
+verbatim at this scale spends time on theater: every new controller adds
+admission-webhook latency, every Vault-style abstraction adds a credential
+plane outside git, every policy framework adds a debugger between agent and
+cluster. The cost is paid every push; the benefit is hypothetical.
+
+This ADR codifies what we accept and what we do not, so future agents and
+contributors do not re-litigate the same decisions.
+
+## Decisions
+
+### Controller-acceptance rule
+
+A new in-cluster controller is acceptable iff:
+
+1. Its desired state lives in git (GitOps-native), AND
+2. It introduces no credential plane outside git.
+
+Under this rule:
+
+| Tool | Verdict |
+|---|---|
+| ArgoCD | ✅ already in use |
+| sealed-secrets | ✅ git-native, no external plane |
+| zot (in-cluster) | ✅ stateful but git-friendly; today runs on host systemd |
+| External Secrets + Vault | ❌ credential plane outside git |
+| Argo Events | ❌ event bus outside git; ArgoCD reconciliation already covers what we need |
+| Kyverno / Gatekeeper | ❌ admission webhook adds latency + debug surface for no homelab benefit |
+| ESO + cert-manager Vault issuer | ❌ as above |
+
+### Node-scale assumption
+
+Single-node assumptions (hostPath, `nodeSelector: ghost`, btrfs reflink) are
+acceptable today. Each occurrence is tagged with a `# TODO(adr-0001):
+single-node` comment so a future scale event can `grep` them in one pass.
+
+### Lint and policy
+
+All lint runs locally as a pre-commit hook (`.githooks/pre-commit`). `main`
+is auto-synced by ArgoCD; broken pushes recover on the next pre-commit fix.
+No GitHub Actions, no admission-controller policy, no Rego/conftest.
+
+### Mutable image tags
+
+Per SECURITY.md: `:latest` and `:latest-dev` tags are an accepted trade-off
+for homelab iteration speed. Determinism for the *bootable* image is
+recovered at BIB time via the source-digest marker (ADR-adjacent: see
+`bib-build-and-push.yaml`). Pod images stay on tags.
+
+### MinIO non-use
+
+MinIO went source-restricted in 2024. The CNCF-aligned replacement for
+artifact storage is the OCI Artifact spec backed by zot (CNCF Sandbox),
+already on ghost. If artifact persistence is needed, use `oras push` to
+zot, not S3-compatible blob storage.
+
+### Duplication over parameterization
+
+Two near-clone WorkflowTemplates (Bluefin/Flatcar provisioning,
+Bluefin/Flatcar teardown) are simpler than one parameterized template with
+Argo `when:` / `if:` conditionals. Keep them as separate files. The
+maintenance cost of duplication is lower than the cognitive cost of
+conditional logic across YAML, especially for autonomous agents reading
+the templates.
+
+### Out of scope (do not re-propose without a new ADR)
+
+- MinIO or any S3-compatible artifact store
+- Kyverno / OPA Gatekeeper / admission webhooks
+- Conftest / Rego policy framework
+- Cosign signature verification, SBOM generation, Rekor / sigstore
+- OpenTelemetry tracing **deployment** (host collector exists; use it)
+- App-of-apps + Kustomize overlays beyond the two existing Applications
+- External Secrets Operator + Vault
+- Argo Events controllers + GitHub webhook trigger
+- Default-deny NetworkPolicy
+- `.github/workflows/` CI
+- Parameterized Bluefin/Flatcar WorkflowTemplate collapse
+- Multi-node HA for results storage
+
+If a future requirement justifies one of these, that requires ADR-0002 —
+never a silent re-introduction.
+
+## Consequences
+
+- Future agents have a one-line check for "is this proposal scoped to this
+  lab?": run it through the controller-acceptance rule and the out-of-scope
+  list.
+- When the lab does grow (≥3 nodes, multi-user, internet-exposed), this ADR
+  must be revised — every accepted trade-off becomes a migration item.


### PR DESCRIPTION
## Summary
- **WORKFLOWS.md**: canonical agent contract. One section per top-level WorkflowTemplate (\`bluefin-qa-pipeline\`, \`bluefin-titan-smoke\`, \`patch-golden-disk\`) plus supporting templates. Documents parameters, defaults, wall-clock, and example \`argo submit\` invocations. The contract is: agents drive the lab via \`argo submit --from workflowtemplate/...\` and \`git push\` only — no scripts, no SSH, no kubectl apply
- **docs/adr/0001-homelab-scale-cncf-minimalism.md**: codifies controller-acceptance rule, mutable-tag stance (per SECURITY.md), MinIO non-use → OCI/zot, and the explicit out-of-scope list (Kyverno/Vault/ESO/Argo Events/cosign/etc.) so future agents do not re-propose them at homelab scale
- **.githooks/pre-commit**: runs \`argo lint --offline argo/workflow-templates/\` on staged changes and blocks plain \`kind: Secret\` in manifests/. **No** image-tag-pinning check — per ADR-0001 and SECURITY.md, mutable tags are accepted. Activate per-clone with \`git config core.hooksPath .githooks\`

## Test plan
- [ ] Stage a workflow template with broken YAML; verify hook fails with argo lint output
- [ ] Stage a file with \`kind: Secret\` under \`manifests/\`; verify hook fails
- [ ] WORKFLOWS.md params match the templates as of this PR's base (one outstanding param — \`branch\` — is added in #34 and will be folded in once #34 merges)

Assisted-by: Claude Opus 4.7 via pi