### PR TITLE
fix: resolve testing-lab#220 #221 #222 #223 — BIB diagnostic, migration-test tag, skopeo retry, subprocess timeouts

### DIFF
--- a/argo/workflow-templates/bib-build-and-push.yaml
+++ b/argo/workflow-templates/bib-build-and-push.yaml
@@ -131,9 +131,17 @@ spec:
           if [[ "${IMAGE_REF}" == 192.168.1.102:5000/* ]]; then
             SKOPEO_TLS_ARGS+=(--tls-verify=false)
           fi
-          REMOTE=$(skopeo inspect "${SKOPEO_TLS_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE_REF}" 2>/dev/null || true)
+          # Retry with exponential backoff — GHCR rate-limits anonymous skopeo
+          # inspects, returning empty output that is misread as stale (testing-lab#222).
+          REMOTE=""
+          for _attempt in 1 2 3; do
+            REMOTE=$(skopeo inspect "${SKOPEO_TLS_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE_REF}" 2>/dev/null || true)
+            [[ -n "${REMOTE}" ]] && break
+            echo "skopeo inspect attempt ${_attempt}/3 failed for ${IMAGE_REF}; retrying in $(( _attempt * 15 ))s..." >&2
+            sleep $(( _attempt * 15 ))
+          done
           if [[ -z "${REMOTE}" ]]; then
-            echo "skopeo inspect failed for ${IMAGE_REF}; treating as stale to force rebuild" >&2
+            echo "skopeo inspect failed after 3 attempts for ${IMAGE_REF}; treating as stale to force rebuild" >&2
             echo -n "stale"
             exit 0
           fi
@@ -241,6 +249,19 @@ spec:
             if [[ -f "${OUT}/image/disk.raw" ]]; then
               echo "disk.raw already exists at ${OUT}/image/disk.raw, skipping BIB build"
               exit 0
+            fi
+            # Preflight: report PCRE2 version for diagnostics (testing-lab#220).
+            # bluefin-lts and dakota require setfiles PCRE2 >= 10.46 (2025-08-27).
+            # centos-stream9 bootc-image-builder ships 10.44 — org.osbuild.selinux will
+            # fail for those images. Fix: update this image to one with PCRE2 >= 10.46.
+            PCRE2_PKG=$(rpm -q --queryformat '%{VERSION}' pcre2 2>/dev/null || echo "unknown")
+            echo "PCRE2 in BIB container: ${PCRE2_PKG}" >&2
+            if [[ "${PCRE2_PKG}" != "unknown" ]]; then
+              PCRE2_MAJ=${PCRE2_PKG%%.*}; PCRE2_MIN=${PCRE2_PKG#*.}; PCRE2_MIN=${PCRE2_MIN%%.*}
+              if (( PCRE2_MAJ < 10 || (PCRE2_MAJ == 10 && PCRE2_MIN < 46) )); then
+                echo "WARNING: PCRE2 ${PCRE2_PKG} < 10.46 in this BIB container." >&2
+                echo "  org.osbuild.selinux will fail for bluefin-lts/dakota. See testing-lab#220." >&2
+              fi
             fi
             # Request 40GB minimum root filesystem so bootc unified-storage
             # can pull a second copy (~5GB) alongside the live OS (~7GB).

--- a/argo/workflow-templates/bluefin-migration-test.yaml
+++ b/argo/workflow-templates/bluefin-migration-test.yaml
@@ -31,9 +31,10 @@ spec:
         value: "ghcr.io/ublue-os/bluefin"
       - name: chunkah-image
         value: "ghcr.io/projectbluefin/bluefin"
-      # Separate tag — projectbluefin only publishes :latest currently; update when more tags land
+      # Separate tag — projectbluefin publishes :stable (bluefin) and :lts (bluefin-lts).
+      # :latest does not exist on any projectbluefin image. See testing-lab#221.
       - name: chunkah-image-tag
-        value: "latest"
+        value: "stable"
       - name: storage-variant
         value: "default"
       - name: golden-root
@@ -107,7 +108,7 @@ spec:
           - name: chunkah-image
             value: "ghcr.io/projectbluefin/bluefin"
           - name: chunkah-image-tag
-            value: "latest"
+            value: "stable"
           - name: storage-variant
             value: "default"
           - name: evidence-root
@@ -525,10 +526,10 @@ spec:
               "-o", "LogLevel=ERROR",
           ]
 
-          def run_remote(command: str) -> subprocess.CompletedProcess:
-              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True)
+          def run_remote(command: str, timeout: int = 60) -> subprocess.CompletedProcess:
+              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True, timeout=timeout)
 
-          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True)
+          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True, timeout=30)
 
           if storage_variant == "experimental-unified-storage":
               command = "sudo bootc image set-unified"
@@ -568,10 +569,10 @@ spec:
 
           step_file = pathlib.Path(f"{step}.json")
           step_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True)
+          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True, timeout=120)
 
           aggregate_file = pathlib.Path("migration-evidence.json")
-          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True)
+          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True, timeout=60)
           aggregate = []
           if fetch.returncode == 0:
               try:
@@ -583,7 +584,7 @@ spec:
           aggregate = [item for item in aggregate if not (isinstance(item, dict) and item.get("step") == step)]
           aggregate.append(payload)
           aggregate_file.write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True)
+          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True, timeout=120)
 
           print(f"=== {step} ({storage_variant}) ({vm_ip}) ===")
           print(json.dumps(payload, indent=2))
@@ -678,8 +679,8 @@ spec:
               "-o", "LogLevel=ERROR",
           ]
 
-          def run_remote(command: str) -> subprocess.CompletedProcess:
-              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True)
+          def run_remote(command: str, timeout: int = 60) -> subprocess.CompletedProcess:
+              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True, timeout=timeout)
 
           def parse_json(text: str):
               try:
@@ -687,7 +688,7 @@ spec:
               except json.JSONDecodeError:
                   return None
 
-          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True)
+          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True, timeout=30)
 
           flags = ["--enforce-container-sigpolicy"]
           if storage_variant == "experimental-unified-storage":
@@ -723,10 +724,10 @@ spec:
 
           step_file = pathlib.Path(f"{step}.json")
           step_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True)
+          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True, timeout=120)
 
           aggregate_file = pathlib.Path("migration-evidence.json")
-          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True)
+          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True, timeout=60)
           aggregate = []
           if fetch.returncode == 0:
               try:
@@ -738,7 +739,7 @@ spec:
           aggregate = [item for item in aggregate if not (isinstance(item, dict) and item.get("step") == step)]
           aggregate.append(payload)
           aggregate_file.write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True)
+          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True, timeout=120)
 
           print(f"=== {step} ({storage_variant}) ({vm_ip}) ===")
           if payload["stdout"]:
@@ -909,8 +910,8 @@ spec:
               "-o", "LogLevel=ERROR",
           ]
 
-          def run_remote(command: str) -> subprocess.CompletedProcess:
-              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True)
+          def run_remote(command: str, timeout: int = 60) -> subprocess.CompletedProcess:
+              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True, timeout=timeout)
 
           def capture(command: str):
               result = run_remote(command)
@@ -950,7 +951,7 @@ spec:
                       return candidate
               return ""
 
-          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True)
+          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True, timeout=30)
 
           results = {
               "bootc_status_json": capture("sudo bootc status --json"),
@@ -1029,10 +1030,10 @@ spec:
 
           step_file = pathlib.Path(f"{step}.json")
           step_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True)
+          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True, timeout=120)
 
           aggregate_file = pathlib.Path("migration-evidence.json")
-          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True)
+          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True, timeout=60)
           aggregate = []
           if fetch.returncode == 0:
               try:
@@ -1044,7 +1045,7 @@ spec:
           aggregate = [item for item in aggregate if not (isinstance(item, dict) and item.get("step") == step)]
           aggregate.append(payload)
           aggregate_file.write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True)
+          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True, timeout=120)
 
           print(f"=== {step} evidence ({storage_variant}) ({vm_ip}) ===")
           print(json.dumps(payload, indent=2))
@@ -1126,7 +1127,7 @@ spec:
               f"{vm_user}@{vm_ip}",
           ]
 
-          result = subprocess.run(ssh_base + ["cat", f"{output_root}/{step}.json"], text=True, capture_output=True)
+          result = subprocess.run(ssh_base + ["cat", f"{output_root}/{step}.json"], text=True, capture_output=True, timeout=15)
           if result.returncode != 0:
               print(result.stderr.rstrip(), file=sys.stderr)
               sys.exit(result.returncode)


### PR DESCRIPTION
## What

Fixes 4 bugs found during live toggle-testing and migration upgrade lab session (2026-06-20).

### #221 — `chunkah-image-tag: latest` invalid default

Changed to `stable`. `:latest` doesn't exist on any projectbluefin image.

### #222 — skopeo transient failures force unnecessary BIB rebuilds

3-retry exponential backoff (15/30/45s) before treating failed skopeo inspect as stale. Fixes ~10 unnecessary 20-min BIB rebuilds per concurrent lab session.

### #223 — `collect-evidence` subprocess.run no timeout — SSH hangs block DAG 15 min

`timeout=` added to every subprocess.run() in all four Python templates:
run_remote()=60s, mkdir=30s, SCP write=120s, SCP fetch=60s, cat=15s.

### #220 (partial) — BIB fails for bluefin-lts/dakota: SELinux PCRE2 mismatch

Preflight `rpm -q pcre2` check prints version and warns clearly if < 10.46.
Full fix: update bootc-image-builder to container with PCRE2 >= 10.46.

Closes #221 Closes #222 Closes #223
Related #220