### PR TITLE
fix: set argo ServiceAccount on workflow templates

### DIFF
--- a/argo/workflow-templates/bib-build-and-push.yaml
+++ b/argo/workflow-templates/bib-build-and-push.yaml
@@ -9,6 +9,7 @@ metadata:
       on ghost's hostPath (/var/tmp/bluefin-golden/<tag>/disk.raw).
       No zot push, no buildah wrap — just the raw disk kept for reflink cloning.
 spec:
+  serviceAccountName: argo
   templates:
     - name: ensure-disk
       inputs:

--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/component: qa-pipeline
     app.kubernetes.io/part-of: bluefin-test-suite
 spec:
+  serviceAccountName: argo
   # ── entrypoint ──────────────────────────────────────────────────────────────
   entrypoint: pipeline
 

--- a/argo/workflow-templates/patch-golden-disk.yaml
+++ b/argo/workflow-templates/patch-golden-disk.yaml
@@ -10,6 +10,7 @@ metadata:
       or when the SSH key secret is rotated.
       Requires NO SSH to ghost — runs as a privileged pod via Argo.
 spec:
+  serviceAccountName: argo
   templates:
     - name: patch-disk
       inputs:

--- a/argo/workflow-templates/provision-flatcar-vm.yaml
+++ b/argo/workflow-templates/provision-flatcar-vm.yaml
@@ -9,6 +9,7 @@ metadata:
       Converts /var/tmp/knuckle-test/flatcar_base.img to .raw once (cached),
       then btrfs reflinks per-VM copy. Cloud-init and guest-agent injection seed SSH access.
 spec:
+  serviceAccountName: argo
   templates:
     - name: provision-vm
       inputs:

--- a/argo/workflow-templates/provision-vm.yaml
+++ b/argo/workflow-templates/provision-vm.yaml
@@ -9,6 +9,7 @@ metadata:
       ~24ms clone time (CoW). No CDI, no zot, no PVC.
       Requires HostDisk feature gate (already enabled in KubeVirt config).
 spec:
+  serviceAccountName: argo
   arguments: {}
   templates:
     - name: provision-vm

--- a/argo/workflow-templates/run-flatcar-tests.yaml
+++ b/argo/workflow-templates/run-flatcar-tests.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     bluefin.io/stack: "plain behave, SSH from runner pod to Flatcar VM"
 spec:
+  serviceAccountName: argo
   templates:
     - name: run-flatcar-tests
       metadata:

--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -7,6 +7,7 @@ metadata:
     bluefin.io/replaces: run-tmt-tests
     bluefin.io/stack: "qecore-headless + behave + dogtail + gnome-ponytail-daemon"
 spec:
+  serviceAccountName: argo
   templates:
     - name: run-gnome-tests
       metadata:

--- a/argo/workflow-templates/teardown-flatcar-vm.yaml
+++ b/argo/workflow-templates/teardown-flatcar-vm.yaml
@@ -4,6 +4,7 @@ metadata:
   name: teardown-flatcar-vm
   namespace: argo
 spec:
+  serviceAccountName: argo
   templates:
     - name: teardown-vm
       inputs:

--- a/argo/workflow-templates/teardown-vm.yaml
+++ b/argo/workflow-templates/teardown-vm.yaml
@@ -4,6 +4,7 @@ metadata:
   name: teardown-bluefin-vm
   namespace: argo
 spec:
+  serviceAccountName: argo
   templates:
     - name: teardown-vm
       inputs:


### PR DESCRIPTION
## Summary
- Add explicit `serviceAccountName: argo` to workflow templates that previously relied on namespace default ServiceAccount.
- This is a defensive follow-up to the default-SA RBAC fix so workflow pods consistently use the intended Argo ServiceAccount.

## Validation
- `argo lint --offline argo/workflow-templates/*.yaml argo/*.yaml` → `✔ no linting errors found!`
- Note: `just lint` on clean `main` currently expands `$$f` incorrectly in the Justfile recipe, so direct Argo lint was used for this follow-up branch.

Do not merge automatically; leaving open for human review.