### PR TITLE
feat(ci): add Python syntax and pytest collection validation (#173)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,3 +29,19 @@ jobs:
             echo "Checking $f..."
             argo lint --offline "$f" || echo "WARNING: $f needs server-side template resolution or has offline lint issues"
           done
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Validate Python syntax
+        run: |
+          echo "Checking Python syntax..."
+          find tests/ -name '*.py' -print0 | xargs -0 python -m py_compile
+
+      - name: Check pytest collection
+        run: |
+          echo "Checking pytest imports and collection..."
+          python -m pip install pytest -q
+          python -m pytest tests/ --collect-only -q 2>&1 | tail -5


### PR DESCRIPTION
Closes #173

Adds Python validation to the lint workflow:
- Python syntax check (`py_compile`) for all test files
- pytest collection check to catch import errors, broken fixtures, and missing conftest

Previously CI only ran `argo lint` on workflow YAML files, leaving Python test errors invisible until runtime.