### PR TITLE
fix: address testing-lab CI bugs (#153, #154, #161)

### DIFF
--- a/argo/workflow-templates/bib-build-and-push.yaml
+++ b/argo/workflow-templates/bib-build-and-push.yaml
@@ -322,6 +322,18 @@ spec:
             fi
             echo "Using pubkey: ${PUBKEY}"
 
+            # Idempotency guard: another workflow may have already configured and
+            # moved the disk to golden (see issue #154). Check golden first.
+            if [[ ! -f "${DISK}" ]]; then
+              GOLDEN_DISK="{{inputs.parameters.golden-root}}/${TAG}/disk.raw"
+              if [[ -f "${GOLDEN_DISK}" ]]; then
+                echo "disk.raw already moved to golden by another workflow: ${GOLDEN_DISK}" >&2
+                exit 0
+              fi
+              echo "ERROR: disk.raw missing at ${DISK} and not in golden either" >&2
+              exit 1
+            fi
+
             echo "=== Configuring golden disk: ${DISK} ==="
             LOOP=$(losetup -f --show -P "${DISK}")
             echo "Loop: ${LOOP}"
@@ -365,6 +377,31 @@ spec:
               echo "ERROR: authorized_keys empty or not written" >&2; exit 1
             }
             chown -R "${BFT_UID}:${BFT_UID}" "${VAR}/home/bluefin-test"
+            # ── GDM auto-login (#161) ────────────────────────────────────
+            # Required for AT-SPI test automation — without this the VM boots to
+            # a login screen with no GNOME session and all AT-SPI tests fail.
+            mkdir -p "${ROOT}/etc/gdm"
+            printf '[daemon]\nAutomaticLoginEnable=True\nAutomaticLogin=bluefin-test\nWaylandEnable=true\n' \
+              > "${ROOT}/etc/gdm/custom.conf"
+
+            # Install gnome-ponytail-daemon — needed for AT-SPI / Dogtail tests.
+            # On bootc images we can't use dnf install. Copy the rpm and extract
+            # it into the deploy root via rpm2cpio.
+            GPD_RPM="/host/var/cache/dnf/fedora*/packages/gnome-ponytail-daemon-*.rpm"
+            if ls ${GPD_RPM} 2>/dev/null | head -1; then
+              GPD=$(ls ${GPD_RPM} 2>/dev/null | head -1)
+              rpm2cpio "${GPD}" | (cd "${ROOT}" && cpio -idm 2>/dev/null)
+              # Enable as user service for the test user
+              mkdir -p "${VAR}/home/bluefin-test/.config/systemd/user/graphical-session.target.wants"
+              if [[ -f "${ROOT}/usr/lib/systemd/user/gnome-ponytail-daemon.service" ]]; then
+                ln -sf /usr/lib/systemd/user/gnome-ponytail-daemon.service \
+                  "${VAR}/home/bluefin-test/.config/systemd/user/graphical-session.target.wants/gnome-ponytail-daemon.service"
+              fi
+              echo "Installed gnome-ponytail-daemon."
+            else
+              echo "WARNING: gnome-ponytail-daemon RPM not found in DNF cache — AT-SPI tests may fail (see #161)" >&2
+            fi
+
             # 750 on home dir: sshd StrictModes rejects world- or group-writable home
             chmod 750 "${VAR}/home/bluefin-test"
             chmod 700 "${VAR}/home/bluefin-test/.ssh"

--- a/manifests/kubevirt-rbac.yaml
+++ b/manifests/kubevirt-rbac.yaml
@@ -1,0 +1,43 @@
+# Grants argo SA permissions to manage KubeVirt VMs in the bluefin-test namespace.
+# Required for create-vm, wait-for-vm-ready, and delete-vm steps.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubevirt-manager
+  namespace: bluefin-test
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubevirt-manager-argo
+  namespace: bluefin-test
+subjects:
+  - kind: ServiceAccount
+    name: argo
+    namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubevirt-manager


### PR DESCRIPTION
Fixes three testing-lab CI bugs:

- **#153**: RBAC — Creates kubevirt-rbac.yaml Role/RoleBinding granting argo SA VirtualMachine/VMI/pods permissions in bluefin-test namespace
- **#154**: Idempotency — Adds guard to bib-disk-configure to prevent losetup failure when concurrent workflow already moved disk.raw to golden
- **#161**: Bootc AT-SPI — Adds GDM auto-login config and gnome-ponytail-daemon install to bib-disk-configure for AT-SPI test automation on bootc-based golden disk images

Closes #153, Closes #154, Closes #161