### PR TITLE
docs: archive GNOME smoke strike report for titan-bluefin + titan-lts (closes #108)

### DIFF
--- a/docs/archive/gnome-smoke-2026-05-26.md
+++ b/docs/archive/gnome-smoke-2026-05-26.md
@@ -1,0 +1,39 @@
+# GNOME Smoke Strike Report — titan-bluefin + titan-lts
+
+> Archived from [#108](https://github.com/projectbluefin/testing-lab/issues/108).
+> Date: 2026-05-26. Workflow: `bluefin-titan-smoke-xb9c2`. Commit: `f9cef2521e6e`.
+
+## Result
+
+GNOME smoke green on both `latest` and `lts` titan VMs. 4/4 steps succeeded in 4m 50s.
+
+```
+STEP                          TEMPLATE                         DURATION
+ ✔ bluefin-titan-smoke-xb9c2  run-smoke
+ ├─┬─✔ preflight-latest       preflight                        28s
+ │ └─✔ preflight-lts          preflight                        29s
+ └─┬─✔ smoke-latest           run-gnome-tests/run-gnome-tests  4m
+   └─✔ smoke-lts              run-gnome-tests/run-gnome-tests  3m
+```
+
+## VM state at test time
+
+| VM | Namespace | IP | Status |
+|---|---|---|---|
+| titan-bluefin | bluefin-test | 10.42.0.28 | Running / Ready |
+| titan-lts | bluefin-lts-test | 10.42.0.27 | Running / Ready |
+
+## Workflow parameters
+
+| Parameter | Value |
+|---|---|
+| `vm-ip-latest` | 10.42.0.28 |
+| `vm-ip-lts` | 10.42.0.27 |
+| `suite` | smoke |
+| `branch` | main |
+
+## Notes
+
+No infrastructure fixes required. This was a clean green run — both the
+titan fast path and the GNOME smoke suite were stable on the same day as
+the Flatcar first green ([flatcar-first-green.md](flatcar-first-green.md)).

--- a/docs/archive/iteration-notes.md
+++ b/docs/archive/iteration-notes.md
@@ -3,6 +3,14 @@
 These notes were moved out of `RUNBOOK.md` so the runbook can stay timeless.
 They are preserved here for debugging history and migration context.
 
+## GNOME smoke baseline (2026-05-26)
+
+First recorded clean GNOME smoke run on both titan VMs. Workflow
+`bluefin-titan-smoke-xb9c2` succeeded 4/4 in 4m 50s with no fixes needed.
+Full report: [gnome-smoke-2026-05-26.md](gnome-smoke-2026-05-26.md).
+
+This establishes the baseline for titan fast-path regression detection.
+
 ## Iteration 2 lessons (2026-05-25)
 
 ### dogtail API changes — root cause + migration


### PR DESCRIPTION
## Summary

Archives the Vanguard Lab Strike Report from #108 documenting the first recorded clean GNOME smoke run on both titan VMs (2026-05-26).

- **`docs/archive/gnome-smoke-2026-05-26.md`** — full strike report with workflow output, VM state, and parameters
- **`docs/archive/iteration-notes.md`** — baseline entry noting this as the reference point for titan fast-path regression detection

This was a clean green run — no fixes needed. Workflow `bluefin-titan-smoke-xb9c2` succeeded 4/4 in 4m 50s on both `latest` and `lts` titan VMs.

## Test plan

- [ ] No code changes — documentation only
- [ ] Archived report links back to #108