### PR TITLE
review(bib): normalize IMAGE_REF in disk-check and disk-configure

### DIFF
--- a/argo/workflow-templates/bib-build-and-push.yaml
+++ b/argo/workflow-templates/bib-build-and-push.yaml
@@ -77,8 +77,9 @@ spec:
             path: /var/tmp/bluefin-golden
             type: DirectoryOrCreate
       script:
-        # fedora: known-good image for script templates (chainguard/bash pulls unreliably in lab)
-        image: quay.io/fedora/fedora:latest
+        # podman/stable already cached on ghost for bib-img-pull; ships skopeo
+        # so we avoid a per-run `dnf install` from a Fedora mirror.
+        image: quay.io/podman/stable:latest
         command: [bash]
         resources:
           requests:
@@ -93,7 +94,14 @@ spec:
         source: |
           set -euo pipefail
           TAG="{{inputs.parameters.image-tag}}"
-          IMAGE="{{inputs.parameters.image}}"
+          IMAGE_REF="{{inputs.parameters.image}}"
+          # If the caller passed `image` without a tag (e.g. bluefin-qa-pipeline
+          # default), append the explicit image-tag so skopeo inspects the
+          # right manifest. `*:*` distinguishes a tag from a `host:port/` ref —
+          # all our registries use the default port so no false positives.
+          if [[ "${IMAGE_REF}" != *:* ]]; then
+            IMAGE_REF="${IMAGE_REF}:${TAG}"
+          fi
           GOLDEN_DIR="/var/tmp/bluefin-golden/${TAG}"
           DISK="${GOLDEN_DIR}/disk.raw"
           MARKER="${GOLDEN_DIR}/source-digest"
@@ -103,26 +111,20 @@ spec:
             exit 0
           fi
 
-          # Install skopeo (the fedora base image doesn't ship it). Fail open
-          # to `exists` if skopeo can't be installed — never want a network
-          # blip to trigger an unwanted rebuild.
-          if ! command -v skopeo &>/dev/null; then
-            dnf install -y --quiet skopeo >/dev/null 2>&1 || {
-              echo "skopeo install failed; treating disk as fresh" >&2
-              echo -n "exists"
-              exit 0
-            }
-          fi
-
-          REMOTE=$(skopeo inspect --no-tags --format '{{.Digest}}' "docker://${IMAGE}" 2>/dev/null || true)
+          REMOTE=$(skopeo inspect --no-tags --format '{{.Digest}}' "docker://${IMAGE_REF}" 2>/dev/null || true)
           if [[ -z "${REMOTE}" ]]; then
-            echo "skopeo inspect failed for ${IMAGE}; treating disk as fresh" >&2
+            echo "skopeo inspect failed for ${IMAGE_REF}; treating disk as fresh" >&2
             echo -n "exists"
             exit 0
           fi
 
+          # Explicit `if` instead of `[[ -f ]] && STORED=$(...)` — under
+          # `set -e`, the latter's non-zero exit when the marker is absent
+          # can terminate the script depending on context.
           STORED=""
-          [[ -f "${MARKER}" ]] && STORED=$(cat "${MARKER}")
+          if [[ -f "${MARKER}" ]]; then
+            STORED=$(cat "${MARKER}")
+          fi
 
           if [[ "${REMOTE}" == "${STORED}" ]]; then
             echo -n "exists"
@@ -276,6 +278,10 @@ spec:
           - |
             set -euo pipefail
             TAG="{{inputs.parameters.image-tag}}"
+            IMAGE_REF="{{inputs.parameters.image}}"
+            if [[ "${IMAGE_REF}" != *:* ]]; then
+              IMAGE_REF="${IMAGE_REF}:${TAG}"
+            fi
             DISK="/var/tmp/bib-output/${TAG}/image/disk.raw"
             PUBKEY="${SSH_PUBKEY}"
             if [[ -z "${PUBKEY}" ]]; then
@@ -364,12 +370,12 @@ spec:
             # Record the source image digest so bib-disk-check can detect when
             # the golden disk falls behind upstream — see issue #1.
             # `podman image inspect` works because bib-img-pull just ran.
-            DIGEST=$(podman image inspect --format '{{.Digest}}' "{{inputs.parameters.image}}" 2>/dev/null || true)
+            DIGEST=$(podman image inspect --format '{{.Digest}}' "${IMAGE_REF}" 2>/dev/null || true)
             if [[ -n "${DIGEST}" ]]; then
               printf '%s' "${DIGEST}" > "${GOLDEN_DIR}/source-digest"
               echo "Recorded source digest: ${DIGEST}"
             else
-              echo "WARNING: could not record source digest for {{inputs.parameters.image}}" >&2
+              echo "WARNING: could not record source digest for ${IMAGE_REF}" >&2
             fi
 
             echo "=== Golden disk ready: ${GOLDEN_DIR}/disk.raw ==="


### PR DESCRIPTION
## Summary
Follow-up review fixes for #35 (gemini-code-assist comments):
- Use \`podman/stable\` for \`bib-disk-check\` (skopeo preinstalled, no per-run \`dnf install\`)
- Normalize bare image refs (\`IMAGE_REF\` gets \`:\${TAG}\` appended when no tag is present) in both \`bib-disk-check\` and \`bib-disk-configure\`
- Replace \`[[ -f ]] && STORED=\$(cat)\` with explicit \`if\` so \`set -e\` doesn't trip on a missing marker

## Test plan
- [ ] \`argo lint argo/workflow-templates/bib-build-and-push.yaml\`
- [ ] Trigger \`bluefin-qa-pipeline\` and confirm disk-check + disk-configure both succeed

Assisted-by: Claude Opus 4.7 via pi