### PR TITLE
fix(manifests): move domain.machine out of devices block

### DIFF
--- a/manifests/titan-bluefin.yaml
+++ b/manifests/titan-bluefin.yaml
@@ -35,8 +35,8 @@ spec:
           interfaces:
             - name: default
               masquerade: {}
-          machine:
-            type: q35
+        machine:
+          type: q35
       networks:
         - name: default
           pod: {}

--- a/manifests/titan-lts.yaml
+++ b/manifests/titan-lts.yaml
@@ -35,8 +35,8 @@ spec:
           interfaces:
             - name: default
               masquerade: {}
-          machine:
-            type: q35
+        machine:
+          type: q35
       networks:
         - name: default
           pod: {}


### PR DESCRIPTION
## Summary
KubeVirt schema mismatch on \`titan-bluefin\` and \`titan-lts\` VMs: \`machine.type\` was nested under \`domain.devices\` instead of \`domain\`. ArgoCD's structured-merge diff bailed with \`field not declared in schema\`, which left \`testing-lab-infra\` in \`Unknown\` sync state.

This unblocks reconciliation for every manifest under \`manifests/\` — including the new \`manifests/mcp/\` resources from #39.

## Test plan
- [ ] \`kubectl --dry-run=server apply -f manifests/titan-bluefin.yaml\` succeeds
- [ ] \`argocd app sync testing-lab-infra\` returns Synced

Assisted-by: Claude Opus 4.7 via pi