### PR TITLE
fix(mcp): NodePort 32801 → 32767 (within k8s default range)

### DIFF
--- a/manifests/mcp-README.md
+++ b/manifests/mcp-README.md
@@ -5,7 +5,7 @@ without SSH to ghost and without a local kubeconfig.
 
 | Server | URL | Backing project |
 |---|---|---|
-| `k8s` | http://192.168.1.102:32801/sse | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) |
+| `k8s` | http://192.168.1.102:32767/sse | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) |
 
 Argo Workflows is driven through the same server — its ClusterRole grants
 `get/list/watch/create/delete` on `argoproj.io` `Workflows`, `WorkflowTemplates`,
@@ -14,7 +14,7 @@ and `CronWorkflows`. No separate Argo MCP server is needed.
 ## Register with Claude Code
 
 ```sh
-claude mcp add --transport sse k8s http://192.168.1.102:32801/sse
+claude mcp add --transport sse k8s http://192.168.1.102:32767/sse
 claude mcp list  # `k8s` should report ✓ Connected
 ```
 

--- a/manifests/mcp-kubernetes-mcp-server.yaml
+++ b/manifests/mcp-kubernetes-mcp-server.yaml
@@ -6,8 +6,8 @@
 # with `skopeo inspect docker://ghcr.io/containers/kubernetes-mcp-server:latest`
 # and update the @sha256 before merging).
 #
-# Reachable at http://192.168.1.102:32801/sse from the local network.
-# Register with: `claude mcp add --transport sse k8s http://192.168.1.102:32801/sse`
+# Reachable at http://192.168.1.102:32767/sse from the local network.
+# Register with: `claude mcp add --transport sse k8s http://192.168.1.102:32767/sse`
 ---
 apiVersion: v1
 kind: Namespace
@@ -133,5 +133,5 @@ spec:
     - name: http
       port: 8080
       targetPort: 8080
-      nodePort: 32801
+      nodePort: 32767
       protocol: TCP


### PR DESCRIPTION
## Summary
- NodePort 32801 was outside the k8s default range (30000-32767) and ArgoCD sync rejected it.
- Picked 32767 (top of range) — well within bounds, no conflicts with the other NodePorts on ghost (2746, 30180).

## Test plan
- [x] Range confirmed via the sync error message itself: "valid ports is 30000-32767"
- [ ] After merge: `kubectl get svc -n mcp kubernetes-mcp-server` shows NodePort 32767
- [ ] After merge: `curl -sf http://192.168.1.102:32767/sse` (or registers as MCP)