### PR TITLE
fix: update stale ublue-os image references to projectbluefin

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -26,7 +26,7 @@ run test suites → teardown VM on exit.
 
 | Parameter | Default | Notes |
 |---|---|---|
-| `image` | `ghcr.io/ublue-os/bluefin` | Source image. Tag is appended from `image-tag` for some callers; pass with tag if invoking directly. |
+| `image` | `ghcr.io/projectbluefin/bluefin` | Source image. Tag is appended from `image-tag` for some callers; pass with tag if invoking directly. |
 | `image-tag` | `latest` | `latest`, `lts`, etc. Also used as the golden-disk dir name. |
 | `namespace` | `bluefin-test` | KubeVirt VM namespace. Use `bluefin-lts-test` for LTS. |
 | `suites` | `smoke,developer` | Comma list; valid: `smoke`, `developer`, `software`. |

--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -18,7 +18,7 @@ spec:
   arguments:
     parameters:
       - name: image
-        value: "ghcr.io/ublue-os/bluefin"
+        value: "ghcr.io/projectbluefin/bluefin"
       - name: image-tag
         value: "latest"
       - name: namespace


### PR DESCRIPTION
Addresses hive advisory findings from [projectbluefin/common#557](https://github.com/projectbluefin/common/issues/557).

- `WORKFLOWS.md`: default image parameter documented as `ghcr.io/ublue-os/bluefin` → `ghcr.io/projectbluefin/bluefin`
- `argo/workflow-templates/bluefin-qa-pipeline.yaml`: default `image` parameter in the Argo WorkflowTemplate → `ghcr.io/projectbluefin/bluefin`

Contributors copy examples from WORKFLOWS.md and pass the wrong image registry to the pipeline.