### PR TITLE
feat(workflows): resource requests/limits on remaining templates

### DIFF
--- a/argo/workflow-templates/patch-golden-disk.yaml
+++ b/argo/workflow-templates/patch-golden-disk.yaml
@@ -31,6 +31,13 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 1Gi
         env:
           - name: SSH_PUBKEY
             valueFrom:

--- a/argo/workflow-templates/provision-flatcar-vm.yaml
+++ b/argo/workflow-templates/provision-flatcar-vm.yaml
@@ -73,6 +73,13 @@ spec:
         command: [bash]
         securityContext:
           runAsUser: 0
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 2Gi
         volumeMounts:
           - name: knuckle-test
             mountPath: /var/tmp/knuckle-test
@@ -187,6 +194,13 @@ spec:
       script:
         image: cgr.dev/chainguard/kubectl:latest-dev
         command: [bash]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
         source: |
           set -euo pipefail
           exec 3>&1

--- a/argo/workflow-templates/provision-vm.yaml
+++ b/argo/workflow-templates/provision-vm.yaml
@@ -187,6 +187,13 @@ spec:
         image: cgr.dev/chainguard/kubectl:latest-dev
         command:
           - bash
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
         source: |
           set -e
           NS="{{inputs.parameters.namespace}}"

--- a/argo/workflow-templates/run-flatcar-tests.yaml
+++ b/argo/workflow-templates/run-flatcar-tests.yaml
@@ -50,6 +50,13 @@ spec:
       container:
         image: quay.io/fedora/fedora:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 512Mi
         env:
           - name: FLATCAR_VM_IP
             value: "{{inputs.parameters.vm-ip}}"

--- a/argo/workflow-templates/teardown-flatcar-vm.yaml
+++ b/argo/workflow-templates/teardown-flatcar-vm.yaml
@@ -56,6 +56,13 @@ spec:
         securityContext:
           runAsUser: 0
         command: [bash]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
         volumeMounts:
           - name: flatcar-vms
             mountPath: /var/tmp/flatcar-test

--- a/argo/workflow-templates/teardown-vm.yaml
+++ b/argo/workflow-templates/teardown-vm.yaml
@@ -56,6 +56,13 @@ spec:
         securityContext:
           runAsUser: 0
         command: [bash]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
         volumeMounts:
           - name: test-disks
             mountPath: /var/tmp/bluefin-test


### PR DESCRIPTION
## Summary
Closes the Step 5 gap from the v4 plan — every workflow container now declares CPU + memory requests/limits, so scheduler decisions become deterministic instead of BestEffort.

Templates touched:
- \`patch-golden-disk\`: 500m/512Mi → 2/1Gi (privileged disk munging)
- \`provision-flatcar-vm\` (prepare-disk + wait-for-flatcar-ready)
- \`run-flatcar-tests\`: same sizing as run-gnome-tests
- \`teardown-bluefin-vm\` + \`teardown-flatcar-vm\`: minimal (rm only)
- \`provision-bluefin-vm\` wait-for-vm-ready: kubectl wait only

## Test plan
- [ ] \`argo lint argo/workflow-templates/\` passes
- [ ] One end-to-end \`bluefin-qa-pipeline\` run completes without OOM/throttling

Assisted-by: Claude Opus 4.7 via pi