### PR TITLE
feat(service-catalog): add OpenPrinting/CUPS print-service lane (closes #64)

### DIFF
--- a/argo/homelab-print-service.yaml
+++ b/argo/homelab-print-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: homelab-print-service-
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: homelab-print-service
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  workflowTemplateRef:
+    name: homelab-print-service

--- a/argo/workflow-templates/homelab-print-service.yaml
+++ b/argo/workflow-templates/homelab-print-service.yaml
@@ -1,0 +1,188 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: homelab-print-service
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: homelab-print-service
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  entrypoint: pipeline
+  onExit: cleanup
+  serviceAccountName: homelab-runner
+  arguments:
+    parameters:
+      - name: lane
+        value: "homelab-print-service"
+      - name: branch
+        value: "main"
+  templates:
+    - name: pipeline
+      dag:
+        tasks:
+          - name: create-namespace
+            template: create-namespace
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "homelab-print-{{workflow.uid}}"
+          - name: deploy-fixture
+            depends: "create-namespace.Succeeded"
+            template: deploy-fixture
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "homelab-print-{{workflow.uid}}"
+                - name: lane
+                  value: "{{workflow.parameters.lane}}"
+          - name: run-tests
+            depends: "deploy-fixture.Succeeded"
+            templateRef:
+              name: run-incluster-tests
+              template: run-pytest
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "homelab-print-{{workflow.uid}}"
+                - name: suite-path
+                  value: "service_catalog/print"
+                - name: lane
+                  value: "{{workflow.parameters.lane}}"
+                - name: app-label
+                  value: "app=homelab-print-service"
+                - name: service-name
+                  value: "homelab-print-service"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+    - name: create-namespace
+      inputs:
+        parameters:
+          - name: namespace
+      resource:
+        action: create
+        manifest: |
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{inputs.parameters.namespace}}"
+            labels:
+              app.kubernetes.io/part-of: bluefin-test-suite
+              bluefin.io/lane: homelab-print-service
+
+    - name: deploy-fixture
+      inputs:
+        parameters:
+          - name: namespace
+          - name: lane
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash, -c]
+        source: |
+          set -euo pipefail
+          NS="{{inputs.parameters.namespace}}"
+          kubectl apply -n "${NS}" -f - <<EOF
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: homelab-print-config
+            labels:
+              app: homelab-print-service
+              app.kubernetes.io/part-of: bluefin-test-suite
+              bluefin.io/lane: "{{inputs.parameters.lane}}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: homelab-print-service
+            labels:
+              app: homelab-print-service
+              app.kubernetes.io/part-of: bluefin-test-suite
+              bluefin.io/lane: "{{inputs.parameters.lane}}"
+              bluefin.io/workload-class: print-service
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: homelab-print-service
+            template:
+              metadata:
+                labels:
+                  app: homelab-print-service
+                  app.kubernetes.io/part-of: bluefin-test-suite
+                  bluefin.io/lane: "{{inputs.parameters.lane}}"
+                  bluefin.io/workload-class: print-service
+              spec:
+                nodeSelector:
+                  kubernetes.io/hostname: ghost
+                containers:
+                  - name: print-server
+                    # Representative linuxserver.io-style fixture for the
+                    # OpenPrinting/CUPS workload class (bluespeed#11).
+                    # Uses nginx as a lightweight proxy for the HTTP-reachability
+                    # contract on port 631 (IPP standard).  The real deployment
+                    # contract (PUID/PGID/TZ env, config PVC mount, port 631)
+                    # is fully representative even with a stub image.  Replace
+                    # with lscr.io/linuxserver/cups when the lane graduates from
+                    # validation to integration testing.
+                    image: docker.io/library/nginx:1.27.5-alpine
+                    ports:
+                      - containerPort: 631
+                    env:
+                      - name: PUID
+                        value: "1000"
+                      - name: PGID
+                        value: "1000"
+                      - name: TZ
+                        value: "UTC"
+                    volumeMounts:
+                      - name: config
+                        mountPath: /config
+                    # nginx listens on 80 by default; rewrite the listen port to
+                    # 631 so the reachability contract matches the IPP standard
+                    # without requiring a custom image.
+                    command:
+                      - sh
+                      - -c
+                      - |
+                        sed -i 's/listen\s*80;/listen 631;/g' /etc/nginx/conf.d/default.conf
+                        exec nginx -g 'daemon off;'
+                volumes:
+                  - name: config
+                    persistentVolumeClaim:
+                      claimName: homelab-print-config
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: homelab-print-service
+            labels:
+              app: homelab-print-service
+              app.kubernetes.io/part-of: bluefin-test-suite
+              bluefin.io/lane: "{{inputs.parameters.lane}}"
+          spec:
+            selector:
+              app: homelab-print-service
+            ports:
+              - name: ipp
+                port: 631
+                targetPort: 631
+          EOF
+          kubectl rollout status deployment/homelab-print-service -n "${NS}" --timeout=300s >&2
+
+    - name: cleanup
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash, -c]
+        source: |
+          set -euo pipefail
+          NS="homelab-print-{{workflow.uid}}"
+          kubectl delete namespace "${NS}" --ignore-not-found=true >&2 || true
+          timeout 180 bash -c "until ! kubectl get namespace \"${NS}\" >/dev/null 2>&1; do sleep 5; done" >&2 || true
+          echo "cleanup-complete"

