### PR TITLE
test: add unit tests for shared helpers and coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install pytest ruff pytest-cov
 
+
+      - name: Run unit tests with coverage
+        run: python -m pytest --cov=tests/shared --cov=tests/service_catalog/shared --cov-report=term-missing --cov-fail-under=60 tests/unit/
 
       - name: Pytest discovery check
         run: python -m pytest --collect-only tests/
@@ -43,3 +46,4 @@ jobs:
       - name: Lint check with ruff
         run: python -m ruff check tests/
         continue-on-error: true
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization

--- a/tests/shared/__init__.py
+++ b/tests/shared/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization

--- a/tests/shared/wait_for_shell.py
+++ b/tests/shared/wait_for_shell.py
@@ -7,59 +7,68 @@ from dogtail import tree as dtree
 
 last_err = "unknown"
 
-for attempt in range(1, 31):
-    try:
-        result = subprocess.run(
-            [
-                "gdbus",
-                "call",
-                "--session",
-                "--dest",
-                "org.gnome.Shell",
-                "--object-path",
-                "/org/gnome/Shell",
-                "--method",
-                "org.gnome.Shell.Eval",
-                "global.context.unsafe_mode = true; Main.panel ? true : false",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0 or "(true," not in result.stdout:
-            err = result.stderr.strip() or result.stdout.strip() or "unknown gdbus failure"
-            last_err = f"Shell.Eval not ready: {err[:200]}"
+def wait_for_shell(attempts=30, sleep_time=2):
+    last_err = "unknown"
+
+    for attempt in range(1, attempts + 1):
+        try:
+            result = subprocess.run(
+                [
+                    "gdbus",
+                    "call",
+                    "--session",
+                    "--dest",
+                    "org.gnome.Shell",
+                    "--object-path",
+                    "/org/gnome/Shell",
+                    "--method",
+                    "org.gnome.Shell.Eval",
+                    "global.context.unsafe_mode = true; Main.panel ? true : false",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode != 0 or "(true," not in result.stdout:
+                err = result.stderr.strip() or result.stdout.strip() or "unknown gdbus failure"
+                last_err = f"Shell.Eval not ready: {err[:200]}"
+                print(f"Readiness attempt {attempt}: {last_err}", flush=True)
+                time.sleep(sleep_time)
+                continue
+
+            shell = dtree.root.application("gnome-shell")
+            panels = shell.findChildren(lambda n: n.roleName == "panel")
+            if not panels:
+                last_err = "gnome-shell panel not exposed in AT-SPI yet"
+                print(f"Readiness attempt {attempt}: {last_err}", flush=True)
+                time.sleep(sleep_time)
+                continue
+
+            # On GNOME Shell 50 the clock button has an empty AT-SPI name.
+            # Readiness: panel exists + Shell.Eval confirms Main.panel is live.
+            # Require 'Activities' or 'Show Apps' to confirm panel is populated.
+            toggles = panels[0].findChildren(lambda n: n.roleName == "toggle button")
+            named = [t.name for t in toggles if t.name]
+            if any(n in ("Activities", "Show Apps") for n in named):
+                print(f"GNOME Shell ready (attempt {attempt}): {named}", flush=True)
+                return True
+
+            last_err = f"panel not yet populated (toggles: {[t.name for t in toggles]})"
             print(f"Readiness attempt {attempt}: {last_err}", flush=True)
-            time.sleep(2)
-            continue
+        except Exception as exc:  # noqa: BLE001
+            last_err = str(exc)
+            print(f"Readiness attempt {attempt} failed: {last_err}", flush=True)
+        time.sleep(sleep_time)
 
-        shell = dtree.root.application("gnome-shell")
-        panels = shell.findChildren(lambda n: n.roleName == "panel")
-        if not panels:
-            last_err = "gnome-shell panel not exposed in AT-SPI yet"
-            print(f"Readiness attempt {attempt}: {last_err}", flush=True)
-            time.sleep(2)
-            continue
+    print(
+        f"ERROR: GNOME Shell AT-SPI readiness failed after {attempts} attempts ({last_err})",
+        file=sys.stderr,
+        flush=True,
+    )
+    return False
 
-        # On GNOME Shell 50 the clock button has an empty AT-SPI name.
-        # Readiness: panel exists + Shell.Eval confirms Main.panel is live.
-        # Require 'Activities' or 'Show Apps' to confirm panel is populated.
-        toggles = panels[0].findChildren(lambda n: n.roleName == "toggle button")
-        named = [t.name for t in toggles if t.name]
-        if any(n in ("Activities", "Show Apps") for n in named):
-            print(f"GNOME Shell ready (attempt {attempt}): {named}", flush=True)
-            sys.exit(0)
 
-        last_err = f"panel not yet populated (toggles: {[t.name for t in toggles]})"
-        print(f"Readiness attempt {attempt}: {last_err}", flush=True)
-    except Exception as exc:  # noqa: BLE001
-        last_err = str(exc)
-        print(f"Readiness attempt {attempt} failed: {last_err}", flush=True)
-    time.sleep(2)
+if __name__ == "__main__":
+    if not wait_for_shell():
+        sys.exit(1)
 
-print(
-    f"ERROR: GNOME Shell AT-SPI readiness failed after 30 attempts ({last_err})",
-    file=sys.stderr,
-    flush=True,
-)
-sys.exit(1)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization

--- a/tests/unit/test_kube.py
+++ b/tests/unit/test_kube.py
@@ -1,0 +1,74 @@
+import pytest
+import json
+from unittest.mock import MagicMock, patch
+import subprocess
+
+from tests.service_catalog.shared.kube import (
+    run_kubectl,
+    require_kubectl,
+    get_pods_json,
+    first_pod_name,
+)
+
+
+@patch("tests.service_catalog.shared.kube.subprocess.run")
+def test_run_kubectl(mock_run):
+    mock_res = MagicMock()
+    mock_run.return_value = mock_res
+    
+    run_kubectl("get", "pods")
+    mock_run.assert_called_once_with(
+        ["kubectl", "get", "pods"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@patch("tests.service_catalog.shared.kube.subprocess.run")
+def test_require_kubectl_success(mock_run):
+    mock_res = MagicMock()
+    mock_res.returncode = 0
+    mock_res.stdout = "pod-output"
+    mock_run.return_value = mock_res
+    
+    res = require_kubectl("get", "pods")
+    assert res == "pod-output"
+
+
+@patch("tests.service_catalog.shared.kube.subprocess.run")
+def test_require_kubectl_failure(mock_run):
+    mock_res = MagicMock()
+    mock_res.returncode = 1
+    mock_res.stdout = "some stdout"
+    mock_res.stderr = "error message"
+    mock_run.return_value = mock_res
+    
+    with pytest.raises(AssertionError) as exc_info:
+        require_kubectl("get", "pods")
+    assert "kubectl get pods failed" in str(exc_info.value)
+    assert "error message" in str(exc_info.value)
+
+
+@patch("tests.service_catalog.shared.kube.require_kubectl")
+def test_get_pods_json(mock_require):
+    mock_require.return_value = json.dumps({"items": [{"metadata": {"name": "test-pod"}}]})
+    
+    data = get_pods_json()
+    assert data["items"][0]["metadata"]["name"] == "test-pod"
+
+
+@patch("tests.service_catalog.shared.kube.get_pods_json")
+def test_first_pod_name_success(mock_get_json):
+    mock_get_json.return_value = {"items": [{"metadata": {"name": "pod-123"}}]}
+    
+    assert first_pod_name() == "pod-123"
+
+
+@patch("tests.service_catalog.shared.kube.get_pods_json")
+def test_first_pod_name_empty(mock_get_json):
+    mock_get_json.return_value = {"items": []}
+    
+    with pytest.raises(AssertionError) as exc_info:
+        first_pod_name()
+    assert "No service-catalog pod found" in str(exc_info.value)

--- a/tests/unit/test_wait_for_shell.py
+++ b/tests/unit/test_wait_for_shell.py
@@ -1,0 +1,47 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+from tests.shared.wait_for_shell import wait_for_shell
+
+
+@patch("tests.shared.wait_for_shell.subprocess.run")
+@patch("tests.shared.wait_for_shell.time.sleep")
+@patch("tests.shared.wait_for_shell.dtree")
+def test_wait_for_shell_success(mock_dtree, mock_sleep, mock_run):
+    # 1. Mock subprocess.run to simulate gdbus returning (true, ...)
+    mock_res = MagicMock()
+    mock_res.returncode = 0
+    mock_res.stdout = "(true, true)"
+    mock_run.return_value = mock_res
+
+    # 2. Mock dogtail components
+    mock_app = MagicMock()
+    mock_panel = MagicMock()
+    mock_panel.roleName = "panel"
+    mock_toggle = MagicMock()
+    mock_toggle.name = "Activities"
+    mock_toggle.roleName = "toggle button"
+    
+    mock_panel.findChildren.return_value = [mock_toggle]
+    mock_app.findChildren.return_value = [mock_panel]
+    mock_dtree.root.application.return_value = mock_app
+
+    # 3. Call function with 1 attempt
+    assert wait_for_shell(attempts=1, sleep_time=0) is True
+    assert mock_run.call_count == 1
+
+
+@patch("tests.shared.wait_for_shell.subprocess.run")
+@patch("tests.shared.wait_for_shell.time.sleep")
+@patch("tests.shared.wait_for_shell.dtree")
+def test_wait_for_shell_failure_gdbus(mock_dtree, mock_sleep, mock_run):
+    # Simulate gdbus failure
+    mock_res = MagicMock()
+    mock_res.returncode = 1
+    mock_res.stderr = "gdbus connection refused"
+    mock_run.return_value = mock_res
+
+    assert wait_for_shell(attempts=2, sleep_time=0) is False
+    assert mock_run.call_count == 2
+    assert mock_sleep.call_count == 2


### PR DESCRIPTION
Adds unit tests for wait_for_shell and kube helpers, and configures pytest-cov in CI with a 60% coverage threshold to satisfy issues #185 and #186.