### PR TITLE
feat: add stuck-VM reaper for knuckle-test namespace (dry-run default)

### DIFF
--- a/manifests/knuckle-stuck-vm-reaper.yaml
+++ b/manifests/knuckle-stuck-vm-reaper.yaml
@@ -1,0 +1,124 @@
+# CronWorkflow: dry-run reaper for knuckle-test VMs stuck before launch.
+# Deletes only knuckle-test VirtualMachines whose VMI is Scheduling for >6h
+# or whose virt-launcher pod remains in Init for >6h with no Running containers.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: knuckle-stuck-vm-reaper
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  schedules:
+    - "0 */2 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  workflowSpec:
+    serviceAccountName: argo
+    entrypoint: reap-stuck-vms
+    arguments:
+      parameters:
+        - name: dry-run
+          value: "true"
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterCompletion: 3600
+    templates:
+      - name: reap-stuck-vms
+        inputs:
+          parameters:
+            - name: dry-run
+              value: "{{workflow.parameters.dry-run}}"
+        nodeSelector:
+          kubernetes.io/hostname: ghost
+        script:
+          image: cgr.dev/chainguard/kubectl:latest-dev
+          command: [bash]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          source: |
+            set -euo pipefail
+            NS="knuckle-test"
+            THRESHOLD_SECONDS=$((6 * 60 * 60))
+            DRY_RUN="{{inputs.parameters.dry-run}}"
+            NOW_SECONDS=$(date -u +%s)
+
+            echo "Checking stuck KubeVirt VMs in namespace: ${NS}" >&2
+            echo "Threshold: ${THRESHOLD_SECONDS}s (6h); dry-run=${DRY_RUN}" >&2
+
+            age_seconds() {
+              local timestamp="$1"
+              if [[ -z "${timestamp}" ]]; then
+                echo 0
+                return
+              fi
+              local created_seconds
+              created_seconds=$(date -u -d "${timestamp}" +%s)
+              echo $((NOW_SECONDS - created_seconds))
+            }
+
+            human_age() {
+              local seconds="$1"
+              local hours=$((seconds / 3600))
+              local minutes=$(((seconds % 3600) / 60))
+              echo "${hours}h${minutes}m"
+            }
+
+            delete_vm() {
+              local vm="$1"
+              local reason="$2"
+              local age="$3"
+              local phase="$4"
+
+              if ! kubectl get vm "${vm}" -n "${NS}" >/dev/null 2>&1; then
+                echo "SKIP ${NS}/${vm}: VMI phase=${phase}, age=$(human_age "${age}"), reason=${reason}; no matching VM found" >&2
+                return
+              fi
+
+              if [[ "${DRY_RUN}" == "true" ]]; then
+                echo "DRY-RUN delete ${NS}/${vm}: VMI phase=${phase}, age=$(human_age "${age}"), reason=${reason}" >&2
+              else
+                echo "DELETE ${NS}/${vm}: VMI phase=${phase}, age=$(human_age "${age}"), reason=${reason}" >&2
+                kubectl delete vm "${vm}" -n "${NS}" --wait=false
+              fi
+            }
+
+            while IFS=$'\t' read -r VMI PHASE CREATED; do
+              [[ -z "${VMI}" ]] && continue
+              VMI_AGE=$(age_seconds "${CREATED}")
+              ACTION_TAKEN="false"
+
+              if [[ "${PHASE}" == "Scheduling" && "${VMI_AGE}" -gt "${THRESHOLD_SECONDS}" ]]; then
+                delete_vm "${VMI}" "VMI Scheduling longer than 6h" "${VMI_AGE}" "${PHASE}"
+                ACTION_TAKEN="true"
+              fi
+
+              if [[ "${ACTION_TAKEN}" == "false" ]]; then
+                while IFS=$'\t' read -r POD POD_CREATED RUNNING_STARTED; do
+                  [[ -z "${POD}" ]] && continue
+                  POD_AGE=$(age_seconds "${POD_CREATED}")
+                  if [[ -z "${RUNNING_STARTED}" && "${POD_AGE}" -gt "${THRESHOLD_SECONDS}" ]]; then
+                    delete_vm "${VMI}" "virt-launcher ${POD} stuck before Running longer than 6h" "${POD_AGE}" "${PHASE}"
+                    ACTION_TAKEN="true"
+                    break
+                  fi
+                done < <(kubectl get pods -n "${NS}" -l "kubevirt.io/domain=${VMI}" \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.creationTimestamp}{"\t"}{.status.initContainerStatuses[*].state.running.startedAt}{.status.containerStatuses[*].state.running.startedAt}{"\n"}{end}' \
+                  2>/dev/null || true)
+              fi
+
+              if [[ "${ACTION_TAKEN}" == "false" ]]; then
+                echo "SKIP ${NS}/${VMI}: VMI phase=${PHASE}, age=$(human_age "${VMI_AGE}"), no stuck Scheduling/Init condition over 6h" >&2
+              fi
+            done < <(kubectl get vmi -n "${NS}" \
+              -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.metadata.creationTimestamp}{"\n"}{end}' \
+              2>/dev/null || true)
+
+            echo "knuckle stuck VM reaper complete." >&2


### PR DESCRIPTION
## Summary
- Add `knuckle-stuck-vm-reaper` CronWorkflow scheduled every 2 hours.
- Scope is hard-coded to `knuckle-test` only.
- Default `dry-run` parameter is `"true"`; operators can validate log output before flipping to false.
- Also fixes the existing `just lint` recipe escaping so validation can run successfully.

## Stuck VM evidence
```console
$ kubectl get vmi -n knuckle-test
NAME                   AGE   PHASE        IP    NODENAME   READY
flatcar-pr248          15h   Scheduling                    False
qa-pr-421-1779758980   11h   Scheduling                    False
```

`argo` service account RBAC was checked and can delete `virtualmachines.kubevirt.io` in `knuckle-test`.

## Safety
- Reaper only evaluates VMIs in `knuckle-test`.
- Action threshold is 6h to avoid racing slow scheduling/provisioning while cleaning pods stuck for many hours.
- Dry-run default logs per-VM rationale (`name`, age, phase, action) without deleting until explicitly flipped to false.

## Validation
```console
$ argo lint --offline manifests/knuckle-stuck-vm-reaper.yaml
✔ no linting errors found!

$ just lint
argo lint --offline argo/workflow-templates/*.yaml argo/*.yaml
✔ no linting errors found!
✓ All manifests valid
```