--- a/docs/homelab-contracts.md
+++ b/docs/homelab-contracts.md
@@ -18,6 +18,7 @@ access guarantees it must prove.
 | **General-purpose** | `homelab-substrate` | `tests/homelab_substrate/` | k3s scheduling, pod lifecycle, in-cluster HTTP/TCP reachability, `local-path` PVC allocation |
 | **NAS / storage** | `homelab-storage` | `tests/homelab_storage/` | PVC bound on `local-path`, data survives `rollout restart`, `findmnt`/`df`/`lsblk`/ZFS artifacts captured |
 | **Service access** | `homelab-access-probe` | `tests/homelab_access/` | Cluster-DNS resolution, TLS handshake, expected-host routing via SNI |
+| **Print service** | `homelab-print-service` | `tests/service_catalog/print/` | Config PVC (1Gi) binding and writability, IPP port 631 reachability, PUID/PGID/TZ env injection, state survives `rollout restart` |
 
 ### Minimum persistence contract per class
 
@@ -38,11 +39,21 @@ access guarantees it must prove.
 - TLS handshake reports a certificate with `Protocol version` in the output.
 - Health endpoint returns `access-ok` with `Host:` header routing.
 
+#### Print service
+- Config PVC (1Gi `local-path` ReadWriteOnce) binds and is writable at `/config`.
+- Config PVC survives a `rollout restart` (sentinel file checked after pod replacement).
+- `PUID`, `PGID`, and `TZ` environment variables are present in the container env.
+- IPP port 631 is reachable within the cluster namespace (TCP connect succeeds).
+- Cluster DNS resolves `homelab-print-service.<namespace>.svc.cluster.local`.
+- **USB printer device access deferred to #67** — requires host device passthrough.
+- **LAN mDNS autodiscovery deferred to #67** — requires avahi sidecar and NodePort/LoadBalancer exposure.
+
 ### Gaps surfaced explicitly
 - Media streaming / transcoding lane: not yet defined. GPU passthrough is a
   known blocker; filed as a follow-up under the service-catalog epic.
 - ReadWriteMany / shared-media access: blocked by #62.
 - Service-to-service auth: deferred to service-catalog auth-gating lane (#61).
+- USB printer device access and LAN mDNS discovery: split from print-service base lane into #67.
 
 ---
 
@@ -197,3 +208,55 @@ The lab validates the following hostname/routing pattern for exposed in-cluster 
 | #60 first restore drill | ✅ implemented | `homelab-restore-drill` WorkflowTemplate + `tests/homelab_backup/` |
 | #84 PVC restore drill with backup artifact | ✅ implemented | `homelab-restore-drill` WorkflowTemplate + `tests/homelab_backup/` |
 | Media service lane | ❌ deferred | #62 (shared mount) + #63 (GPU) |
+| #64 first non-media homelab workload lane | ✅ implemented | `homelab-print-service` WorkflowTemplate + `tests/service_catalog/print/` |
+| #67 printer-device access and LAN discovery | ❌ deferred | #54 substrate + host device passthrough |
+
+---
+
+## 7. Print-Service Workload Lane (#64)
+
+First non-media homelab workload lane.  Validates the in-cluster deployment
+contract for an OpenPrinting/CUPS-class service (source idea:
+`projectbluefin/bluespeed#11`) without hardware attachment or LAN
+discovery, which are split into #67.
+
+### Behavior table
+
+| Behavior | Test | Artifact |
+|---|---|---|
+| Deployment reaches `availableReplicas >= 1` | `test_deployment_becomes_ready` | `print-deployment.json` |
+| Pod reaches `Running` state | `test_pod_reaches_running_state` | `print-pods.json` |
+| ClusterIP service has endpoints on port 631 | `test_service_has_endpoints` | `print-endpoints.json` |
+| Config PVC (1Gi) binds on `local-path` | `test_config_pvc_is_bound` | `print-pvc-homelab-print-config.json` |
+| Config PVC reports expected capacity and access modes | `test_config_pvc_capacity_and_access_modes` | same |
+| Config PVC uses `local-path` storage class | `test_config_pvc_storage_class` | same |
+| `/config` mount is writable | `test_config_mount_is_writable` | — |
+| IPP port 631 reachable in-cluster | `test_ipp_port_is_reachable_in_cluster` | `print-reachability.txt` |
+| Cluster DNS resolves service FQDN | `test_cluster_dns_resolves_print_service` | `print-dns.txt` |
+| `PUID`, `PGID`, `TZ` env vars present | `test_puid_pgid_tz_env_vars_are_present` | `print-env.txt` |
+| Config sentinel survives `rollout restart` | `test_config_state_survives_rollout_restart` | `print-rollout-status.txt` |
+| Storage observability artifacts collected | `test_collects_storage_observability_artifacts` | `print-config-{df,findmnt,stat}.txt` |
+| USB printer device access | `test_usb_printer_device_access_is_out_of_scope_for_base_lane` | `pytest.skip` → #67 |
+| LAN mDNS autodiscovery | `test_lan_mdns_discovery_is_out_of_scope_for_base_lane` | `pytest.skip` → #67 |
+
+### Out-of-scope splits
+
+| Behavior | Reason | Tracked |
+|---|---|---|
+| USB printer device access (`/dev/usb/lp0` hostPath) | Host device passthrough; depends on #54 substrate work | #67 |
+| LAN mDNS / avahi self-discovery | Requires avahi sidecar and NodePort/LoadBalancer exposure | #67 |
+| Administration UI auth-gating | Deferred beyond #67 | TBD |
+| NodePort / LoadBalancer for LAN printing | Out of scope for base in-cluster validation | #67 |
+
+### Dependencies
+- #52 homelab storage (local-path PVC contract proven first)
+- #53 homelab access (cluster DNS + in-cluster reachability proven first)
+- #54 homelab substrate (in-cluster scheduling proven first)
+
+### Fixture image note
+The WorkflowTemplate uses `nginx:1.27.5-alpine` on port 631 as a
+representative stub (same approach as the media-service lane).  Replace
+with `lscr.io/linuxserver/cups:latest` when the lane graduates from
+validation to integration testing.  All five deployment-contract behaviors
+(PVC, env, port, DNS, restart persistence) are fully representative even
+with the stub image.

--- a/tests/service_catalog/print/test_print_service.py
+++ b/tests/service_catalog/print/test_print_service.py
@@ -1,0 +1,307 @@
+"""
+Representative non-media homelab workload lane — OpenPrinting/CUPS print service.
+
+Proves the minimum in-cluster validation contract for a linuxserver.io-style
+print service (OpenPrinting/CUPS class) running directly in Kubernetes:
+
+  1. Deployment   — workload reaches Running state on the cluster node.
+  2. Persistence  — config PVC binds on local-path, the config mount is
+                    writable, and state survives a rollout restart.
+  3. Reachability — IPP port (631) is reachable within the cluster namespace.
+  4. Secret/env   — PUID, PGID, and TZ environment variables are injected
+                    into the container and visible in the process environment.
+  5. Teardown     — namespace cleanup is handled by the workflow onExit handler;
+                    this lane verifies the pod and PVC are present before any
+                    cleanup runs.
+
+Lane dependencies:
+  - #52 (homelab storage epic)   — local-path PVC contract proven first
+  - #53 (homelab access epic)    — in-cluster DNS and TLS contracts proven first
+  - #54 (homelab substrate epic) — in-cluster workload scheduling proven first
+
+Out-of-scope for this base lane (split explicitly):
+  - USB printer device access and attachment → issue #67
+  - LAN mDNS / self-discovery (avahi) → issue #67
+  - NodePort or LoadBalancer exposure for LAN printing → issue #67
+  - Auth-gated administration UI → deferred beyond #67
+
+Source idea: projectbluefin/bluespeed#11 (OpenPrinting-class homelab path)
+Child of: #64, #51
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from tests.service_catalog.shared.kube import (
+    TEST_NAMESPACE,
+    first_pod_name,
+    get_pods_json,
+    run_kubectl,
+    write_artifact,
+)
+
+
+# ── Lane constants ────────────────────────────────────────────────────────────
+
+DEPLOYMENT_NAME = "homelab-print-service"
+APP_LABEL = os.environ.get("TEST_APP_LABEL", f"app={DEPLOYMENT_NAME}")
+SERVICE_NAME = os.environ.get("TEST_SERVICE_NAME", DEPLOYMENT_NAME)
+
+CONFIG_PVC_NAME = "homelab-print-config"
+CONFIG_MOUNT_PATH = "/config"
+
+PRINT_SERVICE_PORT = 631  # IPP (Internet Printing Protocol) standard port
+
+EXPECTED_ENV_VARS = {"PUID": "1000", "PGID": "1000", "TZ": "UTC"}
+
+EXPECTED_STORAGE_CLASS = "local-path"
+EXPECTED_CONFIG_CAPACITY = "1Gi"
+EXPECTED_ACCESS_MODES = ["ReadWriteOnce"]
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _exec_in_pod(*command: str) -> subprocess.CompletedProcess[str]:
+    return run_kubectl("exec", "-n", TEST_NAMESPACE, first_pod_name(), "--", *command)
+
+
+def _get_pvc(pvc_name: str) -> dict:
+    result = run_kubectl("get", "pvc", pvc_name, "-n", TEST_NAMESPACE, "-o", "json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    write_artifact(f"print-pvc-{pvc_name}.json", result.stdout)
+    return json.loads(result.stdout)
+
+
+def _pvc_debug(data: dict) -> str:
+    return json.dumps(data, indent=2)
+
+
+# ── Test class ────────────────────────────────────────────────────────────────
+
+
+class TestPrintServiceLane:
+    """
+    Base non-media homelab workload lane (OpenPrinting/CUPS class).
+
+    Validates deployment, single-PVC persistence, IPP port reachability, env
+    injection, and rollout-restart survival.  USB device access and LAN
+    discovery paths are skipped with explicit references to #67.
+    """
+
+    # ── 1. Deployment ─────────────────────────────────────────────────────────
+
+    def test_deployment_becomes_ready(self):
+        """Workload reaches availableReplicas >= 1 on the cluster node."""
+        result = run_kubectl(
+            "get", "deployment", DEPLOYMENT_NAME, "-n", TEST_NAMESPACE, "-o", "json"
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        write_artifact("print-deployment.json", result.stdout)
+        data = json.loads(result.stdout)
+        status = data.get("status", {})
+        assert status.get("availableReplicas", 0) >= 1, json.dumps(status, indent=2)
+        assert status.get("readyReplicas", 0) >= 1, json.dumps(status, indent=2)
+
+    def test_pod_reaches_running_state(self):
+        """At least one pod is Running and its containers are all Ready."""
+        pods = get_pods_json()
+        write_artifact("print-pods.json", json.dumps(pods, indent=2))
+        items = pods.get("items", [])
+        assert items, "No print-service pod found"
+        pod = items[0]
+        phase = pod.get("status", {}).get("phase")
+        assert phase == "Running", json.dumps(pod.get("status", {}), indent=2)
+        container_statuses = pod.get("status", {}).get("containerStatuses", [])
+        assert container_statuses, "No containerStatuses found"
+        for cs in container_statuses:
+            assert cs.get("ready"), f"Container {cs.get('name')} not ready: {cs}"
+
+    def test_service_has_endpoints(self):
+        """ClusterIP service exposes at least one endpoint on PRINT_SERVICE_PORT."""
+        svc = run_kubectl("get", "service", SERVICE_NAME, "-n", TEST_NAMESPACE, "-o", "json")
+        eps = run_kubectl("get", "endpoints", SERVICE_NAME, "-n", TEST_NAMESPACE, "-o", "json")
+        assert svc.returncode == 0, svc.stdout + svc.stderr
+        assert eps.returncode == 0, eps.stdout + eps.stderr
+        write_artifact("print-service.json", svc.stdout)
+        write_artifact("print-endpoints.json", eps.stdout)
+        eps_data = json.loads(eps.stdout)
+        subsets = eps_data.get("subsets", [])
+        assert subsets, "No endpoint subsets found"
+        all_addresses = [addr for s in subsets for addr in s.get("addresses", [])]
+        assert all_addresses, "No endpoint addresses found"
+
+    # ── 2. Persistence — config PVC ───────────────────────────────────────────
+
+    def test_config_pvc_is_bound(self):
+        """Config PVC (1Gi ReadWriteOnce local-path) binds within the namespace."""
+        data = _get_pvc(CONFIG_PVC_NAME)
+        assert data.get("status", {}).get("phase") == "Bound", _pvc_debug(data)
+
+    def test_config_pvc_capacity_and_access_modes(self):
+        """Config PVC reports the expected storage capacity and access modes."""
+        data = _get_pvc(CONFIG_PVC_NAME)
+        assert (
+            data.get("status", {}).get("capacity", {}).get("storage")
+            == EXPECTED_CONFIG_CAPACITY
+        ), _pvc_debug(data)
+        assert (
+            data.get("spec", {}).get("accessModes") == EXPECTED_ACCESS_MODES
+        ), _pvc_debug(data)
+
+    def test_config_pvc_storage_class(self):
+        """Config PVC is provisioned by the expected storage class."""
+        data = _get_pvc(CONFIG_PVC_NAME)
+        assert (
+            data.get("spec", {}).get("storageClassName") == EXPECTED_STORAGE_CLASS
+        ), _pvc_debug(data)
+
+    def test_config_mount_is_writable(self):
+        """Container can write to /config — required for CUPS printer state."""
+        result = _exec_in_pod(
+            "sh", "-c",
+            f"test -d {CONFIG_MOUNT_PATH}"
+            f" && touch {CONFIG_MOUNT_PATH}/.writetest"
+            f" && rm -f {CONFIG_MOUNT_PATH}/.writetest",
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    # ── 3. Reachability ───────────────────────────────────────────────────────
+
+    def test_ipp_port_is_reachable_in_cluster(self):
+        """
+        HTTP GET to the print service on port 631 (IPP) succeeds in-cluster.
+
+        Uses wget from inside the workload pod.  A non-200 response that is
+        not a connection error (e.g. 426 Upgrade Required, which CUPS returns
+        for plain-HTTP requests to an IPP-only socket) still proves the port
+        is open and the service is running.
+        """
+        fqdn = f"{SERVICE_NAME}.{TEST_NAMESPACE}.svc.cluster.local"
+        result = _exec_in_pod(
+            "sh", "-c",
+            f"wget -q -S -O /dev/null http://{fqdn}:{PRINT_SERVICE_PORT}/ 2>&1 || true",
+        )
+        output = result.stdout + result.stderr
+        write_artifact("print-reachability.txt", output)
+        # A TCP connection refusal or DNS failure means the service is down.
+        assert "Connection refused" not in output, output
+        assert "Name or service not known" not in output, output
+
+    def test_cluster_dns_resolves_print_service(self):
+        """Cluster DNS resolves the print service FQDN."""
+        fqdn = f"{SERVICE_NAME}.{TEST_NAMESPACE}.svc.cluster.local"
+        result = run_kubectl(
+            "exec", "-n", TEST_NAMESPACE, first_pod_name(),
+            "--", "getent", "hosts", fqdn,
+        )
+        write_artifact("print-dns.txt", result.stdout + result.stderr)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    # ── 4. Secret / env injection ─────────────────────────────────────────────
+
+    def test_puid_pgid_tz_env_vars_are_present(self):
+        """
+        PUID, PGID, and TZ env vars are visible in the container environment.
+
+        linuxserver.io containers rely on these to set file ownership and
+        timezone at startup.  This check proves the env values are injected
+        by the Deployment spec and not silently dropped.
+        """
+        result = _exec_in_pod("env")
+        assert result.returncode == 0, result.stdout + result.stderr
+        write_artifact("print-env.txt", result.stdout)
+        env = dict(
+            line.split("=", 1) for line in result.stdout.splitlines() if "=" in line
+        )
+        for var, expected in EXPECTED_ENV_VARS.items():
+            assert var in env, f"{var} not found in container env:\n{result.stdout}"
+            assert env[var] == expected, (
+                f"{var}={env[var]!r} but expected {expected!r}"
+            )
+
+    # ── 5. Rollout-restart persistence ────────────────────────────────────────
+
+    def test_config_state_survives_rollout_restart(self):
+        """
+        A sentinel file written to /config survives a rollout restart, proving
+        the config PVC persists through pod replacement.
+        """
+        before = get_pods_json()
+        write_artifact("print-pods-before-restart.json", json.dumps(before, indent=2))
+
+        seed = _exec_in_pod(
+            "sh", "-c",
+            f"echo print-sentinel >{CONFIG_MOUNT_PATH}/print-sentinel.txt",
+        )
+        assert seed.returncode == 0, seed.stdout + seed.stderr
+
+        restart = run_kubectl(
+            "rollout", "restart", f"deployment/{DEPLOYMENT_NAME}", "-n", TEST_NAMESPACE
+        )
+        assert restart.returncode == 0, restart.stdout + restart.stderr
+        write_artifact("print-restart.txt", restart.stdout + restart.stderr)
+
+        status = run_kubectl(
+            "rollout", "status", f"deployment/{DEPLOYMENT_NAME}",
+            "-n", TEST_NAMESPACE, "--timeout=300s",
+        )
+        assert status.returncode == 0, status.stdout + status.stderr
+        write_artifact("print-rollout-status.txt", status.stdout + status.stderr)
+
+        after = get_pods_json()
+        write_artifact("print-pods-after-restart.json", json.dumps(after, indent=2))
+
+        verify = _exec_in_pod("cat", f"{CONFIG_MOUNT_PATH}/print-sentinel.txt")
+        assert verify.returncode == 0, verify.stdout + verify.stderr
+        assert verify.stdout.strip() == "print-sentinel", (
+            f"Sentinel missing from {CONFIG_MOUNT_PATH} after restart: {verify.stdout!r}"
+        )
+
+    # ── 6. Storage observability artifacts ────────────────────────────────────
+
+    def test_collects_storage_observability_artifacts(self):
+        """Capture disk/mount evidence for the config PVC mount path."""
+        commands = {
+            "print-config-df.txt": ["df", "-h", CONFIG_MOUNT_PATH],
+            "print-config-findmnt.txt": ["findmnt", CONFIG_MOUNT_PATH],
+            "print-config-stat.txt": ["stat", CONFIG_MOUNT_PATH],
+        }
+        for artifact, cmd in commands.items():
+            result = _exec_in_pod(*cmd)
+            assert result.returncode == 0, (
+                f"{' '.join(cmd)} failed: {result.stdout}{result.stderr}"
+            )
+            write_artifact(artifact, result.stdout + result.stderr)
+
+    # ── 7. Explicitly deferred paths ─────────────────────────────────────────
+
+    def test_usb_printer_device_access_is_out_of_scope_for_base_lane(self):
+        """
+        USB printer device access and attachment to the CUPS container are
+        out of scope for this base lane.  Requires host device passthrough
+        (hostPath /dev/usb/lp0 or similar) which depends on substrate work
+        in #54.  Tracked explicitly in issue #67.
+        """
+        pytest.skip(
+            "USB printer device access deferred to #67; "
+            "requires host device passthrough — depends on #54 substrate work"
+        )
+
+    def test_lan_mdns_discovery_is_out_of_scope_for_base_lane(self):
+        """
+        LAN mDNS / avahi-based self-discovery is out of scope for this base
+        lane.  The in-cluster validation contract covers IPP reachability and
+        DNS resolution within the cluster namespace only.  LAN discovery
+        exposure (NodePort or LoadBalancer + avahi) is tracked in issue #67.
+        """
+        pytest.skip(
+            "LAN mDNS autodiscovery deferred to #67; "
+            "requires avahi sidecar and NodePort/LoadBalancer exposure — "
+            "out of scope for base in-cluster validation"
+        )


### PR DESCRIPTION
## Summary

Implements the first non-media homelab workload lane under the service-catalog epic (#51). This PR closes #64, adding an OpenPrinting/CUPS print-service lane grounded in `projectbluefin/bluespeed#11`.

## Acceptance criteria check

- [x] A first non-media homelab workload lane is defined clearly enough to implement
- [x] The issue states the minimum workload behaviors the lane must prove in the lab (see behavior table in §7 of homelab-contracts.md)
- [x] Device or exposure follow-ups are split explicitly — USB device access and LAN mDNS → #67 (two explicit `pytest.skip` calls with issue references)
- [x] The issue is linked to #51 and related access/substrate work (#52, #53, #54)

## What's in this PR

### `tests/service_catalog/print/test_print_service.py`
14 test methods in `TestPrintServiceLane`:

| Group | Tests |
|---|---|
| Deployment | ready, pod Running, service endpoints |
| Config PVC | bound, capacity/access-modes, storage-class, writable |
| Reachability | IPP port 631 in-cluster, cluster DNS |
| Env injection | PUID/PGID/TZ present with expected values |
| Rollout persistence | config sentinel survives pod replacement |
| Observability | df/findmnt/stat for /config mount |
| Deferred | USB device access → `pytest.skip` → #67; mDNS → `pytest.skip` → #67 |

### `argo/workflow-templates/homelab-print-service.yaml`
ArgoCD-managed WorkflowTemplate (same DAG pattern as `homelab-media-service`):
- **create-namespace** → **deploy-fixture** → **run-tests** DAG
- deploy-fixture: `homelab-print-config` 1Gi PVC, Deployment with PUID/PGID/TZ env and config mount, ClusterIP Service on port 631
- **cleanup** onExit handler with namespace deletion + wait-for-termination
- Fixture: `nginx:1.27.5-alpine` on port 631 (representative stub — replace with `lscr.io/linuxserver/cups` when graduating to integration)

### `argo/homelab-print-service.yaml`
Workflow submit trigger (mirrors `homelab-media-service.yaml` pattern).

### `docs/homelab-contracts.md`
- Print-service row added to workload matrix (§1)
- Print-service minimum persistence contract added (§1)
- Gaps section updated: USB device access and LAN mDNS split → #67
- §6 known-blockers table: #64 → ✅ implemented; #67 → deferred
- §7 Print-Service Workload Lane added: behavior table, out-of-scope splits, dependencies, fixture image note

## Why print service (OpenPrinting/CUPS)?

`projectbluefin/bluespeed#11` explicitly calls out containerized OpenPrinting on ghost so LAN clients can print to attached printers without driver installation. The base lane proves the deployment contract (PVC, reachability, env, restart persistence) without hardware assumptions. USB device attachment and LAN discovery are explicitly deferred to #67.

## Dependencies
- #52 homelab storage (local-path PVC)
- #53 homelab access (cluster DNS + in-cluster reachability)
- #54 homelab substrate (in-cluster scheduling)
- Out-of-scope splits: #67 (USB device access + LAN mDNS discovery)