### PR TITLE
fix: ignore KubeVirt-managed VM drift in testing-lab-infra ArgoCD app

### DIFF
--- a/argocd/infra-application.yaml
+++ b/argocd/infra-application.yaml
@@ -17,6 +17,16 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: argo
+  ignoreDifferences:
+    - group: kubevirt.io
+      kind: VirtualMachine
+      jqPathExpressions:
+        - .status
+        - .spec.template.metadata.annotations."kubevirt.io/pci-topology-version"
+        - .spec.template.spec.architecture
+        - .spec.template.spec.domain.firmware
+        - .spec.template.spec.domain.resources
+        - .spec.template.spec.volumes[]?.hostDisk.capacity
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- Adds `spec.ignoreDifferences` for KubeVirt `VirtualMachine` resources in the `testing-lab-infra` ArgoCD Application.
- Ignores only fields observed drifting on the live titan VMs.
- Does not ignore `domain.devices.disks` or `spec.dataVolumeTemplates` because they did not drift / are not present.

## Drift evidence
`argocd` CLI was not available, so I compared `kubectl get vm ... -o json` against the checked-in manifests and confirmed ArgoCD resource status for both VMs was `OutOfSync`.

```text
ArgoCD resource status:
{"group":"kubevirt.io","kind":"VirtualMachine","namespace":"bluefin-lts-test","name":"titan-lts","status":"OutOfSync"}
{"group":"kubevirt.io","kind":"VirtualMachine","namespace":"bluefin-test","name":"titan-bluefin","status":"OutOfSync"}

=== bluefin-test/titan-bluefin drift candidates ===
/status: desired=None live={conditions, created=True, observedGeneration=1, printableStatus=Running, ready=True, runStrategy=Always, volumeSnapshotStatuses=[...]}
/spec/template/metadata/annotations/kubevirt.io~1pci-topology-version: desired=None live='v3'
/spec/template/spec/architecture: desired=None live='amd64'
/spec/template/spec/domain/firmware: desired=None live={'serial': '2f62306c-8960-4692-955a-ed5b07441a0f', 'uuid': '832c4eac-bf3f-4e2c-a5d5-e80983e32ee8'}
/spec/template/spec/domain/resources: desired=None live={}
/spec/template/spec/volumes/0/hostDisk/capacity: desired=None live='0'

=== bluefin-lts-test/titan-lts drift candidates ===
/status: desired=None live={conditions, created=True, observedGeneration=1, printableStatus=Running, ready=True, runStrategy=Always, volumeSnapshotStatuses=[...]}
/spec/template/metadata/annotations/kubevirt.io~1pci-topology-version: desired=None live='v3'
/spec/template/spec/architecture: desired=None live='amd64'
/spec/template/spec/domain/firmware: desired=None live={'serial': 'f9c3c225-7470-43d5-8a6f-70eb2dc330ed', 'uuid': 'aefdc9aa-9a33-4789-992c-5d785c9d6bec'}
/spec/template/spec/domain/resources: desired=None live={}
/spec/template/spec/volumes/0/hostDisk/capacity: desired=None live='0'
```

## Why these ignored fields are safe
- `.status`: controller-owned runtime state; not declarative desired state.
- `.spec.template.metadata.annotations."kubevirt.io/pci-topology-version"`: KubeVirt-injected runtime compatibility annotation.
- `.spec.template.spec.architecture`: defaulted by the cluster from the node/runtime architecture.
- `.spec.template.spec.domain.firmware`: generated serial/UUID values; should not be pinned by GitOps for persistent VMs.
- `.spec.template.spec.domain.resources`: empty default object injected by KubeVirt.
- `.spec.template.spec.volumes[]?.hostDisk.capacity`: defaulted hostDisk capacity metadata (`"0"`) injected by KubeVirt; the desired hostDisk path/type remain managed.

## Validation
```text
just lint
argo lint --offline argo/workflow-templates/*.yaml argo/*.yaml
✔ no linting errors found!
✓ All manifests valid
```