### PR TITLE
fix(argo): update stack annotation from qecore-headless to qecore

### DIFF
--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -4,7 +4,7 @@ metadata:
   name: run-gnome-tests
   namespace: argo
   annotations:
-    bluefin.io/stack: "qecore-headless + behave + dogtail + gnome-ponytail-daemon"
+    bluefin.io/stack: "qecore + behave + dogtail + gnome-ponytail-daemon"
 spec:
   serviceAccountName: argo
   templates:


### PR DESCRIPTION
## Summary

Updates the `bluefin.io/stack` annotation in the `run-gnome-tests` workflow template to use the correct PyPI package name.

## Changes

- **`argo/workflow-templates/run-gnome-tests.yaml`**: Change stack annotation from `qecore-headless` to `qecore`.

## Why

`qecore-headless` is not a PyPI package — it's the binary entry point installed by the `qecore` package. The annotation should reference the canonical package name. The pip install step in the same workflow template already correctly installs `qecore` (not `qecore-headless`).

Closes #160