### PR TITLE
docs: archive Flatcar E2E first green strike report (closes #106)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -96,6 +96,9 @@ Golden disks can be patched by workflow after key rotation; titan disk key refre
 | VM stuck `Terminating` | KubeVirt controller race with launcher cleanup | Delete the `virt-launcher-*` pod and let reconciliation finish |
 | `run-gnome-tests` pod fails at startup | Workflow template structure error, often misplaced `volumes:` | Fix the template in git and let ArgoCD reconcile it |
 | WorkflowTemplate change appears ignored | Workflow was submitted before the new template was reconciled | Verify ArgoCD revision, wait or sync, then submit a new workflow |
+| Flatcar runner: `pip3: command not found` | Fedora minimal lacks standalone `pip3` | Use `python3 -m pip install` in runner pods |
+| Flatcar runner: exit code 64 | Template has `outputs.artifacts` but Argo artifact storage is not configured | Remove artifact `outputs:` from the template |
+| Flatcar test: `ctr version` fails as `core` | containerd socket requires root | Use `sudo ctr version` (core has passwordless sudo) |
 
 ## Historical notes
 

--- a/docs/archive/flatcar-first-green.md
+++ b/docs/archive/flatcar-first-green.md
@@ -1,0 +1,45 @@
+# Flatcar E2E First Green Run — Strike Report
+
+> Archived from [#106](https://github.com/projectbluefin/testing-lab/issues/106).
+> Date: 2026-05-26. Workflow: `flatcar-smoke-b9ngr`. Commit: `f0f8714`.
+
+## Result
+
+7/7 boot scenarios passed. Workflow succeeded in 1m 30s.
+
+```
+STEP                           TEMPLATE                DURATION
+ ✔ flatcar-smoke-b9ngr         flatcar-test-pipeline
+ ├─✔ provision                 provision-flatcar-vm
+ │ ├───✔ prepare-disk          prepare-flatcar-disk       4s
+ │ ├───✔ create-vm             create-flatcar-vm          2s
+ │ └───✔ wait-for-vm           wait-for-flatcar-ready    15s
+ └─✔ run-tests                 run-flatcar-tests         19s
+
+ ✔ flatcar-smoke-b9ngr.onExit  cleanup
+ └───✔ teardown                teardown-flatcar-vm
+     ├───✔ delete-vm           delete-vm                  6s
+     └───✔ delete-hostdisk     delete-hostdisk            3s
+```
+
+## Infrastructure fixes applied before first green
+
+Seven bugs discovered and fixed during the bringup session:
+
+| # | Commit | Problem | Fix |
+|---|---|---|---|
+| 1 | `e9e9085` | Fedora minimal has no `pip3` binary | `pip3` → `python3 -m pip` |
+| 2 | `e9be83c` | Runner pod missing Python and SSH | `dnf install python3 python3-pip openssh-clients` in runner |
+| 3 | `c3c8339` | SSH pubkey not available to Flatcar provisioner | Read from `bluefin-test-ssh-key` secret via `secretKeyRef` |
+| 4 | `ce4eae7` | `html-pretty` behave formatter not installed | Drop `html-pretty`; use `json.pretty` only |
+| 5 | `5614971` | Tests read from stale hostPath `/var/tmp/bluefin-tests` | Clone tests from git at runtime |
+| 6 | `f0f8714` | Argo artifact storage not configured | Remove artifact `outputs:` (causes exit 64) |
+| 7 | `698c61f` | `ctr version` fails as `core` user | `ctr version` → `sudo ctr version` (containerd socket requires root) |
+
+## Durable lessons
+
+- **Fedora minimal images lack `pip3`**: always use `python3 -m pip` in workflow pods.
+- **Never rely on hostPath for test files**: clone from git at runtime via `git-sync` or inline clone.
+- **Argo artifact `outputs:` requires storage config**: omit artifact outputs if Argo's artifact repository is not configured; the workflow exits 64 silently.
+- **Flatcar `core` user cannot access containerd socket directly**: use `sudo` for `ctr` commands. The `core` user has passwordless sudo.
+- **SSH key injection for Flatcar**: use `secretKeyRef` from the shared `bluefin-test-ssh-key` secret, same as Bluefin pipelines.

--- a/docs/archive/iteration-notes.md
+++ b/docs/archive/iteration-notes.md
@@ -3,6 +3,34 @@
 These notes were moved out of `RUNBOOK.md` so the runbook can stay timeless.
 They are preserved here for debugging history and migration context.
 
+## Flatcar E2E bringup lessons (2026-05-26)
+
+Seven infra bugs fixed to achieve the first green Flatcar run. Full report:
+[flatcar-first-green.md](flatcar-first-green.md).
+
+### Runner pod image assumptions
+
+Fedora minimal images (`quay.io/fedora/fedora:latest`) do not include `pip3` as a
+standalone binary. Always use `python3 -m pip install` instead of `pip3 install`.
+The runner also needs `openssh-clients` installed explicitly.
+
+### Test delivery: git clone, not hostPath
+
+The original Flatcar runner read tests from a stale hostPath (`/var/tmp/bluefin-tests`).
+This is fragile — the same pattern that Bluefin runners already fixed with `git-sync`.
+Always clone tests from git at runtime.
+
+### Argo artifact outputs require storage config
+
+Adding `outputs.artifacts` to a template causes exit code 64 if the Argo artifact
+repository is not configured. Since this cluster does not use artifact storage,
+workflow evidence goes to pod stdout (captured by Loki). Omit artifact outputs.
+
+### Flatcar containerd socket permissions
+
+The `core` user cannot access `/run/containerd/containerd.sock` directly. Use
+`sudo ctr version` in tests. The `core` user has passwordless sudo on Flatcar.
+
 ## Iteration 2 lessons (2026-05-25)
 
 ### dogtail API changes — root cause + migration


### PR DESCRIPTION
## Summary

Archives the Vanguard Lab Strike Report from #106 documenting the first successful Flatcar E2E pipeline run (`flatcar-smoke-b9ngr`, 7/7 scenarios, 1m 30s).

- **`docs/archive/flatcar-first-green.md`** — full strike report with workflow output, the 7 infra/test fixes applied, and durable lessons extracted
- **`docs/archive/iteration-notes.md`** — Flatcar bringup section added covering: Fedora minimal `pip3` absence, test delivery via git (not hostPath), Argo artifact exit 64, and containerd socket permissions
- **`RUNBOOK.md`** — three new failure-mode rows for Flatcar-specific issues (`pip3` missing, exit code 64, `ctr version` as core user)

All 7 fixes referenced in the report are already on main. This PR archives the evidence and extracts the reusable lessons into the repo's knowledge base.

## Test plan

- [ ] No code changes — documentation only
- [ ] Archived report links back to #106
- [ ] Iteration notes cross-reference the full report