### PR TITLE
docs: add Tier 3 NOGO full example to vanguard report template

### DIFF
--- a/docs/vanguard-report-template.md
+++ b/docs/vanguard-report-template.md
@@ -92,6 +92,108 @@ The HTML comment at the end is parsed by automation. Keep it on its own line.
 - Skipped Tier when one was actually run (e.g. "trusted the unit test layer").
 - Missing blocker issue links when verdict is NOGO.
 
+## Full example (bluefin latest, Tier 3, NOGO) — 2026-05-26
+
+This example demonstrates a complete fresh-VM Tier 3 run that reached GNOME Shell
+but failed the top-bar contract.  Use it as a reference for the full evidence shape,
+NOGO verdict formatting, and blocker issue linking.
+
+```markdown
+## ⚡ Vanguard Lab Strike Report: bluefin-test-a4af2fb9
+**Alpha**: Blue Universal CI Companion · testing-lab report example
+**Guardian on Duty**: `castrojo` on Ghost Homelab
+
+*"Fresh-VM smoke reached GNOME Shell, then the live top-bar contract broke wide open."*
+
+| Field | Value |
+|---|---|
+| **Branch** | `main` @ `e0da826ff097` |
+| **PR** | — |
+| **Closes** | — |
+| **Target** | `testing-lab` |
+| **VM/Host** | `bluefin-test-a4af2fb9-0878-44da-ac72-89eb027aca92` (bluefin-test namespace on ghost; VM IP `10.42.0.220`) |
+| **Image** | `ghcr.io/ublue-os/bluefin:latest` |
+| **Date** | 2026-05-26T14:18:16Z |
+| **Tier** | 3 · **Strike Confirmed** |
+| **Labels** | `domain:testing` `domain:desktop` `domain:shell` `domain:data-capture` |
+
+### Tier 3 — Strike Confirmed · Full Loop
+
+```text
+$ argo get bluefin-qa-smoke-qbpc2 -n argo --no-color
+Name:                bluefin-qa-smoke-qbpc2
+Namespace:           argo
+ServiceAccount:      argo
+Status:              Failed
+Finished:            Tue May 26 10:18:16 -0400
+Duration:            4 minutes 39 seconds
+Parameters:
+  image:             ghcr.io/ublue-os/bluefin:latest
+  image-tag:         latest
+  branch:            main
+
+STEP                              TEMPLATE                           PODNAME                                              DURATION  MESSAGE
+ ✖ bluefin-qa-smoke-qbpc2         bluefin-test-pipeline
+ ├─✔ ensure-disk                  bib-build-and-push/ensure-disk
+ │ ├───✔ check                    bib-disk-check                     bluefin-qa-smoke-qbpc2-bib-disk-check-3186093576     4s
+ │ ├───○ pull-image               bib-img-pull                                                                                      when 'exists != exists' evaluated false
+ │ ├───○ build                    bib-img-build                                                                                     when 'exists != exists' evaluated false
+ │ └───○ configure                bib-disk-configure                                                                                when 'exists != exists' evaluated false
+ ├─✔ provision                    provision-bluefin-vm/provision-vm
+ │ ├───✔ reflink-disk             reflink-disk                       bluefin-qa-smoke-qbpc2-reflink-disk-2562694658       4s
+ │ ├───✔ create-vm                create-vm                          bluefin-qa-smoke-qbpc2-create-vm-2881440482          2s
+ │ └───✔ wait-for-vm              wait-for-vm-ready                  bluefin-qa-smoke-qbpc2-wait-for-vm-ready-3689230188  12s
+ └─✖ run-tests                    run-gnome-tests/run-gnome-tests    bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209    3m        main: Error (exit code 1)
+```
+
+### Workflow Evidence
+
+```text
+$ argo logs bluefin-qa-smoke-qbpc2 -n argo --no-color | rg 'Waiting for SSH|SSH ready|Dependencies ready|ASSERT FAILED'
+bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209: Waiting for SSH on 10.42.0.220 (variant=latest, suite=smoke)...
+bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209: SSH ready.
+bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209: Dependencies ready.
+bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209:               "ASSERT FAILED: Panel (role='panel') not found in gnome-shell.",
+bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209:             "error_message": "ASSERT FAILED: Activities overview did not open after 4s",
+bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209:             "error_message": "ASSERT FAILED: Quick Settings not open — Shell.Eval inner: '\"true\"'",
+bluefin-qa-smoke-qbpc2-run-gnome-tests-3392667209:             "error_message": "ASSERT FAILED: Date menu not open — Shell.Eval inner: '\"true\"'"
+```
+
+### Desktop Smoke Test
+
+```text
+$ python3 summarize-results.py /tmp/bluefin-qa-smoke-qbpc2-results.json
+3 passed, 11 failed, 14 total
+- Panel is present in AT-SPI tree
+- Activities toggle button is visible in panel
+- Clock toggle button is visible in panel
+- System menu toggle button is visible in panel
+- Super key opens Activities overview
+- Typing in overview populates search bar
+- Escape closes Activities overview
+- Clicking System menu opens Quick Settings
+- Escape closes Quick Settings
+- Clicking clock opens calendar popup
+- Escape closes calendar popup
+```
+
+### Blockers
+
+```text
+$ gh issue view 101 --repo castrojo/testing-lab
+#101 bug: fresh latest smoke run loses GNOME Shell panel/top-bar coverage
+https://github.com/castrojo/testing-lab/issues/101
+```
+
+---
+
+**🔴 NOGO** — `bluefin-qa-smoke-qbpc2` completed the full fresh-VM loop but failed GNOME Shell smoke coverage; blocker: #101.
+
+<!-- status:FAIL target:testing-lab label:kind:report digest:bluefin-qa-smoke-qbpc2 -->
+```
+
+---
+
 ## Minimum example (testing-lab self-PR, Tier 1)
 
 ```markdown


### PR DESCRIPTION
Closes #102.

## Summary

Adds a **Full example (bluefin latest, Tier 3, NOGO)** section to `docs/vanguard-report-template.md`, sourced from the 2026-05-26 bluefin latest run (`bluefin-qa-smoke-qbpc2`).

## Why

The template previously had only a minimal Tier 1 GO example. Agents and operators reviewing PRs now have a concrete Tier 3 NOGO reference showing:

- All four evidence sections in use: **Tier 3 Full Loop**, **Workflow Evidence**, **Desktop Smoke Test**, **Blockers**
- Real `argo get` + `argo logs` output shape (step tree with ✔/✖/○, duration, message)
- NOGO verdict line referencing the workflow name and a filed blocker issue
- Correct HTML comment format (`status:FAIL`)

## Change

Single file: `docs/vanguard-report-template.md` — +102 lines (new section inserted before the existing Minimum example).