### PR TITLE
fix: grant default ServiceAccount workflowtaskresults RBAC in argo namespace

### DIFF
--- a/manifests/argo-default-sa-rbac.yaml
+++ b/manifests/argo-default-sa-rbac.yaml
@@ -1,0 +1,32 @@
+# Grants the Argo emissary executor its upstream minimum permissions when a
+# workflow accidentally runs as the namespace default ServiceAccount.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-default-executor
+  namespace: argo
+  annotations:
+    workflows.argoproj.io/description: |
+      Recommended minimum permissions for the Argo emissary executor.
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtaskresults
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-default-executor
+  namespace: argo
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-default-executor


### PR DESCRIPTION
## Summary
- Add a GitOps-managed Role `argo-default-executor` in the `argo` namespace.
- Bind the Role to ServiceAccount `default` so accidental/default workflow execution has the upstream minimum Argo emissary executor permissions.
- Rules are intentionally limited to `workflowtaskresults.argoproj.io` `create` and `patch`, matching upstream Argo Workflows executor RBAC.

## Bug evidence
- Workflow `patch-golden-disk-7fl68` failed with: `workflowtaskresults.argoproj.io is forbidden: User "system:serviceaccount:argo:default" cannot create resource "workflowtaskresults" in API group "argoproj.io" in the namespace "argo"`.
- `kubectl auth can-i create workflowtaskresults.argoproj.io --as=system:serviceaccount:argo:default -n argo` returned `no`.
- No default/executor workflow Role or RoleBinding was present in `argo`.

## Investigation
- Upstream Argo Workflows documents the emissary executor minimum RBAC as `workflowtaskresults` `create` and `patch`.
- Audited `argo/workflow-templates/*.yaml`; several templates omit `serviceAccountName`, so resilient default-SA RBAC is the safest immediate fix. A separate defensive follow-up can normalize template `serviceAccountName: argo` settings.

## Validation
- `just lint` → `✔ no linting errors found!`

Do not merge automatically; leaving open for human review.