### PR TITLE
fix(argo): replace unsupported 'contains' operator with =~ in when conditions

### DIFF
--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -71,7 +71,7 @@ spec:
           # 3a. Phase 1 — smoke (behave + qecore, every PR)
           - name: run-smoke
             depends: "provision.Succeeded"
-            when: "'{{workflow.parameters.suites}}' contains 'smoke'"
+            when: "'{{workflow.parameters.suites}}' =~ 'smoke'"
             templateRef:
               name: run-gnome-tests
               template: run-gnome-tests
@@ -91,7 +91,7 @@ spec:
           # 3b. Phase 2 — developer tools (sequential after smoke)
           - name: run-developer
             depends: "run-smoke.Succeeded"
-            when: "'{{workflow.parameters.suites}}' contains 'developer'"
+            when: "'{{workflow.parameters.suites}}' =~ 'developer'"
             templateRef:
               name: run-gnome-tests
               template: run-gnome-tests
@@ -111,7 +111,7 @@ spec:
           # 3c. Phase 3 — software management (sequential, only if in suites list)
           - name: run-software
             depends: "run-developer.Succeeded"
-            when: "'{{workflow.parameters.suites}}' contains 'software'"
+            when: "'{{workflow.parameters.suites}}' =~ 'software'"
             templateRef:
               name: run-gnome-tests
               template: run-gnome-tests

--- a/argo/workflow-templates/dakota-qa-pipeline.yaml
+++ b/argo/workflow-templates/dakota-qa-pipeline.yaml
@@ -113,7 +113,7 @@ spec:
           # 5. Run smoke test suite against the provisioned Dakota VM
           - name: run-smoke
             depends: "provision.Succeeded"
-            when: "'{{workflow.parameters.suites}}' contains 'smoke'"
+            when: "'{{workflow.parameters.suites}}' =~ 'smoke'"
             templateRef:
               name: run-gnome-tests
               template: run-gnome-tests

--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -4,7 +4,7 @@ metadata:
   name: run-gnome-tests
   namespace: argo
   annotations:
-    bluefin.io/stack: "qecore-headless + behave + dogtail + gnome-ponytail-daemon"
+    bluefin.io/stack: "qecore + behave + dogtail + gnome-ponytail-daemon"
 spec:
   serviceAccountName: argo
   templates:


### PR DESCRIPTION
## Summary

Argo Workflows v4 does not support the `contains` operator in `when` expressions. Replaces all occurrences with `=~` (regex match), which is the supported equivalent.

## Changes

- **`argo/workflow-templates/bluefin-qa-pipeline.yaml`**: Replace `contains 'smoke'`, `contains 'developer'`, `contains 'software'` with `=~ 'smoke'`, `=~ 'developer'`, `=~ 'software'`
- **`argo/workflow-templates/dakota-qa-pipeline.yaml`**: Replace `contains 'smoke'` with `=~ 'smoke'`

Closes #155