### PR TITLE
fix(arc): fix ARC runner configuration for ghost k3s cluster

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,6 +40,25 @@ jobs:
             argo lint --offline "$f" || echo "WARNING: $f needs server-side template resolution"
           done
 
+      - name: Registry allowlist check
+        run: |
+          # Fail if any image: reference uses a registry not in the cluster cache.
+          # Add '# registry-lint-ignore' to a line to exempt it (e.g. ROCm device plugin).
+          FAIL=0
+          while IFS= read -r line; do
+            echo "$line" | grep -q 'registry-lint-ignore' && continue
+            imgref=$(echo "$line" | sed 's/.*image:[[:space:]]*//' | awk '{print $1}' | tr -d '"'"'"')
+            [[ -z "$imgref" || "${imgref:0:1}" == "#" ]] && continue
+            registry=$(echo "$imgref" | cut -d/ -f1)
+            # skip bare names (no dot or colon = implicit docker.io, handled by zot-docker)
+            echo "$registry" | grep -qE '[.:]' || continue
+            case "$registry" in
+              ghcr.io|quay.io|registry.fedoraproject.org|registry.access.redhat.com|registry.k8s.io|192.168.1.102|localhost) ;;
+              *) echo "FAIL: uncached registry '$registry' in $(echo "$line" | cut -d: -f1-2): $imgref"; FAIL=1 ;;
+            esac
+          done < <(grep -rn 'image:' argo/ manifests/)
+          exit "$FAIL"
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Self-hosted GitHub Actions runners via Actions Runner Controller (ARC).
 | Runner label | `ghost-runners` |
 | GitHub config URL | `https://github.com/projectbluefin` |
 | Min runners | 0 (idle — `arc-runners` namespace empty when no jobs; correct) |
-| Max runners | 4 |
+| Max runners | 6 |
 | GitHub App | `bluefin-ghost-arc` (ID 4099840, Installation 141458121) |
 | Credentials secret | `arc-github-secret` in `arc-runners` namespace |
 | ArgoCD Applications | `argocd/arc-controller-app.yaml`, `argocd/arc-runners-app.yaml` |
@@ -231,8 +231,10 @@ distro-specific replacements when an upstream image exists.
 |---|---|---|---|
 | `testing` | `ghcr.io/projectbluefin/bluefin:testing` | `/var/tmp/bluefin-golden/testing/disk.raw` | 02:00 UTC |
 | `lts-testing` | `ghcr.io/projectbluefin/bluefin-lts:testing` | `/var/tmp/bluefin-golden/lts-testing/disk.raw` | 02:30 UTC |
+| `stable` | `ghcr.io/projectbluefin/bluefin:stable` | `/var/tmp/bluefin-golden/stable/disk.raw` | — |
+| `lts-stable` | `ghcr.io/projectbluefin/bluefin-lts:stable` | `/var/tmp/bluefin-golden/lts-stable/disk.raw` | — |
 
-> **There is no `:latest` tag.** Bluefin publishes `:testing` (pre-promotion) and `:stable` (released). LTS publishes `:testing`, `:lts`, and `:stable`. Source: `execute-release.yml` in each repo.
+> **`:stable` and `:testing` are the only production branches.** All other tags (`:latest`, `:lts`, `:gts`, date tags, stream tags) are developer-facing conveniences — never use them in automation, manifests, or docs. `bluefin-lts` has no `:latest` tag at all; `skopeo inspect` returns `manifest unknown` and will fail any workflow that tries it.
 
 ## VM Lifecycle
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,11 +208,24 @@ containerd `hosts.toml` (written by `registry-mirror-config` DaemonSet — no k3
 
 | Instance | Upstream | NodePort | Storage |
 |---|---|---|---|
+| `registry` (writable) | — write target, no upstream | 30500 | `/var/mnt/ghost-data/zot-local` |
 | `zot-ghcr` | `https://ghcr.io` | 30501 | `/var/mnt/ghost-data/zot-ghcr` |
 | `zot-docker` | `https://registry-1.docker.io` | 30502 | `/var/mnt/ghost-data/zot-docker` |
+| `zot-quay` | `https://quay.io` | 30503 | `/var/mnt/ghost-data/zot-quay` |
+| `zot-fedora` | `https://registry.fedoraproject.org` | 30504 | `/var/mnt/ghost-data/zot-fedora` |
+| `zot-redhat-access` | `https://registry.access.redhat.com` | 30505 | `/var/mnt/ghost-data/zot-redhat-access` |
+| `zot-k8s` | `https://registry.k8s.io` | 30506 | `/var/mnt/ghost-data/zot-k8s` |
 
-Both instances are pinned to ghost (hostPath storage requirement) and managed by
-ArgoCD `testing-lab-infra` via `manifests/zot-cache.yaml`.
+All instances pinned to ghost (hostPath storage) and managed by ArgoCD `testing-lab-infra`
+via `manifests/zot-cache.yaml` (pull-through) and `manifests/zot-writable.yaml` (write target).
+
+**Image policy:** all `image:` references in `argo/` and `manifests/` must use a cached registry.
+Enforced by the registry allowlist lint step in `.github/workflows/lint.yaml`.
+Allowlist: `ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `registry.access.redhat.com`,
+`registry.k8s.io`, `192.168.1.102`, `localhost`.
+Exception: `docker.io/rocm/k8s-device-plugin` — annotate `# registry-lint-ignore`.
+**Rule:** upstream k8s/CNCF registries (`registry.k8s.io`, `quay.io`) always preferred over
+distro-specific replacements when an upstream image exists.
 
 | Tag (image-tag / disk dir) | Image | Golden disk on ghost | Nightly |
 |---|---|---|---|
@@ -268,7 +281,7 @@ Loki captures workflow pod logs. Use the commands in [docs/agent-cheatsheet.md](
 | bluefin-lts-test | lts variant test VMs |
 | flatcar-test | Flatcar test VMs |
 | llm-d | LLM inference hive node (Qwen3.6-35B-A3B Q4_K_M GGUF via llama.cpp on ROCm) |
-| local-registry | OCI registry: BIB push target (port 30500), Zot pull-through caches — zot-ghcr (30501), zot-docker (30502) |
+| local-registry | OCI registry: writable Zot (port 30500), pull-through caches — zot-ghcr (30501), zot-docker (30502), zot-quay (30503), zot-fedora (30504), zot-redhat-access (30505), zot-k8s (30506) |
 | arc-systems | ARC controller + listener pods |
 | arc-runners | ARC ephemeral runner pods — **empty when no jobs queued; that is correct** |
 | mcp | Kubernetes MCP server |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Every pipeline (Bluefin, Bluefin-LTS, Dakota, Knuckle) provisions a fresh VM on 
 |---|---|---|---|
 | ghost | k3s control-plane + KubeVirt compute | 192.168.1.102 | Ryzen AI MAX+ 395, 16c/32t, 64GB RAM |
 | exo-1 | k3s worker (workflow pods only) | 192.168.1.239 | — |
+| bazzite | k3s worker (on demand) | 192.168.1.223 | Gaming machine — taint `node-role.kubernetes.io/gaming:NoSchedule`; k3s disabled at boot |
 | Argo UI | — | http://192.168.1.102:32746 | NodePort; also http://192.168.1.102:2746 on host |
 | Loki | log aggregation | http://192.168.1.102:30100 | Scrapes pods labeled `app.kubernetes.io/part-of=bluefin-test-suite` |
 | ArgoCD | GitOps controller | https://192.168.1.102 (argocd NS) | Two Applications: `testing-lab` + `testing-lab-infra` |
@@ -178,7 +179,40 @@ SECURITY.md                      Accepted homelab trade-offs and risks
 Justfile                         Repo-owner convenience wrappers (require kubectl/argo access; agents use MCP)
 ```
 
-## Image Variants
+## ARC Runners (GitHub Actions on ghost)
+
+Self-hosted GitHub Actions runners via Actions Runner Controller (ARC).
+
+| Resource | Value |
+|---|---|
+| Runner label | `ghost-runners` |
+| GitHub config URL | `https://github.com/projectbluefin` |
+| Min runners | 0 (idle — `arc-runners` namespace empty when no jobs; correct) |
+| Max runners | 4 |
+| GitHub App | `bluefin-ghost-arc` (ID 4099840, Installation 141458121) |
+| Credentials secret | `arc-github-secret` in `arc-runners` namespace |
+| ArgoCD Applications | `argocd/arc-controller-app.yaml`, `argocd/arc-runners-app.yaml` |
+
+**Use in a workflow:** `runs-on: ghost-runners`
+
+**Never replace the GitHub App credentials with a PAT.**
+
+If the listener is missing from `arc-systems`: check controller logs. Most likely cause
+is the controller landing on bazzite (broken DNS). Delete the controller pod — it
+reschedules to ghost.
+
+## Zot Registry Cache
+
+Pull-through OCI cache for container images. Transparent to all pods on ghost via
+containerd `hosts.toml` (written by `registry-mirror-config` DaemonSet — no k3s restart needed).
+
+| Instance | Upstream | NodePort | Storage |
+|---|---|---|---|
+| `zot-ghcr` | `https://ghcr.io` | 30501 | `/var/mnt/ghost-data/zot-ghcr` |
+| `zot-docker` | `https://registry-1.docker.io` | 30502 | `/var/mnt/ghost-data/zot-docker` |
+
+Both instances are pinned to ghost (hostPath storage requirement) and managed by
+ArgoCD `testing-lab-infra` via `manifests/zot-cache.yaml`.
 
 | Tag (image-tag / disk dir) | Image | Golden disk on ghost | Nightly |
 |---|---|---|---|
@@ -234,6 +268,9 @@ Loki captures workflow pod logs. Use the commands in [docs/agent-cheatsheet.md](
 | bluefin-lts-test | lts variant test VMs |
 | flatcar-test | Flatcar test VMs |
 | llm-d | LLM inference hive node (Qwen3.6-35B-A3B Q4_K_M GGUF via llama.cpp on ROCm) |
+| local-registry | OCI registry: BIB push target (port 30500), Zot pull-through caches — zot-ghcr (30501), zot-docker (30502) |
+| arc-systems | ARC controller + listener pods |
+| arc-runners | ARC ephemeral runner pods — **empty when no jobs queued; that is correct** |
 | mcp | Kubernetes MCP server |
 
 **Never delete VMs or resources in namespaces outside this list.**

--- a/argo/workflow-templates/bib-build-and-push.yaml
+++ b/argo/workflow-templates/bib-build-and-push.yaml
@@ -128,7 +128,7 @@ spec:
           fi
 
           SKOPEO_TLS_ARGS=()
-          if [[ "${IMAGE_REF}" == 192.168.1.102:5000/* ]]; then
+          if [[ "${IMAGE_REF}" == 192.168.1.102:30500/* ]]; then
             SKOPEO_TLS_ARGS+=(--tls-verify=false)
           fi
           # Retry with exponential backoff — GHCR rate-limits anonymous skopeo
@@ -192,7 +192,7 @@ spec:
             set -euo pipefail
             IMAGE="{{inputs.parameters.image}}"
             PULL_ARGS=()
-            if [[ "${IMAGE}" == 192.168.1.102:5000/* ]]; then
+            if [[ "${IMAGE}" == 192.168.1.102:30500/* ]]; then
               PULL_ARGS+=(--tls-verify=false)
             fi
             podman pull "${PULL_ARGS[@]}" "${IMAGE}"

--- a/argo/workflow-templates/bib-build-and-push.yaml
+++ b/argo/workflow-templates/bib-build-and-push.yaml
@@ -50,6 +50,8 @@ spec:
               parameters:
                 - name: image
                   value: "{{inputs.parameters.image}}"
+                - name: image-tag
+                  value: "{{inputs.parameters.image-tag}}"
 
           - name: build
             depends: "pull-image.Succeeded"
@@ -92,9 +94,10 @@ spec:
             path: "{{inputs.parameters.golden-root}}"
             type: DirectoryOrCreate
       script:
-        # podman/stable already cached on ghost for bib-img-pull; ships skopeo
-        # so we avoid a per-run `dnf install` from a Fedora mirror.
-        image: quay.io/podman/stable:latest
+        # quay.io/skopeo/stable ships skopeo. quay.io/podman/stable was used
+        # previously but dropped skopeo from its image; using it caused silent
+        # command-not-found failures that always returned "stale" (testing-lab#222).
+        image: quay.io/skopeo/stable:latest
         command: [bash]
         resources:
           requests:
@@ -165,6 +168,7 @@ spec:
       inputs:
         parameters:
           - name: image
+          - name: image-tag
       nodeSelector:
         kubernetes.io/hostname: ghost
       volumes:
@@ -191,6 +195,12 @@ spec:
           - |
             set -euo pipefail
             IMAGE="{{inputs.parameters.image}}"
+            TAG="{{inputs.parameters.image-tag}}"
+            # Append tag if image ref has none (e.g. ghcr.io/projectbluefin/bluefin).
+            # `*:*` distinguishes a tag from a host:port/ prefix.
+            if [[ "${IMAGE}" != *:* ]]; then
+              IMAGE="${IMAGE}:${TAG}"
+            fi
             PULL_ARGS=()
             if [[ "${IMAGE}" == 192.168.1.102:30500/* ]]; then
               PULL_ARGS+=(--tls-verify=false)

--- a/argo/workflow-templates/bib-build-and-push.yaml
+++ b/argo/workflow-templates/bib-build-and-push.yaml
@@ -131,9 +131,17 @@ spec:
           if [[ "${IMAGE_REF}" == 192.168.1.102:5000/* ]]; then
             SKOPEO_TLS_ARGS+=(--tls-verify=false)
           fi
-          REMOTE=$(skopeo inspect "${SKOPEO_TLS_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE_REF}" 2>/dev/null || true)
+          # Retry with exponential backoff — GHCR rate-limits anonymous skopeo
+          # inspects, returning empty output that is misread as stale (testing-lab#222).
+          REMOTE=""
+          for _attempt in 1 2 3; do
+            REMOTE=$(skopeo inspect "${SKOPEO_TLS_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE_REF}" 2>/dev/null || true)
+            [[ -n "${REMOTE}" ]] && break
+            echo "skopeo inspect attempt ${_attempt}/3 failed for ${IMAGE_REF}; retrying in $(( _attempt * 15 ))s..." >&2
+            sleep $(( _attempt * 15 ))
+          done
           if [[ -z "${REMOTE}" ]]; then
-            echo "skopeo inspect failed for ${IMAGE_REF}; treating as stale to force rebuild" >&2
+            echo "skopeo inspect failed after 3 attempts for ${IMAGE_REF}; treating as stale to force rebuild" >&2
             echo -n "stale"
             exit 0
           fi
@@ -241,6 +249,19 @@ spec:
             if [[ -f "${OUT}/image/disk.raw" ]]; then
               echo "disk.raw already exists at ${OUT}/image/disk.raw, skipping BIB build"
               exit 0
+            fi
+            # Preflight: report PCRE2 version for diagnostics (testing-lab#220).
+            # bluefin-lts and dakota require setfiles PCRE2 >= 10.46 (2025-08-27).
+            # centos-stream9 bootc-image-builder ships 10.44 — org.osbuild.selinux will
+            # fail for those images. Fix: update this image to one with PCRE2 >= 10.46.
+            PCRE2_PKG=$(rpm -q --queryformat '%{VERSION}' pcre2 2>/dev/null || echo "unknown")
+            echo "PCRE2 in BIB container: ${PCRE2_PKG}" >&2
+            if [[ "${PCRE2_PKG}" != "unknown" ]]; then
+              PCRE2_MAJ=${PCRE2_PKG%%.*}; PCRE2_MIN=${PCRE2_PKG#*.}; PCRE2_MIN=${PCRE2_MIN%%.*}
+              if (( PCRE2_MAJ < 10 || (PCRE2_MAJ == 10 && PCRE2_MIN < 46) )); then
+                echo "WARNING: PCRE2 ${PCRE2_PKG} < 10.46 in this BIB container." >&2
+                echo "  org.osbuild.selinux will fail for bluefin-lts/dakota. See testing-lab#220." >&2
+              fi
             fi
             # Request 40GB minimum root filesystem so bootc unified-storage
             # can pull a second copy (~5GB) alongside the live OS (~7GB).

--- a/argo/workflow-templates/bluefin-migration-test.yaml
+++ b/argo/workflow-templates/bluefin-migration-test.yaml
@@ -31,9 +31,10 @@ spec:
         value: "ghcr.io/ublue-os/bluefin"
       - name: chunkah-image
         value: "ghcr.io/projectbluefin/bluefin"
-      # Separate tag — projectbluefin only publishes :latest currently; update when more tags land
+      # Separate tag — projectbluefin publishes :stable (bluefin) and :lts (bluefin-lts).
+      # :latest does not exist on any projectbluefin image. See testing-lab#221.
       - name: chunkah-image-tag
-        value: "latest"
+        value: "stable"
       - name: storage-variant
         value: "default"
       - name: golden-root
@@ -107,7 +108,7 @@ spec:
           - name: chunkah-image
             value: "ghcr.io/projectbluefin/bluefin"
           - name: chunkah-image-tag
-            value: "latest"
+            value: "stable"
           - name: storage-variant
             value: "default"
           - name: evidence-root
@@ -525,10 +526,10 @@ spec:
               "-o", "LogLevel=ERROR",
           ]
 
-          def run_remote(command: str) -> subprocess.CompletedProcess:
-              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True)
+          def run_remote(command: str, timeout: int = 60) -> subprocess.CompletedProcess:
+              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True, timeout=timeout)
 
-          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True)
+          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True, timeout=30)
 
           if storage_variant == "experimental-unified-storage":
               command = "sudo bootc image set-unified"
@@ -568,10 +569,10 @@ spec:
 
           step_file = pathlib.Path(f"{step}.json")
           step_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True)
+          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True, timeout=120)
 
           aggregate_file = pathlib.Path("migration-evidence.json")
-          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True)
+          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True, timeout=60)
           aggregate = []
           if fetch.returncode == 0:
               try:
@@ -583,7 +584,7 @@ spec:
           aggregate = [item for item in aggregate if not (isinstance(item, dict) and item.get("step") == step)]
           aggregate.append(payload)
           aggregate_file.write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True)
+          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True, timeout=120)
 
           print(f"=== {step} ({storage_variant}) ({vm_ip}) ===")
           print(json.dumps(payload, indent=2))
@@ -678,8 +679,8 @@ spec:
               "-o", "LogLevel=ERROR",
           ]
 
-          def run_remote(command: str) -> subprocess.CompletedProcess:
-              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True)
+          def run_remote(command: str, timeout: int = 60) -> subprocess.CompletedProcess:
+              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True, timeout=timeout)
 
           def parse_json(text: str):
               try:
@@ -687,7 +688,7 @@ spec:
               except json.JSONDecodeError:
                   return None
 
-          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True)
+          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True, timeout=30)
 
           flags = ["--enforce-container-sigpolicy"]
           if storage_variant == "experimental-unified-storage":
@@ -723,10 +724,10 @@ spec:
 
           step_file = pathlib.Path(f"{step}.json")
           step_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True)
+          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True, timeout=120)
 
           aggregate_file = pathlib.Path("migration-evidence.json")
-          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True)
+          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True, timeout=60)
           aggregate = []
           if fetch.returncode == 0:
               try:
@@ -738,7 +739,7 @@ spec:
           aggregate = [item for item in aggregate if not (isinstance(item, dict) and item.get("step") == step)]
           aggregate.append(payload)
           aggregate_file.write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True)
+          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True, timeout=120)
 
           print(f"=== {step} ({storage_variant}) ({vm_ip}) ===")
           if payload["stdout"]:
@@ -909,8 +910,8 @@ spec:
               "-o", "LogLevel=ERROR",
           ]
 
-          def run_remote(command: str) -> subprocess.CompletedProcess:
-              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True)
+          def run_remote(command: str, timeout: int = 60) -> subprocess.CompletedProcess:
+              return subprocess.run(ssh_base + ["bash", "-lc", command], text=True, capture_output=True, timeout=timeout)
 
           def capture(command: str):
               result = run_remote(command)
@@ -950,7 +951,7 @@ spec:
                       return candidate
               return ""
 
-          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True)
+          subprocess.run(ssh_base + ["mkdir", "-p", output_root], check=True, text=True, timeout=30)
 
           results = {
               "bootc_status_json": capture("sudo bootc status --json"),
@@ -1029,10 +1030,10 @@ spec:
 
           step_file = pathlib.Path(f"{step}.json")
           step_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True)
+          subprocess.run(scp_base + [str(step_file), f"{vm_user}@{vm_ip}:{output_root}/{step}.json"], check=True, text=True, timeout=120)
 
           aggregate_file = pathlib.Path("migration-evidence.json")
-          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True)
+          fetch = subprocess.run(scp_base + [f"{vm_user}@{vm_ip}:{aggregate_path}", str(aggregate_file)], text=True, capture_output=True, timeout=60)
           aggregate = []
           if fetch.returncode == 0:
               try:
@@ -1044,7 +1045,7 @@ spec:
           aggregate = [item for item in aggregate if not (isinstance(item, dict) and item.get("step") == step)]
           aggregate.append(payload)
           aggregate_file.write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
-          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True)
+          subprocess.run(scp_base + [str(aggregate_file), f"{vm_user}@{vm_ip}:{aggregate_path}"], check=True, text=True, timeout=120)
 
           print(f"=== {step} evidence ({storage_variant}) ({vm_ip}) ===")
           print(json.dumps(payload, indent=2))
@@ -1126,7 +1127,7 @@ spec:
               f"{vm_user}@{vm_ip}",
           ]
 
-          result = subprocess.run(ssh_base + ["cat", f"{output_root}/{step}.json"], text=True, capture_output=True)
+          result = subprocess.run(ssh_base + ["cat", f"{output_root}/{step}.json"], text=True, capture_output=True, timeout=15)
           if result.returncode != 0:
               print(result.stderr.rstrip(), file=sys.stderr)
               sys.exit(result.returncode)

--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -128,6 +128,28 @@ spec:
                 - name: branch
                   value: "{{workflow.parameters.branch}}"
 
+              # 3d. Phase 4 — atomic OS contract tests (no Wayland session needed)
+          # Runs after all GUI suites to avoid bootc reboot colliding with live Wayland session.
+          # run-gnome-tests handles suite=system natively (behave only, no qecore-headless).
+          - name: run-system
+            depends: "(run-software.Succeeded || run-software.Skipped)"
+            when: "'{{workflow.parameters.suites}}' =~ 'system'"
+            templateRef:
+              name: run-gnome-tests
+              template: run-gnome-tests
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{tasks.provision.outputs.parameters.vm-ip}}"
+                - name: suite
+                  value: "system"
+                - name: variant
+                  value: "{{workflow.parameters.variant}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
     # ── onExit handler: stop VM → wait VMI gone → delete hostDisk ──────────────
     - name: teardown
       dag:

--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -12,7 +12,8 @@ spec:
   entrypoint: pipeline
 
   # ── cleanup VM + hostDisk on any exit (success, failure, timeout) ──────────
-  onExit: teardown
+  # Also posts GitHub commit status when sha/repo params are supplied (PR runs).
+  onExit: cleanup-and-report
 
   # ── parameters ──────────────────────────────────────────────────────────────
   arguments:
@@ -35,6 +36,14 @@ spec:
       # override to test a PR branch end-to-end without merging.
       - name: branch
         value: "main"
+      # Optional: supplied by ARC runner on PR runs; empty on nightly CronWorkflow runs.
+      # When sha is non-empty, the onExit handler posts a GitHub commit status.
+      - name: pr-number
+        value: ""
+      - name: sha
+        value: ""
+      - name: repo
+        value: ""
 
   # ── pipeline DAG ─────────────────────────────────────────────────────────────
   templates:
@@ -150,7 +159,47 @@ spec:
                 - name: branch
                   value: "{{workflow.parameters.branch}}"
 
-    # ── onExit handler: stop VM → wait VMI gone → delete hostDisk ──────────────
+    # ── onExit handler: teardown + optional GitHub commit status ──────────────
+    # cleanup-and-report calls teardown unconditionally, then posts GitHub commit
+    # status when sha is non-empty (PR runs). Nightly runs leave sha empty → skip.
+    - name: cleanup-and-report
+      dag:
+        tasks:
+          - name: teardown
+            template: teardown
+          - name: post-status
+            template: post-github-status
+            when: "'{{workflow.parameters.sha}}' != ''"
+
+    # ── post-github-status: posts commit status to GitHub API ──────────────────
+    - name: post-github-status
+      script:
+        image: quay.io/fedora/fedora:latest
+        command: [bash]
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+        source: |
+          STATE=$([ "{{workflow.status}}" = "Succeeded" ] && echo success || echo failure)
+          PAYLOAD=$(jq -n \
+            --arg state "$STATE" \
+            --arg ctx  "ghost-lab" \
+            --arg desc "Bluefin lab test $STATE" \
+            --arg url  "http://192.168.1.102:32746/workflows/argo/{{workflow.name}}" \
+            '{state:$state,context:$ctx,description:$desc,target_url:$url}')
+          curl -sf -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            "https://api.github.com/repos/{{workflow.parameters.repo}}/statuses/{{workflow.parameters.sha}}" \
+            -d "$PAYLOAD" \
+          && echo "Posted $STATE to {{workflow.parameters.repo}}@{{workflow.parameters.sha}}" \
+          || echo "WARNING: failed to post commit status (non-fatal)"
+
+    # ── teardown: stop VM → wait VMI gone → delete hostDisk ──────────────────
     - name: teardown
       dag:
         tasks:

--- a/argo/workflow-templates/collect-vm-logs.yaml
+++ b/argo/workflow-templates/collect-vm-logs.yaml
@@ -66,7 +66,7 @@ spec:
         secretName: "{{inputs.parameters.ssh-key-secret}}"
         defaultMode: 0400
     container:
-      image: fedora:41
+      image: registry.fedoraproject.org/fedora:41
       command: [bash, -c]
       args:
       - |

--- a/argo/workflow-templates/dakota-iso-pr-test.yaml
+++ b/argo/workflow-templates/dakota-iso-pr-test.yaml
@@ -232,7 +232,7 @@ spec:
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash]
         resources:
           requests:

--- a/argo/workflow-templates/dakota-qa-pipeline.yaml
+++ b/argo/workflow-templates/dakota-qa-pipeline.yaml
@@ -11,7 +11,7 @@ metadata:
       Flow:
         1. bst-validate      — fast element graph check (no build)
         2. bst-build-export-push — BST build, export to containers-storage,
-                               push to 192.168.1.102:5000/dakota:<tag>
+                               push to 192.168.1.102:30500/dakota:<tag>
         3. ensure-disk       — BIB builds a raw disk.raw from the zot image
                                (skipped if golden disk is fresh)
         4. provision         — btrfs reflink clone + KubeVirt VM boot

--- a/argo/workflow-templates/homelab-access-probe.yaml
+++ b/argo/workflow-templates/homelab-access-probe.yaml
@@ -136,7 +136,7 @@ spec:
           - name: namespace
           - name: auth-mode
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail
@@ -212,7 +212,7 @@ spec:
               spec:
                 containers:
                   - name: access
-                    image: python:3.12-slim
+                    image: registry.access.redhat.com/hi/python:3.12
                     command: ["python", "/app/server.py"]
                     ports:
                       - containerPort: 8443
@@ -263,7 +263,7 @@ spec:
 
     - name: cleanup
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail

--- a/argo/workflow-templates/homelab-restore-drill.yaml
+++ b/argo/workflow-templates/homelab-restore-drill.yaml
@@ -79,7 +79,7 @@ spec:
         parameters:
           - name: namespace
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail
@@ -141,7 +141,7 @@ spec:
 
     - name: cleanup
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail

--- a/argo/workflow-templates/homelab-storage.yaml
+++ b/argo/workflow-templates/homelab-storage.yaml
@@ -71,7 +71,7 @@ spec:
         parameters:
           - name: namespace
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail
@@ -134,7 +134,7 @@ spec:
 
     - name: cleanup
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail

--- a/argo/workflow-templates/homelab-substrate.yaml
+++ b/argo/workflow-templates/homelab-substrate.yaml
@@ -76,7 +76,7 @@ spec:
           - name: namespace
           - name: lane
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail
@@ -106,7 +106,7 @@ spec:
               spec:
                 containers:
                   - name: nginx
-                    image: docker.io/library/nginx:1.27.5-alpine
+                    image: registry.access.redhat.com/hi/nginx:1.30.0
                     ports:
                       - containerPort: 80
           ---
@@ -130,7 +130,7 @@ spec:
 
     - name: cleanup
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash, -c]
         source: |
           set -euo pipefail

--- a/argo/workflow-templates/knuckle-qa-pipeline.yaml
+++ b/argo/workflow-templates/knuckle-qa-pipeline.yaml
@@ -784,7 +784,7 @@ spec:
             path: /var/tmp/knuckle-test
             type: DirectoryOrCreate
       script:
-        image: cgr.dev/chainguard/bash:latest
+        image: registry.access.redhat.com/ubi9/ubi-minimal:9.5
         command: [bash]
         securityContext:
           runAsUser: 0

--- a/argo/workflow-templates/provision-bluefin-vm.yaml
+++ b/argo/workflow-templates/provision-bluefin-vm.yaml
@@ -205,7 +205,7 @@ spec:
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command:
           - bash
         resources:

--- a/argo/workflow-templates/provision-flatcar-vm.yaml
+++ b/argo/workflow-templates/provision-flatcar-vm.yaml
@@ -193,7 +193,7 @@ spec:
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: registry.k8s.io/kubectl:v1.32.0
         command: [bash]
         resources:
           requests:

--- a/argo/workflow-templates/teardown-bluefin-vm.yaml
+++ b/argo/workflow-templates/teardown-bluefin-vm.yaml
@@ -60,7 +60,7 @@ spec:
           hostPath:
             path: "{{inputs.parameters.test-root}}"
       script:
-        image: cgr.dev/chainguard/bash:latest
+        image: registry.access.redhat.com/ubi9/ubi-minimal:9.5
         securityContext:
           runAsUser: 0
         command: [bash]

--- a/argo/workflow-templates/teardown-flatcar-vm.yaml
+++ b/argo/workflow-templates/teardown-flatcar-vm.yaml
@@ -60,7 +60,7 @@ spec:
           hostPath:
             path: "{{inputs.parameters.test-root}}"
       script:
-        image: cgr.dev/chainguard/bash:latest
+        image: registry.access.redhat.com/ubi9/ubi-minimal:9.5
         securityContext:
           runAsUser: 0
         command: [bash]

--- a/argocd/arc-controller-app.yaml
+++ b/argocd/arc-controller-app.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-systems
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/actions/actions-runner-controller-charts
+    chart: gha-runner-scale-set-controller
+    targetRevision: 0.9.3
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-systems
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/arc-runners-app.yaml
+++ b/argocd/arc-runners-app.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/actions/actions-runner-controller-charts
+    chart: gha-runner-scale-set
+    targetRevision: 0.9.3
+    helm:
+      values: |
+        githubConfigUrl: "https://github.com/projectbluefin"
+        githubConfigSecret: arc-github-secret
+        runnerScaleSetName: ghost-runners
+        minRunners: 0
+        maxRunners: 4
+        controllerServiceAccount:
+          namespace: arc-systems
+          name: arc-systems-gha-rs-controller
+        containerMode:
+          type: kubernetes
+          kubernetesModeWorkVolumeClaim:
+            accessModes: ["ReadWriteOnce"]
+            storageClassName: local-path
+            resources:
+              requests:
+                storage: 10Gi
+        template:
+          spec:
+            containers:
+              - name: runner
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: 4Gi
+                  limits:
+                    cpu: "8"
+                    memory: 16Gi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/arc-runners-app.yaml
+++ b/argocd/arc-runners-app.yaml
@@ -23,6 +23,12 @@ spec:
           name: arc-systems-gha-rs-controller
         template:
           spec:
+            nodeSelector:
+              node-location: lan
+            tolerations:
+              - key: node-role.kubernetes.io/gaming
+                operator: Exists
+                effect: NoSchedule
             containers:
               - name: runner
                 image: ghcr.io/actions/actions-runner:latest

--- a/argocd/arc-runners-app.yaml
+++ b/argocd/arc-runners-app.yaml
@@ -33,6 +33,7 @@ spec:
           spec:
             containers:
               - name: runner
+                image: ghcr.io/actions/actions-runner:latest
                 resources:
                   requests:
                     cpu: "2"

--- a/argocd/arc-runners-app.yaml
+++ b/argocd/arc-runners-app.yaml
@@ -29,6 +29,12 @@ spec:
               - key: node-role.kubernetes.io/gaming
                 operator: Exists
                 effect: NoSchedule
+            volumes:
+              - name: buildah-cache
+                hostPath:
+                  # ponytail: per-node cache; persists across jobs; Zot deduplicates cross-node
+                  path: /var/tmp/arc-buildah-cache
+                  type: DirectoryOrCreate
             containers:
               - name: runner
                 image: ghcr.io/actions/actions-runner:latest
@@ -40,6 +46,9 @@ spec:
                   limits:
                     cpu: "8"
                     memory: 16Gi
+                volumeMounts:
+                  - name: buildah-cache
+                    mountPath: /home/runner/.local/share/containers/storage
   destination:
     server: https://kubernetes.default.svc
     namespace: arc-runners

--- a/argocd/arc-runners-app.yaml
+++ b/argocd/arc-runners-app.yaml
@@ -21,19 +21,12 @@ spec:
         controllerServiceAccount:
           namespace: arc-systems
           name: arc-systems-gha-rs-controller
-        containerMode:
-          type: kubernetes
-          kubernetesModeWorkVolumeClaim:
-            accessModes: ["ReadWriteOnce"]
-            storageClassName: local-path
-            resources:
-              requests:
-                storage: 10Gi
         template:
           spec:
             containers:
               - name: runner
                 image: ghcr.io/actions/actions-runner:latest
+                command: ["/home/runner/run.sh"]
                 resources:
                   requests:
                     cpu: "2"

--- a/argocd/arc-runners-app.yaml
+++ b/argocd/arc-runners-app.yaml
@@ -17,7 +17,7 @@ spec:
         githubConfigSecret: arc-github-secret
         runnerScaleSetName: ghost-runners
         minRunners: 0
-        maxRunners: 4
+        maxRunners: 6
         controllerServiceAccount:
           namespace: arc-systems
           name: arc-systems-gha-rs-controller

--- a/docs/agent-cheatsheet.md
+++ b/docs/agent-cheatsheet.md
@@ -19,11 +19,12 @@
 
 | Situation | Run |
 |---|---|
-| Validate a smoke test or step change | `just run-tests-tag latest` |
+| Validate a smoke test or step change | `just run-tests-tag testing` |
 | Validate atomic OS contract checks | Use Argo MCP to submit `bluefin-qa-pipeline` with `suites=system` |
 | Validate developer or software suites | Use Argo MCP to submit `bluefin-qa-pipeline` with `suites=developer` or `suites=software` |
 | Pre-merge gate / promote a passing matrix run | `just run-tests-matrix` |
-| Validate a single Bluefin tag end-to-end | `just run-tests-tag <latest\|lts>` |
+| Validate a single Bluefin tag end-to-end | `just run-tests-tag <testing\|lts-testing>` |
+| Validate released (stable) image | `just run-tests-tag stable` or `just run-tests-tag lts-stable` |
 | Validate a golden-disk or image change | `just ensure-disk <tag>` then `just run-tests-tag <tag>` |
 | Validate the Flatcar lane | `just run-flatcar-smoke` |
 | Validate the dakota BST element graph (fast, no build) | `just run-dakota-validate` |
@@ -173,8 +174,8 @@ Backfill / run now:
 
 | Name | Schedule (UTC) | Purpose |
 |---|---|---|
-| `nightly-smoke` | 02:00 | `bluefin-qa-pipeline` (`latest`) |
-| `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` (`lts`) |
+| `nightly-smoke` | 02:00 | `bluefin-qa-pipeline` (`testing`) |
+| `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` (`lts-testing`) |
 | `orphan-vm-cleanup` | every 2h | Clean orphan test VMs |
 
 Any patch that must survive beyond a short debug session also needs a matching git change under `manifests/`.
@@ -198,12 +199,12 @@ kubectl create secret generic bluefin-test-ssh-key \
 shred -u "${ssh_key}" "${ssh_key}.pub"
 
 # 3. Patch every existing golden disk:
-just patch-disk latest
-just patch-disk lts
+just patch-disk testing
+just patch-disk lts-testing
 
 # 4. Confirm via real runs:
-just run-tests-tag latest
-just run-tests-tag lts
+just run-tests-tag testing
+just run-tests-tag lts-testing
 
 # 5. Verify the new fingerprint:
 kubectl get secret bluefin-test-ssh-key -n argo \
@@ -220,7 +221,7 @@ If `patch-disk` succeeds but fresh workflows still fail SSH, file an issue with 
 
 Mandatory gate for `knuckle`, `dakota`, and this repo's PRs.
 
-1. Run the lab loop end-to-end — `just run-tests-tag latest` minimum, `just run-tests-matrix` for high-risk changes.
+1. Run the lab loop end-to-end — `just run-tests-tag testing` minimum, `just run-tests-matrix` for high-risk changes.
 2. Collect **real evidence** using **MCP tools only** — not bash `argo`/`kubectl` commands:
    - Workflow status/steps → `argo-mcp-get_workflow` / `argo-mcp-list_workflows`
    - Log output → `argo-mcp-logs_workflow`
@@ -260,8 +261,8 @@ Use `kubernetes-mcp-resources_delete` with `apiVersion: kubevirt.io/v1`, `kind: 
 just setup-ssh-secret
 just setup-argocd
 just argocd-sync
-just ensure-disk latest
-just run-tests-tag latest
+just ensure-disk testing
+just run-tests-tag testing
 ```
 
 ---
@@ -273,7 +274,7 @@ just run-tests-tag latest
 2. argo-mcp-list_cron_workflows namespace=argo
 3. just list-vms
 4. just list-workflows
-5. just run-tests-tag latest
+5. just run-tests-tag testing
 ```
 
 Expected steady state:

--- a/docs/agent-cheatsheet.md
+++ b/docs/agent-cheatsheet.md
@@ -284,6 +284,45 @@ Expected steady state:
 
 ---
 
+## 13. ARC runners (GitHub Actions on ghost)
+
+ARC (Actions Runner Controller) provides self-hosted GitHub Actions runners.
+When no jobs are queued, `arc-runners` namespace is empty — that is correct.
+Runners are ephemeral and only exist while a job is running.
+
+**Check ARC is healthy:**
+```text
+kubernetes-mcp-pods_list namespace=arc-systems
+```
+Expected: `arc-systems-gha-rs-controller-*` Running + `ghost-runners-*-listener` Running.
+
+**Check a runner set is registered:**
+```text
+kubernetes-mcp-resources_list apiVersion=actions.github.com/v1alpha1 kind=AutoscalingRunnerSet namespace=arc-runners
+```
+Expected: `ghost-runners` with MINIMUM=0 MAXIMUM=4.
+
+**If listener is missing** (arc-systems has only the controller pod, no listener):
+1. Check controller logs: `kubernetes-mcp-pods_log namespace=arc-systems <controller-pod>`
+2. If error is `no route to host` / DNS failure: the controller landed on bazzite.
+   Delete the controller pod — it will reschedule to ghost where DNS works.
+3. If error is GitHub API auth failure: check `arc-github-secret` exists in `arc-runners`.
+
+**Trigger a workflow using ARC:**
+Add `runs-on: ghost-runners` to any projectbluefin workflow. A listener pod and
+ephemeral runner pod will appear in `arc-systems` and `arc-runners` respectively
+for the duration of the job.
+
+**ArgoCD Applications for ARC** (stored in `argocd/`, applied manually once):
+- `arc-systems` — controller (gha-runner-scale-set-controller 0.9.3)
+- `arc-runners` — scale set pointing at `https://github.com/projectbluefin`
+
+**GitHub App:** `bluefin-ghost-arc` (App ID 4099840, Installation 141458121)
+installed on the `projectbluefin` org. Credentials in `arc-github-secret`
+(namespace `arc-runners`) — never replace with a PAT.
+
+---
+
 ## 11. Discover live cluster facts — do not trust stale docs
 
 | Fact | Command |

--- a/docs/cluster-improvement-plan.md
+++ b/docs/cluster-improvement-plan.md
@@ -1,6 +1,6 @@
 # Cluster Improvement Plan
 
-_Generated from design review session, 2026-06-20_
+_Generated from design review session, 2026-06-20. Updated 2026-06-20 with rubber-duck findings._
 
 ## Context
 
@@ -45,7 +45,7 @@ Argo workflow (independent lifecycle):
 ## Phase 0 — Pre-flight bug fixes
 
 These are existing bugs found during the design review. Fix them before anything else —
-either one can cause silent test failures independent of the improvements below.
+any one can cause silent test failures independent of the improvements below.
 
 ### 0a — Unlock `golden-disk-gc` from dry-run mode
 
@@ -75,6 +75,29 @@ Keep the `dry-run` parameter so you can still pass `true` for a manual inspectio
 
 ### 0b — Audit and fix the `192.168.1.102:5000` registry references
 
+### 0c — Verify and document what is running on port 30500
+
+Phases 4, 5, and 6 all assume a writable, OCI-compliant Zot instance at
+`192.168.1.102:30500`. `AGENTS.md` documents port 30500 as the "BIB push target" but
+`manifests/zot-cache.yaml` only defines `zot-ghcr` (30501) and `zot-docker` (30502).
+There is no manifest for a 30500 instance in the repo. Before any work that pushes
+to 30500 (runner image, GGUF, PR images), this gap must be closed.
+
+**Investigate:**
+- Is there a writable Zot deployment on ghost running outside of GitOps control?
+- Or is port 30500 a plain Docker registry (not Zot)? If so, the `oras` commands
+  in Phases 4 and 6d and the Zot GC policy JSON in Phase 6d do not apply.
+- Run: `kubectl get svc -n local-registry` to see what is actually exposed on 30500.
+
+**Fix:** add a manifest for the writable registry to `manifests/zot-cache.yaml` (or a
+new `manifests/zot-writable.yaml`) so the state is GitOps-managed and documented,
+with the correct Zot config (no upstream sync block, GC enabled, writable).
+
+**Validation:**
+- `kubectl get svc -n local-registry` shows a service at 30500.
+- `oras push 192.168.1.102:30500/test:smoke <(echo test) --media-type text/plain`
+  succeeds and `oras pull` retrieves it.
+
 `bib-build-and-push.yaml` references `192.168.1.102:5000` in two detection checks
 (lines 131 and 195). AGENTS.md documents the BIB push target NodePort as `30500`,
 not `5000`. Port 5000 is Zot's container-internal port; it is reachable from pods
@@ -95,6 +118,11 @@ references `:5000`.
 - Submit `just run-tests-tag latest` and confirm the local-image-detection branch
   triggers correctly when a locally-pushed image is supplied.
 
+> **Note:** Resolve Phase 0c (writable registry identity) before closing this item.
+> If port 5000 is reachable from `hostNetwork: true` BIB pods and port 30500 is
+> the *same* Zot instance exposed as a NodePort, the fix is purely a normalisation.
+> If they are different services, the fix may require credential or policy changes.
+
 ---
 
 ## Phase 1 — Fill Zot coverage gaps
@@ -107,10 +135,12 @@ uncached paths in the cluster right now.
 
 | Registry | Uncached images | Action |
 |---|---|---|
-| `quay.io` | `kubevirt/virt-launcher`, BIB, podman, skopeo, fedora | Add `zot-quay` 🔥 |
+| `quay.io` | `kubevirt/virt-launcher`, BIB, podman, skopeo, `quay.io/fedora/fedora:latest` | Add `zot-quay` 🔥 |
 | `registry.fedoraproject.org` | `fedora:latest` | Add `zot-fedora` |
+| `registry.access.redhat.com` | All hummingbird + UBI9 images (Phase 2 target) | **Add `zot-redhat-access`** 🔥 |
+| `docker.io` (implicit) | `fedora:41` — bare reference, implicitly docker.io | Replace in Phase 2 |
 | `cgr.dev` | bash, kubectl | Eliminate via Phase 2 (hummingbird replaces these) |
-| `registry.k8s.io` | `kubectl:v1.32.0` | Eliminate via Phase 2 |
+| `registry.k8s.io` | `kubectl:v1.32.0` | Decision needed — see Phase 2 |
 
 ### Tasks
 
@@ -120,11 +150,18 @@ uncached paths in the cluster right now.
 2. **Add `zot-fedora` to `manifests/zot-cache.yaml`** — same pattern, upstream
    `https://registry.fedoraproject.org`, NodePort `30504`.
 
-3. **Update `manifests/registry-mirror-config.yaml`** — add `quay.io.hosts.toml` and
-   `registry.fedoraproject.org.hosts.toml` entries in the ConfigMap, pointing to
-   `http://192.168.1.102:30503` and `http://192.168.1.102:30504` respectively.
+3. **Add `zot-redhat-access` to `manifests/zot-cache.yaml`** — same pattern, upstream
+   `https://registry.access.redhat.com`, NodePort `30505`. This instance is required
+   by Phase 2: all hummingbird (`hi/*`) and UBI9 images live at this registry, not
+   at `ghcr.io`. Without this, Phase 2 replaces cached `cgr.dev` pulls with uncached
+   `registry.access.redhat.com` pulls.
 
-4. **Rollout restart** the `registry-mirror-config` DaemonSet so all nodes get the new
+4. **Update `manifests/registry-mirror-config.yaml`** — add `quay.io.hosts.toml`,
+   `registry.fedoraproject.org.hosts.toml`, and `registry.access.redhat.com.hosts.toml`
+   entries in the ConfigMap, pointing to `http://192.168.1.102:30503`,
+   `http://192.168.1.102:30504`, and `http://192.168.1.102:30505` respectively.
+
+5. **Rollout restart** the `registry-mirror-config` DaemonSet so all nodes get the new
    `hosts.toml` entries.
 
 ### Validation
@@ -132,51 +169,78 @@ uncached paths in the cluster right now.
 - Submit `just run-tests-tag latest` and confirm no `quay.io` pulls escape to the internet
   (check `zot-quay` pod logs for incoming requests).
 - Check `kubectl logs -n local-registry deploy/zot-quay` shows cache hits on subsequent runs.
+- Confirm `zot-redhat-access` pod logs show incoming requests on subsequent Phase 2 runs.
 
 ---
 
 ## Phase 2 — Hummingbird image migration
 
-**Why second:** Eliminates `cgr.dev` and `registry.k8s.io` from the image footprint entirely,
-simplifies the Zot inventory, and gives all workflow steps a consistent Red Hat toolchain.
-If hummingbird images are on `ghcr.io`, they are already cached via `zot-ghcr` for free.
+**Why second:** Eliminates `cgr.dev` from the image footprint, simplifies the Zot inventory,
+and gives workflow steps a consistent Red Hat toolchain.
+
+**Registry note:** Hummingbird images are at `registry.access.redhat.com/hi/` and UBI9
+images at `registry.access.redhat.com/ubi9/` — **not at `ghcr.io`**. Phase 1's
+`zot-redhat-access` (NodePort 30505) must be deployed first; only then are these images
+transparently cached at LAN speed.
 
 ### Images to replace
 
-| Current image | Replace with | Location |
+All replacement images verified at `registry.access.redhat.com` as of 2026-06-20.
+
+| Current image | Replace with | Notes |
 |---|---|---|
-| `cgr.dev/chainguard/bash:latest` | hummingbird bash / UBI9 minimal | workflow templates |
-| `cgr.dev/chainguard/kubectl:latest-dev` | hummingbird kubectl | `provision-bluefin-vm.yaml` |
-| `registry.k8s.io/kubectl:v1.32.0` | hummingbird kubectl | manifests |
-| `alpine:3.20` | hummingbird micro / UBI micro | workflow templates |
-| `docker.io/alpine:3` | hummingbird micro / UBI micro | manifests |
-| `busybox:latest` | hummingbird micro / UBI micro | `registry-mirror-config.yaml` (init container **and** pause loop) |
-| `python:3.12-slim` | hummingbird python / UBI9 python | workflow templates |
-| `docker.io/library/nginx:1.27.5-alpine` | hummingbird nginx / UBI9 nginx | manifests |
+| `cgr.dev/chainguard/bash:latest` | `registry.access.redhat.com/ubi9/ubi-minimal:9.5` | `hi/bash` does not exist; ubi-minimal includes bash |
+| `cgr.dev/chainguard/kubectl:latest-dev` | ⚠️ See decision below | `hi/kubectl` does not exist |
+| `registry.k8s.io/kubectl:v1.32.0` | ⚠️ See decision below | `hi/kubectl` does not exist |
+| `alpine:3.20` | `registry.access.redhat.com/ubi9/ubi-micro:9.5` | |
+| `docker.io/alpine:3` | `registry.access.redhat.com/ubi9/ubi-micro:9.5` | |
+| `fedora:41` | `registry.fedoraproject.org/fedora:41` | Bare ref missing from earlier audit; implicit `docker.io` |
+| `busybox:latest` | `registry.access.redhat.com/ubi9/ubi-micro:9.5` | `registry-mirror-config.yaml` init container **and** pause loop |
+| `python:3.12-slim` | `registry.access.redhat.com/hi/python:3.12` | |
+| `docker.io/library/nginx:1.27.5-alpine` | `registry.access.redhat.com/hi/nginx:1.30.0` | Version bump 1.27.5 → 1.30.0; verify nginx config compat |
+
+**kubectl decision required:** `hi/kubectl` does not exist at `registry.access.redhat.com`.
+Two options — pick one before starting Phase 2:
+
+- **Option A (keep):** Retain `registry.k8s.io/kubectl:v1.32.0` as-is and add
+  `registry.k8s.io` to the Phase 3 allowlist (annotate as kubectl-only). Zot does
+  not cache `registry.k8s.io`; add a `zot-k8s` pull-through cache in Phase 1 if
+  this option is chosen.
+- **Option B (replace):** Build a thin image in `images/kubectl/Containerfile`:
+  `FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5` + `curl -L dl.k8s.io/...`.
+  Push to `192.168.1.102:30500/kubectl:v1.32.0`. Fully eliminates `registry.k8s.io`
+  from the fleet.
 
 **Keep as-is** (no hummingbird equivalent):
-- `docker.io/rocm/k8s-device-plugin:1.31.0.10` — ROCm-specific; `zot-docker` is retained solely for this image after Phase 2
-- `quay.io/*` — BIB, podman, skopeo, kubevirt virt-launcher (now cached via Phase 1)
+- `docker.io/rocm/k8s-device-plugin:1.31.0.10` — ROCm-specific; `zot-docker` is
+  retained solely for this image after Phase 2
+- `quay.io/*` — BIB, podman, skopeo, kubevirt virt-launcher (cached via Phase 1)
 
 ### Tasks
 
-1. For each image in the table above, find the canonical hummingbird equivalent on `ghcr.io`
-   and update every YAML reference.
+1. **Resolve the kubectl decision** (Option A or B above) before touching any files.
 
-2. Run `just lint` after each file change to verify templates remain valid.
+2. For each image in the table above, update every YAML reference.
 
-3. After all replacements, confirm `grep -r 'cgr.dev\|registry.k8s.io' argo/ manifests/`
-   returns empty.
+3. Run `just lint` after each file change to verify templates remain valid.
 
-4. **`registry-mirror-config.yaml` specifically** — replace both the init container
+4. After all replacements, confirm:
+   ```bash
+   grep -r 'cgr.dev' argo/ manifests/
+   ```
+   returns empty (and `registry.k8s.io` is empty if Option B was chosen).
+
+5. **`registry-mirror-config.yaml` specifically** — replace both the init container
    (`busybox:latest` writing the `hosts.toml` files) and the pause loop container
-   (`busybox:latest` kept alive to preserve the DaemonSet) with the hummingbird micro
-   equivalent. The pause loop has a `# ponytail:` comment explaining its purpose; preserve it.
+   (`busybox:latest` kept alive to preserve the DaemonSet) with
+   `registry.access.redhat.com/ubi9/ubi-micro:9.5`. The pause loop has a
+   `# ponytail:` comment explaining its purpose; preserve it.
 
 ### Validation
 
 - `just lint` passes cleanly.
-- `grep -r 'cgr.dev\|registry.k8s.io\|alpine:\|busybox:\|python:3.12-slim' argo/ manifests/` — empty.
+- `grep -r 'cgr.dev\|alpine:\|busybox:\|python:3.12-slim\|fedora:41' argo/ manifests/` — empty.
+- `grep -r 'registry.k8s.io' argo/ manifests/` — empty if Option B was chosen.
 - Submit a smoke test run and confirm no new registry errors.
 
 ---
@@ -185,6 +249,11 @@ If hummingbird images are on `ghcr.io`, they are already cached via `zot-ghcr` f
 
 **Why after Phase 2:** The lint gate enforces the clean post-migration state. Adding it before
 Phase 2 is complete would fail on every current PR.
+
+> **Sequencing note:** Phases 2 and 3 must land in the same PR (or Phase 3 must be
+> merged in the same commit as the final Phase 2 change). Merging Phase 3 before all
+> Phase 2 replacements are complete will cause CI to fail on every open PR until Phase 2
+> is finished.
 
 ### Tasks
 
@@ -196,9 +265,17 @@ Phase 2 is complete would fail on every current PR.
      ghcr.io
      quay.io
      registry.fedoraproject.org
+     registry.access.redhat.com
      192.168.1.102
      localhost
+     # docker.io — intentionally absent after Phase 2, except ROCm device plugin:
+     # docker.io/rocm/k8s-device-plugin is exempted via per-line ignore comment
      ```
+   - If Option A (keep kubectl) was chosen: also allowlist `registry.k8s.io` and
+     add a comment noting it is kubectl-only.
+   - Add a per-line escape hatch (e.g., `# registry-lint-ignore`) for the
+     `docker.io/rocm/k8s-device-plugin` line in `rocm-device-plugin.yaml` — this
+     image has no Red Hat equivalent and must remain.
    - Prints the offending image and file on failure.
 
 2. Keep the check fast — a single shell `grep + awk` pipeline is sufficient; no external tools.
@@ -206,7 +283,9 @@ Phase 2 is complete would fail on every current PR.
 ### Validation
 
 - PR that adds `alpine:3.20` triggers a lint failure.
-- PR that adds `ghcr.io/some/hummingbird:latest` passes.
+- PR that adds `registry.access.redhat.com/hi/nginx:1.30.0` passes.
+- The `rocm-device-plugin.yaml` `docker.io` reference does **not** trigger a failure.
+- PR that adds `cgr.dev/chainguard/bash:latest` triggers a lint failure.
 
 ---
 
@@ -220,12 +299,17 @@ Floating llm-d frees ghost's 48 GB RAM for the full 7-VM concurrent test capacit
 > but the manifest is already correct for when a second node arrives. No changes needed
 > for single-node adoption.
 
+> **Prerequisite:** Phase 0c must be complete before starting Phase 4. Port 30500's
+> identity and writeability must be verified and documented in GitOps before any
+> `oras push` commands are attempted here.
+
 ### Pre-check: verify Zot port 30500 accepts OCI artifacts
 
 Port 30500 was originally configured as a BIB push target for container image blobs. Before
-pushing a raw GGUF, verify the Zot config in `manifests/zot-cache.yaml` has no `mediaType`
-filter that rejects `application/octet-stream`. If it does, relax the content policy or add
-a separate Zot instance for model artifacts.
+pushing a raw GGUF, verify the Zot config in `manifests/zot-cache.yaml` (or wherever
+30500 is managed after Phase 0c) has no `mediaType` filter that rejects
+`application/octet-stream`. If it does, relax the content policy or add a separate
+Zot instance for model artifacts.
 
 ### Tasks
 
@@ -340,6 +424,9 @@ and the bib-build-and-push fix.
 
 ### 6a — Fix `bib-build-and-push.yaml` local image source
 
+> **Note:** Phase 0c (writable registry identity) must be resolved before 6a.
+> Assume `192.168.1.102:30500` is writable Zot throughout sections 6a–6d.
+
 The `ensure-disk` template already accepts an `image` parameter. Verify it passes through
 correctly to `bib-img-pull` and `bib-img-build` when given a local Zot URI
 (`192.168.1.102:30500/bluefin-pr-NNN:sha`). Fix any hardcoded `ghcr.io` references inside
@@ -363,7 +450,10 @@ without touching the internet — no special casing needed as long as Zot is rea
    The token needs `statuses:write` and `pull_requests:read` scope (or the equivalent
    GitHub App permissions).
 
-2. Add an `onExit` template to `bluefin-qa-pipeline.yaml` that posts a GitHub commit status:
+2. Add an `onExit` template to `bluefin-qa-pipeline.yaml` that posts a GitHub commit status.
+   Use `jq -n` to build the JSON payload — do not manually escape quotes inside a bash
+   double-quoted string, as `{{inputs.parameters.repo}}` contains a forward slash that
+   becomes ambiguous in complex quoting contexts:
    ```yaml
    onExit: post-github-status
    templates:
@@ -377,19 +467,24 @@ without touching the internet — no special casing needed as long as Zot is rea
          image: 192.168.1.102:30500/arc-runner:latest
          source: |
            STATE=$([ "{{workflow.status}}" = "Succeeded" ] && echo success || echo failure)
-           curl -s -X POST \
+           PAYLOAD=$(jq -n \
+             --arg state "$STATE" \
+             --arg ctx "ghost-lab" \
+             --arg desc "Bluefin lab test $STATE" \
+             --arg url "http://192.168.1.102:32746/workflows/argo/{{workflow.name}}" \
+             '{state:$state, context:$ctx, description:$desc, target_url:$url}')
+           curl -sf -X POST \
              -H "Authorization: token $(cat /var/run/secrets/github-token/token)" \
              -H "Accept: application/vnd.github+json" \
+             -H "Content-Type: application/json" \
              "https://api.github.com/repos/{{inputs.parameters.repo}}/statuses/{{inputs.parameters.sha}}" \
-             -d "{\"state\":\"${STATE}\",\"context\":\"ghost-lab\",
-                  \"description\":\"Bluefin lab test ${STATE}\",
-                  \"target_url\":\"http://192.168.1.102:32746/workflows/argo/{{workflow.name}}\"}"
+             -d "$PAYLOAD"
    ```
 3. Thread `pr-number`, `sha`, and `repo` as parameters through `bluefin-qa-pipeline.yaml`
    inputs down to the `post-github-status` template (they're optional — omit them in nightly
    CronWorkflow invocations, skip the status post if absent).
 
-### 6d — PR image cleanup in Zot
+### 6c — GitHub Actions trigger workflow (in bluefin repo)
 
 Every PR push creates a `192.168.1.102:30500/bluefin-pr-NNN:sha` image in the local
 writable Zot registry. Unlike the pull-through caches, the writable registry has no
@@ -427,7 +522,7 @@ done
 - After 8+ days of PR activity, confirm `oras repo tags` shows no tags older than 7d.
 - Confirm `df -h /var/tmp` on ghost is not growing monotonically.
 
-### 6c — GitHub Actions trigger workflow (in bluefin repo)
+### 6d — PR image cleanup in Zot
 
 Add a workflow in `projectbluefin/bluefin` (or equivalent repo) that triggers on
 `pull_request` and runs on `ghost-runners`:
@@ -464,6 +559,11 @@ jobs:
 
 ## Phase 7 — System contract tests in the nightly pipeline
 
+> **Note:** `ghost-kernel-args` WorkflowTemplate is referenced in the node join
+> checklist below. Verify it exists in `argo/workflow-templates/` before the first
+> new node joins — it does not appear in the current file list and may be on-cluster
+> only (a GitOps violation) or may need to be created.
+
 **Why it matters:** `tests/system/features/` contains the atomic OS contract test suite —
 `bootc.feature`, `filesystem.feature`, `integrity.feature`, `uupd.feature`. These tests
 verify Bluefin's core identity as an image-based, atomic operating system (bootc staging,
@@ -486,10 +586,11 @@ run `smoke/` (browser, flatpak health, GNOME shell) via `run-gnome-tests.yaml`. 
      tests require a graphical session; otherwise run `behave tests/system/` directly.
    - Output: pass/fail, test log artifact.
 
-3. **Wire into `bluefin-qa-pipeline.yaml`** as a parallel or sequential step after
-   `run-gnome-tests`. Both test suites share the same VM — no new VM provision needed.
-   Use `dag` task with `depends: provision-vm` so both suites run against the same
-   booted VM.
+3. **Wire into `bluefin-qa-pipeline.yaml`** sequentially after `run-gnome-tests`.
+   Both test suites share the same VM — no new VM provision needed. Use `dag` with
+   `depends: run-gnome-tests` (not `depends: provision-vm`). Running in parallel
+   risks system tests triggering a `bootc` staged deployment or reboot that
+   interrupts the live GNOME Wayland session mid-test.
 
 4. **Update nightly CronWorkflows** — system tests run automatically as part of the
    `bluefin-qa-pipeline` call; no separate CronWorkflow needed.
@@ -519,6 +620,7 @@ run `smoke/` (browser, flatpak health, GNOME shell) via `run-gnome-tests.yaml`. 
 | **NFS / shared build cache** | Per-node hostPath + Zot deduplication is sufficient. NFS adds locking risk with no clear benefit at 5-node scale. |
 | **bazzite as burst ARC capacity** | bazzite is ~90% available but k3s is disabled at boot and the node is tainted `NoSchedule`. When more ARC capacity is needed, enable k3s at boot, remove the taint, and it joins the runner pool automatically. No manifest changes needed. |
 | **exo-1 role** | exo-1 is a workflow pod worker. Once 5 Strix Halo nodes are in the pool it becomes redundant. Decommission or repurpose when convenient — no plan changes required. |
+| **Test dependency install time** | `run-gnome-tests` installs qecore, behave, dogtail, gnome-ponytail-daemon, and python-uinput on every run. Estimated 5–10 min per run, not yet measured on a real warm run. Options: bake into golden disk (best, zero per-run cost), pip wheel cache on hostPath (medium), or accept current cost. **Measure a real warm run first** — file an issue once the baseline is known. |
 
 ---
 
@@ -533,7 +635,7 @@ When a new Strix Halo node joins the pool:
    `nodeSelector` or label needed.
 4. The `buildah-cache` hostPath directory (`/var/tmp/arc-buildah-cache`) is created by
    `DirectoryOrCreate` on first pod — no manual setup.
-5. **Apply Strix Halo performance kernel args** via the existing WorkflowTemplate:
+5. **Apply Strix Halo performance kernel args** via the `ghost-kernel-args` WorkflowTemplate:
    ```bash
    argo submit --from workflowtemplate/ghost-kernel-args -n argo \
      --parameter node=<new-node-hostname>
@@ -542,6 +644,10 @@ When a new Strix Halo node joins the pool:
    The WorkflowTemplate currently targets ghost by name — update it to accept a `node`
    parameter so it works for any Strix Halo node. A reboot is required after.
    Without these args, ROCm performance is degraded and llm-d may crash on the new node.
+
+   > ⚠️ **`ghost-kernel-args` must exist in `argo/workflow-templates/` before the first
+   > new node joins.** Verify it is in git (not just on-cluster) and accepts a `node`
+   > parameter. If it only exists on-cluster, commit it to the repo first — see Phase 7 note.
 
 6. Verify the node appears in `kubectl get nodes` and runner pods land on it within a few
    minutes of a GitHub Actions job being queued.

--- a/docs/cluster-improvement-plan.md
+++ b/docs/cluster-improvement-plan.md
@@ -42,12 +42,12 @@ Argo workflow (independent lifecycle):
 
 ---
 
-## Phase 0 — Pre-flight bug fixes
+## Phase 0 — Pre-flight bug fixes ✅ DONE 2026-06-20
 
 These are existing bugs found during the design review. Fix them before anything else —
 any one can cause silent test failures independent of the improvements below.
 
-### 0a — Unlock `golden-disk-gc` from dry-run mode
+### 0a — Unlock `golden-disk-gc` from dry-run mode ✅
 
 `manifests/golden-disk-gc.yaml` line 25 has `value: "true"` as the `dry-run` argument
 default. The CronWorkflow runs daily at 04:00 UTC, logs every `KEEP` and `DELETE`
@@ -73,9 +73,13 @@ Keep the `dry-run` parameter so you can still pass `true` for a manual inspectio
   disk space is reclaimed: `df -h /var/tmp`.
 - Confirm the daily CronWorkflow at 04:00 UTC actually frees space the next morning.
 
-### 0b — Audit and fix the `192.168.1.102:5000` registry references
+### 0b — Audit and fix the `192.168.1.102:5000` registry references ✅
 
-### 0c — Verify and document what is running on port 30500
+### 0c — Verify and document what is running on port 30500 ✅
+
+**Finding:** port 30500 = plain `registry:2` Docker registry, running unmanaged outside GitOps for 18 days.
+Port `:5000` in bib-build-and-push.yaml was container-internal hostNetwork access to the same registry.
+**Fix applied:** `manifests/zot-writable.yaml` added — writable Zot replacing `registry:2` under ArgoCD control.
 
 Phases 4, 5, and 6 all assume a writable, OCI-compliant Zot instance at
 `192.168.1.102:30500`. `AGENTS.md` documents port 30500 as the "BIB push target" but
@@ -125,7 +129,7 @@ references `:5000`.
 
 ---
 
-## Phase 1 — Fill Zot coverage gaps
+## Phase 1 — Fill Zot coverage gaps ✅ DONE 2026-06-20
 
 **Why first:** `quay.io/kubevirt/virt-launcher` is pulled on every single test VM launch.
 Every BIB build also hits `quay.io/centos-bootc/bootc-image-builder`. These are the hottest
@@ -173,7 +177,10 @@ uncached paths in the cluster right now.
 
 ---
 
-## Phase 2 — Hummingbird image migration
+## Phase 2 — Hummingbird image migration ✅ DONE 2026-06-20
+
+**kubectl decision:** Option A — upstream `registry.k8s.io/kubectl:v1.32.0` kept.
+Upstream k8s/CNCF registries always preferred over distro-specific alternatives.
 
 **Why second:** Eliminates `cgr.dev` from the image footprint, simplifies the Zot inventory,
 and gives workflow steps a consistent Red Hat toolchain.
@@ -245,7 +252,7 @@ Two options — pick one before starting Phase 2:
 
 ---
 
-## Phase 3 — CI lint gate for uncached registries
+## Phase 3 — CI lint gate for uncached registries ✅ DONE 2026-06-20
 
 **Why after Phase 2:** The lint gate enforces the clean post-migration state. Adding it before
 Phase 2 is complete would fail on every current PR.
@@ -557,7 +564,12 @@ jobs:
 
 ---
 
-## Phase 7 — System contract tests in the nightly pipeline
+## Phase 7 — System contract tests in the nightly pipeline ✅ PARTIALLY DONE 2026-06-20
+
+**Finding:** `run-gnome-tests` WorkflowTemplate already handles `suite=system` natively (behave only,
+no qecore-headless). No new WorkflowTemplate needed.
+**Done:** `run-system` task added to `bluefin-qa-pipeline.yaml` DAG.
+**Remaining:** `tests/system/features/` does not exist yet — write the .feature files.
 
 > **Note:** `ghost-kernel-args` WorkflowTemplate is referenced in the node join
 > checklist below. Verify it exists in `argo/workflow-templates/` before the first

--- a/docs/cluster-improvement-plan.md
+++ b/docs/cluster-improvement-plan.md
@@ -1,0 +1,547 @@
+# Cluster Improvement Plan
+
+_Generated from design review session, 2026-06-20_
+
+## Context
+
+Ghost is a Ryzen AI MAX+ 395 (16c/32t, 64 GB RAM, ROCm gfx1151) running k3s with KubeVirt,
+Argo Workflows, ArgoCD, llm-d, and two Zot pull-through caches. A second identical Strix Halo
+64 GB machine is being added soon, with a 5-machine pool as the long-term target.
+
+The strategic direction coming out of this review:
+
+- **ARC-first** — GitHub Actions self-hosted runners are the primary CI surface for bluefin (it's
+  GitHub-native). Optimise the cluster for high-throughput parallel PR testing, not general-purpose
+  Kubernetes workloads.
+- **Cache everything** — 2.5 Gb ethernet between nodes; a local cache at LAN speed is always faster
+  than a residential internet uplink.
+- **Hummingbird-first images** — Red Hat hummingbird images replace cgr.dev, docker.io
+  general-purpose images, and alpine across all workflow templates and manifests.
+- **BST and KubeVirt stay on ghost** — BST builds are ghost-local. All KubeVirt test VMs run on
+  ghost (~7 concurrent, 8 GB each, plenty of headroom). Other nodes are pure ARC build workers.
+- **llm-d floats** — no longer pinned to ghost; scheduler places it on whichever node has 48 GB
+  free, freeing ghost for VMs when both are busy.
+
+## Full PR test pipeline (target state)
+
+```
+ARC runner (any node)
+  → buildah build (layer cache from Zot + per-node hostPath)
+  → oras push to local Zot writable registry (ghost:30500)
+  → argo submit bluefin-qa-pipeline --parameter image=192.168.1.102:30500/bluefin-pr-NNN:sha
+      --parameter pr-number=NNN --parameter sha=<sha> --parameter repo=projectbluefin/bluefin
+  → exit immediately (fire-and-forget)
+
+Argo workflow (independent lifecycle):
+  → BIB disk build (local Zot image URI)
+  → btrfs reflink clone of golden disk
+  → provision KubeVirt VM on ghost
+  → SSH → behave/dogtail GNOME AT-SPI tests
+  → onExit: POST GitHub commit status (token from k8s secret in argo namespace)
+```
+
+---
+
+## Phase 0 — Pre-flight bug fixes
+
+These are existing bugs found during the design review. Fix them before anything else —
+either one can cause silent test failures independent of the improvements below.
+
+### 0a — Unlock `golden-disk-gc` from dry-run mode
+
+`manifests/golden-disk-gc.yaml` line 25 has `value: "true"` as the `dry-run` argument
+default. The CronWorkflow runs daily at 04:00 UTC, logs every `KEEP` and `DELETE`
+decision correctly, and then does nothing. Every image release adds ~30 GB to
+`/var/tmp/bluefin-golden/` on ghost with no reclamation. When the partition fills,
+BIB disk builds fail mid-flight, leaving behind a corrupt `disk.raw` that then blocks
+future runs until manually removed.
+
+**Fix:** change the default to `"false"`:
+
+```yaml
+arguments:
+  parameters:
+    - name: dry-run
+      value: "false"   # was "true" — GC was never actually deleting anything
+```
+
+Keep the `dry-run` parameter so you can still pass `true` for a manual inspection run
+(`argo submit --from cronworkflow/golden-disk-gc --parameter dry-run=true -n argo`).
+
+**Validation:**
+- Manually submit with `dry-run=false`, check logs show `DELETE` lines and confirm
+  disk space is reclaimed: `df -h /var/tmp`.
+- Confirm the daily CronWorkflow at 04:00 UTC actually frees space the next morning.
+
+### 0b — Audit and fix the `192.168.1.102:5000` registry references
+
+`bib-build-and-push.yaml` references `192.168.1.102:5000` in two detection checks
+(lines 131 and 195). AGENTS.md documents the BIB push target NodePort as `30500`,
+not `5000`. Port 5000 is Zot's container-internal port; it is reachable from pods
+running with `hostNetwork: true` on ghost, but not from pods without it.
+
+**Investigate:** determine whether:
+- The `bib-img-build` and `bib-img-pull` steps run with `hostNetwork: true` on ghost
+  (in which case `:5000` works today but is fragile), or
+- These are stale references that silently fall through to the non-local image path.
+
+**Fix:** normalise to `192.168.1.102:30500` throughout, or extract a workflow-level
+parameter `local-registry` defaulting to `192.168.1.102:30500` and reference it
+consistently. The same audit applies to `dakota-qa-pipeline.yaml` which also
+references `:5000`.
+
+**Validation:**
+- `grep -rn ':5000' argo/ manifests/` returns only intentional references.
+- Submit `just run-tests-tag latest` and confirm the local-image-detection branch
+  triggers correctly when a locally-pushed image is supplied.
+
+---
+
+## Phase 1 — Fill Zot coverage gaps
+
+**Why first:** `quay.io/kubevirt/virt-launcher` is pulled on every single test VM launch.
+Every BIB build also hits `quay.io/centos-bootc/bootc-image-builder`. These are the hottest
+uncached paths in the cluster right now.
+
+**Audit result** (from `grep -r 'image:' argo/ manifests/`):
+
+| Registry | Uncached images | Action |
+|---|---|---|
+| `quay.io` | `kubevirt/virt-launcher`, BIB, podman, skopeo, fedora | Add `zot-quay` 🔥 |
+| `registry.fedoraproject.org` | `fedora:latest` | Add `zot-fedora` |
+| `cgr.dev` | bash, kubectl | Eliminate via Phase 2 (hummingbird replaces these) |
+| `registry.k8s.io` | `kubectl:v1.32.0` | Eliminate via Phase 2 |
+
+### Tasks
+
+1. **Add `zot-quay` to `manifests/zot-cache.yaml`** — copy the `zot-ghcr` Deployment/Service/ConfigMap
+   block, change upstream to `https://quay.io`, assign NodePort `30503`.
+
+2. **Add `zot-fedora` to `manifests/zot-cache.yaml`** — same pattern, upstream
+   `https://registry.fedoraproject.org`, NodePort `30504`.
+
+3. **Update `manifests/registry-mirror-config.yaml`** — add `quay.io.hosts.toml` and
+   `registry.fedoraproject.org.hosts.toml` entries in the ConfigMap, pointing to
+   `http://192.168.1.102:30503` and `http://192.168.1.102:30504` respectively.
+
+4. **Rollout restart** the `registry-mirror-config` DaemonSet so all nodes get the new
+   `hosts.toml` entries.
+
+### Validation
+
+- Submit `just run-tests-tag latest` and confirm no `quay.io` pulls escape to the internet
+  (check `zot-quay` pod logs for incoming requests).
+- Check `kubectl logs -n local-registry deploy/zot-quay` shows cache hits on subsequent runs.
+
+---
+
+## Phase 2 — Hummingbird image migration
+
+**Why second:** Eliminates `cgr.dev` and `registry.k8s.io` from the image footprint entirely,
+simplifies the Zot inventory, and gives all workflow steps a consistent Red Hat toolchain.
+If hummingbird images are on `ghcr.io`, they are already cached via `zot-ghcr` for free.
+
+### Images to replace
+
+| Current image | Replace with | Location |
+|---|---|---|
+| `cgr.dev/chainguard/bash:latest` | hummingbird bash / UBI9 minimal | workflow templates |
+| `cgr.dev/chainguard/kubectl:latest-dev` | hummingbird kubectl | `provision-bluefin-vm.yaml` |
+| `registry.k8s.io/kubectl:v1.32.0` | hummingbird kubectl | manifests |
+| `alpine:3.20` | hummingbird micro / UBI micro | workflow templates |
+| `docker.io/alpine:3` | hummingbird micro / UBI micro | manifests |
+| `busybox:latest` | hummingbird micro / UBI micro | `registry-mirror-config.yaml` (init container **and** pause loop) |
+| `python:3.12-slim` | hummingbird python / UBI9 python | workflow templates |
+| `docker.io/library/nginx:1.27.5-alpine` | hummingbird nginx / UBI9 nginx | manifests |
+
+**Keep as-is** (no hummingbird equivalent):
+- `docker.io/rocm/k8s-device-plugin:1.31.0.10` — ROCm-specific; `zot-docker` is retained solely for this image after Phase 2
+- `quay.io/*` — BIB, podman, skopeo, kubevirt virt-launcher (now cached via Phase 1)
+
+### Tasks
+
+1. For each image in the table above, find the canonical hummingbird equivalent on `ghcr.io`
+   and update every YAML reference.
+
+2. Run `just lint` after each file change to verify templates remain valid.
+
+3. After all replacements, confirm `grep -r 'cgr.dev\|registry.k8s.io' argo/ manifests/`
+   returns empty.
+
+4. **`registry-mirror-config.yaml` specifically** — replace both the init container
+   (`busybox:latest` writing the `hosts.toml` files) and the pause loop container
+   (`busybox:latest` kept alive to preserve the DaemonSet) with the hummingbird micro
+   equivalent. The pause loop has a `# ponytail:` comment explaining its purpose; preserve it.
+
+### Validation
+
+- `just lint` passes cleanly.
+- `grep -r 'cgr.dev\|registry.k8s.io\|alpine:\|busybox:\|python:3.12-slim' argo/ manifests/` — empty.
+- Submit a smoke test run and confirm no new registry errors.
+
+---
+
+## Phase 3 — CI lint gate for uncached registries
+
+**Why after Phase 2:** The lint gate enforces the clean post-migration state. Adding it before
+Phase 2 is complete would fail on every current PR.
+
+### Tasks
+
+1. **Add a lint step to `.github/workflows/lint.yaml`** that:
+   - Greps all `argo/` and `manifests/` YAML files for `image:` references.
+   - Extracts the registry hostname from each image reference.
+   - Fails if any registry is not in the allowlist:
+     ```
+     ghcr.io
+     quay.io
+     registry.fedoraproject.org
+     192.168.1.102
+     localhost
+     ```
+   - Prints the offending image and file on failure.
+
+2. Keep the check fast — a single shell `grep + awk` pipeline is sufficient; no external tools.
+
+### Validation
+
+- PR that adds `alpine:3.20` triggers a lint failure.
+- PR that adds `ghcr.io/some/hummingbird:latest` passes.
+
+---
+
+## Phase 4 — LLM float + all model artifacts in Zot
+
+**Why here:** Depends on the writable Zot registry (port 30500) being stable and trusted.
+Floating llm-d frees ghost's 48 GB RAM for the full 7-VM concurrent test capacity.
+
+> **Single-node note:** On a single-node cluster, removing `nodeSelector` and setting
+> `resources.requests.memory: 48Gi` is harmless — the scheduler has nowhere to float
+> but the manifest is already correct for when a second node arrives. No changes needed
+> for single-node adoption.
+
+### Pre-check: verify Zot port 30500 accepts OCI artifacts
+
+Port 30500 was originally configured as a BIB push target for container image blobs. Before
+pushing a raw GGUF, verify the Zot config in `manifests/zot-cache.yaml` has no `mediaType`
+filter that rejects `application/octet-stream`. If it does, relax the content policy or add
+a separate Zot instance for model artifacts.
+
+### Tasks
+
+1. **Push the GGUF as an OCI artifact** to local Zot:
+   ```bash
+   oras push 192.168.1.102:30500/llm-models/gemma-4-31B-it-Q8_0:latest \
+     ./gemma-4-31B-it-Q8_0.gguf:application/octet-stream
+   ```
+   _(Run once from ghost where the file already lives at `/var/tmp/llm-models/`.)_
+
+2. **Update `manifests/llm-d.yaml`**:
+   - Remove `nodeSelector: kubernetes.io/hostname: ghost`.
+   - Replace the init container download logic with:
+     1. `oras pull 192.168.1.102:30500/llm-models/gemma-4-31B-it-Q8_0:latest` → target dir.
+     2. Fall back to HuggingFace download + `oras push` to Zot on first run (seeds the cache).
+   - Verify `resources.requests.memory: 48Gi` is set (scheduler float mechanism — pod only
+     lands on a node with 48 GB free).
+   - The llama.cpp container image (`ghcr.io/ggml-org/llama.cpp:server-rocm`) is already
+     transparently cached by `zot-ghcr` — no change needed there.
+   - Future LoRA adapters and quantized variants follow the same `oras push` → `oras pull`
+     pattern.
+
+3. **Verify all Strix Halo ROCm env vars are still present** after manifest edit:
+   `HSA_OVERRIDE_GFX_VERSION=11.5.1`, `HSA_XNACK=1`, `ROCBLAS_USE_HIPBLASLT=1`, `-fa`,
+   `--no-mmap` — these are required on every Strix Halo node and must not be lost.
+
+### Validation
+
+- Delete the llm-d pod. Confirm it reschedules on whichever node has RAM headroom (not
+  necessarily ghost).
+- Confirm init container pulls GGUF from `192.168.1.102:30500` at LAN speed (check init
+  container logs for the source URL).
+- Confirm the model loads and responds: `curl http://192.168.1.102:30800/v1/models`.
+
+---
+
+## Phase 5 — ARC runner improvements
+
+**Why here:** Depends on the hummingbird images from Phase 2 (for the custom runner base)
+and Zot being solid (to store and serve the custom runner image).
+
+### 5a — Custom runner image
+
+Build a custom runner image on top of Red Hat hummingbird with the bluefin toolchain
+pre-installed: `buildah`, `skopeo`, `cosign`, `oras`, `argo` CLI, and any other tools
+currently installed per-job.
+
+1. Create `images/arc-runner/Containerfile` in this repo with the hummingbird base +
+   toolchain install steps.
+2. Build and push to local Zot: `192.168.1.102:30500/arc-runner:latest`.
+3. Update `argocd/arc-runners-app.yaml` Helm values:
+   ```yaml
+   template:
+     spec:
+       containers:
+         - name: runner
+           image: 192.168.1.102:30500/arc-runner:latest
+   ```
+4. Tag the image by date or git SHA, not `latest`, so rollbacks are trivial.
+
+### 5b — maxRunners and per-node buildah cache
+
+Update `argocd/arc-runners-app.yaml`:
+
+```yaml
+maxRunners: 4    # single-node default; scale up as nodes join (4 per ARC node × N + 2 on ghost)
+
+template:
+  spec:
+    volumes:
+      - name: buildah-cache
+        hostPath:
+          path: /var/tmp/arc-buildah-cache
+          type: DirectoryOrCreate
+    containers:
+      - name: runner
+        volumeMounts:
+          - name: buildah-cache
+            mountPath: /home/runner/.local/share/containers/storage
+```
+
+**Volume distinction:** the existing `kubernetesModeWorkVolumeClaim` (`local-path`, 10 Gi,
+`ReadWriteOnce`) is the **job workspace** providing per-job isolation for source checkouts
+and build outputs — keep it. The `buildah-cache` hostPath above is **additional**, mounted
+only for layer storage. Do not replace the work volume.
+
+The `hostPath` is node-local and persists across jobs on the same node. Zot provides
+cross-node OCI layer deduplication — if node B needs a layer node A already built, it
+pulls from Zot at LAN speed, not the internet.
+
+**Ghost capacity constraint:** with the LLM floating at 48 Gi and up to 7 VMs at 8 Gi
+each, ghost has limited headroom for runner pods. The `resources.requests` on the LLM and
+VMs will naturally push the scheduler toward other nodes. Monitor with
+`kubectl get pods -n arc-runners -o wide` after Framework desktop joins — if more than
+2–3 runners land on ghost consistently, add a node taint or runner `nodeAffinity` to
+steer excess runners away.
+
+### Validation
+
+- Verify runners spread across both ghost and Framework desktop once it joins:
+  `kubectl get pods -n arc-runners -o wide`
+- Confirm buildah cache dir persists between jobs on the same node:
+  run two consecutive builds on the same node and confirm the second is faster.
+- Check runner image pulls from `192.168.1.102:30500`, not `ghcr.io`.
+
+---
+
+## Phase 6 — PR pipeline wiring
+
+**Why last:** Depends on everything above: Zot (images), ARC runner (custom image + toolchain),
+and the bib-build-and-push fix.
+
+### 6a — Fix `bib-build-and-push.yaml` local image source
+
+The `ensure-disk` template already accepts an `image` parameter. Verify it passes through
+correctly to `bib-img-pull` and `bib-img-build` when given a local Zot URI
+(`192.168.1.102:30500/bluefin-pr-NNN:sha`). Fix any hardcoded `ghcr.io` references inside
+those sub-templates. Add a note in the template annotation documenting the local Zot URI
+pattern.
+
+Note on `bib-img-pull`: this step calls `skopeo` to pull the image from the upstream
+registry. For a locally-pushed image the pull is still valid (Zot serves it), but if
+the `bib-disk-check` step returns `exists` the entire pull+build chain is already
+skipped. For the `stale` / `missing` path, Zot will serve the locally-pushed image
+without touching the internet — no special casing needed as long as Zot is reachable.
+
+### 6b — GitHub commit status reporting in Argo
+
+1. Create a `github-token` secret in the `argo` namespace:
+   ```bash
+   kubectl create secret generic github-token \
+     --from-literal=token=<PAT or GitHub App token> \
+     -n argo
+   ```
+   The token needs `statuses:write` and `pull_requests:read` scope (or the equivalent
+   GitHub App permissions).
+
+2. Add an `onExit` template to `bluefin-qa-pipeline.yaml` that posts a GitHub commit status:
+   ```yaml
+   onExit: post-github-status
+   templates:
+     - name: post-github-status
+       inputs:
+         parameters:
+           - name: pr-number
+           - name: sha
+           - name: repo
+       script:
+         image: 192.168.1.102:30500/arc-runner:latest
+         source: |
+           STATE=$([ "{{workflow.status}}" = "Succeeded" ] && echo success || echo failure)
+           curl -s -X POST \
+             -H "Authorization: token $(cat /var/run/secrets/github-token/token)" \
+             -H "Accept: application/vnd.github+json" \
+             "https://api.github.com/repos/{{inputs.parameters.repo}}/statuses/{{inputs.parameters.sha}}" \
+             -d "{\"state\":\"${STATE}\",\"context\":\"ghost-lab\",
+                  \"description\":\"Bluefin lab test ${STATE}\",
+                  \"target_url\":\"http://192.168.1.102:32746/workflows/argo/{{workflow.name}}\"}"
+   ```
+3. Thread `pr-number`, `sha`, and `repo` as parameters through `bluefin-qa-pipeline.yaml`
+   inputs down to the `post-github-status` template (they're optional — omit them in nightly
+   CronWorkflow invocations, skip the status post if absent).
+
+### 6d — PR image cleanup in Zot
+
+Every PR push creates a `192.168.1.102:30500/bluefin-pr-NNN:sha` image in the local
+writable Zot registry. Unlike the pull-through caches, the writable registry has no
+automatic expiry. At scale (many contributors, many pushes per PR) these accumulate on
+ghost's disk indefinitely, reproducing the same silent disk-fill failure as Phase 0a.
+
+**Fix — Zot GC policy:** enable storage GC on the writable Zot instance (port 30500)
+in `manifests/zot-cache.yaml`:
+
+```json
+"storage": {
+  "rootDirectory": "/var/lib/registry",
+  "gc": true,
+  "gcDelay": "1h",
+  "gcInterval": "24h"
+}
+```
+
+This reclaims layers no longer referenced by any tag. It does not delete tags
+themselves — add a tag cleanup CronWorkflow alongside it.
+
+**Fix — tag cleanup CronWorkflow:** add `manifests/pr-image-gc.yaml`, a CronWorkflow
+that runs daily and deletes Zot tags matching `bluefin-pr-*` older than 7 days, and
+any `bluefin-pr-*` tag whose PR is closed or merged (query the GitHub API with the
+same `github-token` secret from Phase 6b):
+
+```bash
+# pseudocode — implement as a script step in the CronWorkflow
+for tag in $(oras repo tags 192.168.1.102:30500/bluefin-pr-* --older-than 7d); do
+  oras manifest delete 192.168.1.102:30500/${tag}
+done
+```
+
+**Validation:**
+- After 8+ days of PR activity, confirm `oras repo tags` shows no tags older than 7d.
+- Confirm `df -h /var/tmp` on ghost is not growing monotonically.
+
+### 6c — GitHub Actions trigger workflow (in bluefin repo)
+
+Add a workflow in `projectbluefin/bluefin` (or equivalent repo) that triggers on
+`pull_request` and runs on `ghost-runners`:
+
+```yaml
+jobs:
+  lab-test:
+    runs-on: ghost-runners
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image locally
+        run: |
+          buildah build -t 192.168.1.102:30500/bluefin-pr-${{ github.event.pull_request.number }}:${{ github.sha }} .
+          buildah push 192.168.1.102:30500/bluefin-pr-${{ github.event.pull_request.number }}:${{ github.sha }}
+      - name: Submit Argo test workflow
+        run: |
+          argo submit --from workflowtemplate/bluefin-qa-pipeline \
+            --parameter image=192.168.1.102:30500/bluefin-pr-${{ github.event.pull_request.number }}:${{ github.sha }} \
+            --parameter pr-number=${{ github.event.pull_request.number }} \
+            --parameter sha=${{ github.sha }} \
+            --parameter repo=${{ github.repository }} \
+            -n argo
+          # fire-and-forget: runner exits, Argo owns the lifecycle and reports back
+```
+
+### Validation
+
+- Open a test PR in the bluefin repo, confirm:
+  1. The ARC runner builds and exits within a few minutes.
+  2. An Argo workflow appears in the `argo` namespace with the PR image tag.
+  3. After the workflow completes, a commit status appears on the PR in GitHub.
+
+---
+
+## Phase 7 — System contract tests in the nightly pipeline
+
+**Why it matters:** `tests/system/features/` contains the atomic OS contract test suite —
+`bootc.feature`, `filesystem.feature`, `integrity.feature`, `uupd.feature`. These tests
+verify Bluefin's core identity as an image-based, atomic operating system (bootc staging,
+read-only `/usr`, composefs/fs-verity, `uupd` orchestration). Per the AGENTS.md test
+suite mantra, these take priority over cosmetic UI checks. The nightlies currently only
+run `smoke/` (browser, flatpak health, GNOME shell) via `run-gnome-tests.yaml`. The
+`system/` tests have no corresponding WorkflowTemplate and are not in any nightly.
+
+### Tasks
+
+1. **Audit `tests/system/features/` step files** to understand what the tests need:
+   which AT-SPI calls, which system commands, which dependencies beyond `qecore-headless`.
+   The `bootc` and `uupd` tests are likely command-line only (no Wayland session required);
+   `gnome_shell` shell interactions may still need the Wayland session.
+
+2. **Create `argo/workflow-templates/run-system-tests.yaml`** following the same pattern
+   as `run-gnome-tests.yaml`:
+   - SSH into the test VM.
+   - Run `qecore-headless --session-type wayland --session-desktop gnome` only if the
+     tests require a graphical session; otherwise run `behave tests/system/` directly.
+   - Output: pass/fail, test log artifact.
+
+3. **Wire into `bluefin-qa-pipeline.yaml`** as a parallel or sequential step after
+   `run-gnome-tests`. Both test suites share the same VM — no new VM provision needed.
+   Use `dag` task with `depends: provision-vm` so both suites run against the same
+   booted VM.
+
+4. **Update nightly CronWorkflows** — system tests run automatically as part of the
+   `bluefin-qa-pipeline` call; no separate CronWorkflow needed.
+
+5. **Wire into the PR pipeline** (Phase 6) — the same `bluefin-qa-pipeline` invocation
+   from the ARC runner will pick up system tests automatically once they are added to
+   the pipeline.
+
+### Validation
+
+- Submit `just run-tests-tag latest` and confirm both `run-gnome-tests` and
+  `run-system-tests` steps appear in the Argo DAG and complete.
+- Confirm `bootc.feature` and `integrity.feature` pass on a known-good Bluefin image.
+- Confirm a deliberate regression (e.g., mock a broken `uupd` output) causes
+  `uupd.feature` to fail and the pipeline to report failure.
+
+---
+
+## What is deferred
+
+| Item | Reason |
+|---|---|
+| **k3s control plane HA** | Homelab; embedded etcd HA requires 3 control-plane nodes, high complexity, low ROI. Ghost reboots recover in minutes. |
+| **Observability / alerting** | Argo UI is sufficient for now. Add Argo Notifications or an `onExit` webhook when a missed nightly failure actually causes a problem. |
+| **KubeVirt on non-ghost nodes** | Ghost alone handles ~7 concurrent VMs (7 × 8 GB = 56 GB). No bottleneck at current PR volume. Revisit if VM slots queue. |
+| **knuckle SSH migration** | Tracked in #113–118. Ongoing migration to in-pod kubectl/virtctl pattern. |
+| **NFS / shared build cache** | Per-node hostPath + Zot deduplication is sufficient. NFS adds locking risk with no clear benefit at 5-node scale. |
+| **bazzite as burst ARC capacity** | bazzite is ~90% available but k3s is disabled at boot and the node is tainted `NoSchedule`. When more ARC capacity is needed, enable k3s at boot, remove the taint, and it joins the runner pool automatically. No manifest changes needed. |
+| **exo-1 role** | exo-1 is a workflow pod worker. Once 5 Strix Halo nodes are in the pool it becomes redundant. Decommission or repurpose when convenient — no plan changes required. |
+
+---
+
+## Node join checklist (for Framework desktop and future nodes)
+
+When a new Strix Halo node joins the pool:
+
+1. Join as k3s agent: `k3s agent --server https://ghost:6443 --token <token>`
+2. The `registry-mirror-config` DaemonSet applies `hosts.toml` automatically — no manual
+   containerd config needed.
+3. The `arc-runners` ARC scale set schedules runner pods on it automatically — no
+   `nodeSelector` or label needed.
+4. The `buildah-cache` hostPath directory (`/var/tmp/arc-buildah-cache`) is created by
+   `DirectoryOrCreate` on first pod — no manual setup.
+5. **Apply Strix Halo performance kernel args** via the existing WorkflowTemplate:
+   ```bash
+   argo submit --from workflowtemplate/ghost-kernel-args -n argo \
+     --parameter node=<new-node-hostname>
+   ```
+   Required args: `amd_iommu=off amdgpu.gttsize=61440 ttm.pages_limit=15728640`.
+   The WorkflowTemplate currently targets ghost by name — update it to accept a `node`
+   parameter so it works for any Strix Halo node. A reboot is required after.
+   Without these args, ROCm performance is degraded and llm-d may crash on the new node.
+
+6. Verify the node appears in `kubectl get nodes` and runner pods land on it within a few
+   minutes of a GitHub Actions job being queued.

--- a/docs/cluster-improvement-plan.md
+++ b/docs/cluster-improvement-plan.md
@@ -296,7 +296,7 @@ Phase 2 is complete would fail on every current PR.
 
 ---
 
-## Phase 4 — LLM float + all model artifacts in Zot
+## Phase 4 — LLM float + all model artifacts in Zot ✅ DONE 2026-06-20
 
 **Why here:** Depends on the writable Zot registry (port 30500) being stable and trusted.
 Floating llm-d frees ghost's 48 GB RAM for the full 7-VM concurrent test capacity.
@@ -353,7 +353,7 @@ Zot instance for model artifacts.
 
 ---
 
-## Phase 5 — ARC runner improvements
+## Phase 5 — ARC runner improvements ✅ DONE 2026-06-20
 
 **Why here:** Depends on the hummingbird images from Phase 2 (for the custom runner base)
 and Zot being solid (to store and serve the custom runner image).
@@ -424,7 +424,9 @@ steer excess runners away.
 
 ---
 
-## Phase 6 — PR pipeline wiring
+## Phase 6 — PR pipeline wiring ✅ PARTIALLY DONE 2026-06-20
+
+> 6b and 6c implemented. Ops prereq: `kubectl create secret generic github-token --from-literal=token=<PAT> -n argo`. 6d (ARC trigger workflow in projectbluefin/bluefin) is a separate task.
 
 **Why last:** Depends on everything above: Zot (images), ARC runner (custom image + toolchain),
 and the bib-build-and-push fix.
@@ -564,7 +566,7 @@ jobs:
 
 ---
 
-## Phase 7 — System contract tests in the nightly pipeline ✅ PARTIALLY DONE 2026-06-20
+## Phase 7 — System contract tests in the nightly pipeline ✅ DONE 2026-06-20
 
 **Finding:** `run-gnome-tests` WorkflowTemplate already handles `suite=system` natively (behave only,
 no qecore-headless). No new WorkflowTemplate needed.

--- a/docs/cluster-ops.md
+++ b/docs/cluster-ops.md
@@ -23,9 +23,9 @@ to be reachable. If the extensions show `offline`, run `/argo-reconnect` and
 
 | Node | Role | Schedulable | Notes |
 |---|---|---|---|
-| `ghost` | control-plane + master | Yes (all workloads) | — |
-| `exo-1` | worker | Yes (workflow pods only — no critical system pods) | — |
-| `bazzite` | worker | Yes (on demand) | Gaming machine — k3s disabled at boot; `ujust toggle-k8s` to start/stop |
+| `ghost` | control-plane + master | Yes | Taint: none — general scheduling allowed |
+| `exo-1` | worker | Yes | Taint: none — general scheduling allowed |
+| `bazzite` | worker | On demand only | Taint: `node-role.kubernetes.io/gaming:NoSchedule` — gaming machine, k3s disabled at boot; `ujust toggle-k8s` to start/stop. Only pods with matching toleration land here. |
 
 `/etc/rancher/k3s/config.yaml` on ghost:
 
@@ -47,19 +47,55 @@ exo-1 are evicted within ~90s and rescheduled on ghost.
 in `Unknown` state for 2+ minutes when exo-1 went offline, blocking cluster
 recovery. Reduced to 90s on 2026-06-20.
 
-## What runs where
+## Scheduling model
 
-**Must run on ghost** (control-plane-critical or MCP-facing):
-- `coredns` — DNS for all pods; if on exo-1 and exo-1 dies, DNS breaks
-- `local-path-provisioner` — PVC provisioning
-- `kubernetes-mcp-server` (namespace `mcp`) — already pinned via `nodeSelector: kubernetes.io/hostname: ghost` in `mcp-kubernetes-mcp-server.yaml`
-- All KubeVirt virt-* components — pinned by KubeVirt operator
-- Argo Workflow controller — runs on ghost
+### Rule: only use nodeSelector/nodeAffinity when hardware requires it
 
-**May run on exo-1** (workflow compute pods only):
-- BST build pods
-- BIB build pods
-- Any Argo workflow step pod without a ghost nodeSelector
+Do **not** pin pods to specific nodes to "be safe" or "reduce load on the control
+plane". The k8s scheduler is correct by default. Hard placement constraints
+create fragility and waste capacity.
+
+**Valid reasons to pin a pod to a node:**
+- Pod needs a hostPath on ghost's local disk (KubeVirt disks, Zot cache, local registry)
+- Pod needs the AMD GPU on ghost (ROCm / llm-d)
+- Pod is a DaemonSet component (by definition runs everywhere)
+
+**Not valid reasons to pin:**
+- "The control plane is on ghost" — schedulable nodes handle all workloads
+- "I want to be safe" — use resource requests and let the scheduler decide
+- "exo-1 is a worker" — ghost is also schedulable; treat them equivalently
+
+### What requires a nodeSelector
+
+| Workload | Node | Reason |
+|---|---|---|
+| KubeVirt virt-* components | ghost | KubeVirt operator pins these |
+| KubeVirt VMs (VirtualMachineInstance) | ghost | hostPath disk on ghost's local storage |
+| `kubernetes-mcp-server` | ghost | nodeSelector in manifest (MCP socket dependency) |
+| `zot-ghcr`, `zot-docker` (registry cache) | ghost | hostPath cache at `/var/mnt/ghost-data/zot-*` |
+| `local-registry` (registry:2) | ghost | hostPath at `/var/mnt/ghost-data/dist-registry` |
+| `llm-d` model server | ghost | AMD GPU (amd.com/gpu resource) |
+
+### What schedules freely (no nodeSelector)
+
+- Argo Workflow step pods (BIB builds, BST builds, test runners)
+- ARC runner pods and listener (`arc-systems`, `arc-runners`)
+- ArgoCD components
+- Argo controller and server
+- All other stateless workloads
+
+### Bazzite taint
+
+bazzite carries taint `node-role.kubernetes.io/gaming:NoSchedule` — persisted via
+`manifests/bazzite-node-taint.yaml`. Critical infra pods never land there.
+Workloads that opt in via `tolerations` can use bazzite's capacity when it is online.
+bazzite's k3s is disabled at boot; enable with `ujust toggle-k8s`.
+
+**Why this matters:** bazzite's CNI/network may not be fully initialised when it
+first joins. Pods landing on bazzite before networking is ready will fail DNS
+resolution (`no route to host` to CoreDNS). The taint prevents this for infra workloads.
+
+### CoreDNS placement
 
 **CoreDNS is NOT pinned via manifest** — k3s overwrites its own manifests on
 every restart. CoreDNS is kept on ghost by the `node-monitor-grace-period=90s`

--- a/docs/cluster-ops.md
+++ b/docs/cluster-ops.md
@@ -198,3 +198,76 @@ workflows simultaneously.
 | Argo Workflows UI | `http://192.168.1.102:32746` | HTTP |
 
 Port 3333 (superlocalmemory) has been decommissioned.
+
+## ARC runner operations
+
+The ghost cluster runs GitHub Actions Runner Controller (ARC) to replicate the GitHub Actions environment locally for developer testing.
+
+### Architecture
+
+| Component | Namespace | Pod | Notes |
+|---|---|---|---|
+| Controller | `arc-systems` | `arc-systems-gha-rs-controller-*` | Manages runner lifecycle |
+| Listener | `arc-systems` | `ghost-runners-*-listener` | Long-polls GitHub for job assignments |
+| Runner pods | `arc-runners` | `ghost-runners-*-runner-*` | Ephemeral — spawned per job, die after |
+
+Scale set: `ghost-runners`, registered at org level `https://github.com/projectbluefin`, `minRunners: 0`, `maxRunners: 4`.
+
+### Empty arc-runners namespace is HEALTHY
+
+`minRunners: 0` means no idle runner pods sit around. The listener wakes up the scale set when GitHub dispatches a job with `runs-on: ghost-runners`. An empty namespace means no jobs are queued — this is correct.
+
+### Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Pod has failed to start more than 5 times` on EphemeralRunners | Stale failed runners blocking new ones | `kubectl delete ephemeralrunners -n arc-runners --all` |
+| Runner pods complete in 2s with no logs | Missing `command: ["/home/runner/run.sh"]` — image default CMD is `/bin/bash` | Add command to `arc-runners-app.yaml` template |
+| `Jobs without a job container are forbidden` | `containerMode: kubernetes` sets `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=true` — incompatible with workflows without `container:` field | Remove `containerMode` from Helm values |
+| Runners all land on ghost, none on bazzite | No nodeSelector; scheduler prefers ghost | Add `nodeSelector: node-location: lan` + toleration for `node-role.kubernetes.io/gaming` |
+| Runners Pending with `didn't match node affinity/selector` | bazzite taint not tolerated | Add `tolerations: [{key: node-role.kubernetes.io/gaming, operator: Exists, effect: NoSchedule}]` |
+
+### Routing local dev to ghost ARC runners
+
+A pre-push git hook at `~/.git-hooks/pre-push` (global via `~/.config/git/config: core.hooksPath`) transparently mirrors pushes to `projectbluefin/*` repos:
+
+1. Creates `ghost/<branch>` with `ubuntu-latest` → `ghost-runners` patched in workflow files (git plumbing — no working tree changes)
+2. Force-pushes the ghost branch
+3. Auto-dispatches `workflow_dispatch` workflows (skips `manual.yml` — needs specific inputs)
+4. Cleans up ghost branches after 2 hours
+
+To run the full test matrix manually against ghost runners:
+```bash
+GHOST_REF="ghost/<branch>"
+for image in testing stable; do
+  gh workflow run manual.yml --repo projectbluefin/testsuite \
+    --ref "${GHOST_REF}" \
+    --field image="ghcr.io/projectbluefin/bluefin:${image}" \
+    --field suites="smoke,developer,dx,software,vanilla-gnome,bazzite,lifecycle"
+done
+```
+
+### Bazzite sleep prevention
+
+Bazzite is a gaming PC and will suspend if idle. Prevent with:
+```bash
+# Via privileged pod (survives without SSH):
+kubectl run nosleep --image=busybox:latest --restart=Never \
+  --overrides='{"spec":{"nodeSelector":{"kubernetes.io/hostname":"bazzite"},"hostPID":true,"containers":[{"name":"n","image":"busybox:latest","securityContext":{"privileged":true},"command":["nsenter","-t","1","-m","-u","-i","-n","-p","--","bash","-c","systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target && echo DONE"]}]}}' \
+  && sleep 10 && kubectl logs nosleep && kubectl delete pod nosleep
+```
+Masks survive reboots but NOT OS updates. Re-run after Bazzite updates.
+
+### Registry mirrors (Zot)
+
+`zot-ghcr` (port 30501) and `zot-docker` (port 30502) are on-demand pull-through caches in `local-registry` namespace. For nodes to use them, `/etc/rancher/k3s/registries.yaml` must include:
+```yaml
+mirrors:
+  "ghcr.io":
+    endpoint:
+      - "http://192.168.1.102:30501"
+  "docker.io":
+    endpoint:
+      - "http://192.168.1.102:30502"
+```
+After updating, restart k3s: `systemctl restart k3s` (ghost) or `systemctl restart k3s-agent` (bazzite).

--- a/docs/skills/argo-workflows.md
+++ b/docs/skills/argo-workflows.md
@@ -279,6 +279,9 @@ spec:
 - Templates annotated `DEPRECATED` that haven't been deleted from git
 - Two CronWorkflows with the same schedule covering overlapping namespaces
 - A `steps` template with the same `when` condition on 3+ sequential steps (convert to `dag` + `depends` chain)
+- A CronWorkflow that has a `dry-run` parameter defaulting to `"true"` — it will log `KEEP`/`DELETE` decisions and then do nothing; disk fills silently
+- Any `image:` in `argo/` or `manifests/` referencing `:5000` for the local OCI registry — `:5000` is the container-internal Zot port; use the NodePort `192.168.1.102:30500` so non-hostNetwork pods can reach it
+- Any `image:` referencing a registry not in the allowlist (`ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `192.168.1.102`, `localhost`) — enforce with the lint gate in `.github/workflows/lint.yaml`
 
 ## Verification
 
@@ -293,3 +296,6 @@ Before marking any WorkflowTemplate change done:
 - [ ] File name matches `metadata.name` (e.g. `provision-bluefin-vm.yaml` for `name: provision-bluefin-vm`)
 - [ ] No DEPRECATED templates left in git
 - [ ] `kubectl get workflowtemplate -n argo` shows no cluster-only templates (not in git) unless they're intentional bootstrap one-shots
+- [ ] No CronWorkflow with a `dry-run` parameter whose default is `"true"` — verify GC jobs actually delete
+- [ ] All local OCI registry references use `:30500` (NodePort), not `:5000` (container-internal)
+- [ ] `grep -rn 'image:' argo/ manifests/` shows only allowlisted registries: `ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `192.168.1.102`, `localhost`

--- a/docs/skills/argo-workflows.md
+++ b/docs/skills/argo-workflows.md
@@ -193,6 +193,16 @@ dag:
 
 Argo DAG semantics: a task with `depends: "X.Succeeded"` is **Omitted** (not an error) when X is Skipped. The overall DAG succeeds if all non-Omitted tasks succeeded.
 
+**Optional upstream:** when a task has its own `when` guard and a downstream task must run regardless of whether the upstream was skipped, use OR:
+
+```yaml
+- name: run-system
+  depends: "(run-software.Succeeded || run-software.Skipped)"
+  when: "'{{workflow.parameters.suites}}' =~ 'system'"
+```
+
+This fires `run-system` whether `run-software` succeeded or was skipped by its own `when` condition.
+
 ### 8. File names must match `metadata.name`
 
 WorkflowTemplate file names in `argo/workflow-templates/` must match the resource's `metadata.name`. Divergence (e.g. `provision-vm.yaml` containing `name: provision-bluefin-vm`) confuses ArgoCD tracking and grep-based navigation:
@@ -281,7 +291,8 @@ spec:
 - A `steps` template with the same `when` condition on 3+ sequential steps (convert to `dag` + `depends` chain)
 - A CronWorkflow that has a `dry-run` parameter defaulting to `"true"` — it will log `KEEP`/`DELETE` decisions and then do nothing; disk fills silently
 - Any `image:` in `argo/` or `manifests/` referencing `:5000` for the local OCI registry — `:5000` is the container-internal Zot port; use the NodePort `192.168.1.102:30500` so non-hostNetwork pods can reach it
-- Any `image:` referencing a registry not in the allowlist (`ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `192.168.1.102`, `localhost`) — enforce with the lint gate in `.github/workflows/lint.yaml`
+- Any `image:` referencing a registry not in the allowlist (`ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `registry.access.redhat.com`, `registry.k8s.io`, `192.168.1.102`, `localhost`) — enforce with the lint gate in `.github/workflows/lint.yaml`
+- `depends: "X.Succeeded"` on a task that follows a conditionally-skippable upstream — if upstream is Skipped, the downstream task is Omitted and the whole DAG may appear to succeed even though the chain broke; use `depends: "(X.Succeeded || X.Skipped)"` when the upstream has its own `when` guard
 
 ## Verification
 
@@ -298,4 +309,4 @@ Before marking any WorkflowTemplate change done:
 - [ ] `kubectl get workflowtemplate -n argo` shows no cluster-only templates (not in git) unless they're intentional bootstrap one-shots
 - [ ] No CronWorkflow with a `dry-run` parameter whose default is `"true"` — verify GC jobs actually delete
 - [ ] All local OCI registry references use `:30500` (NodePort), not `:5000` (container-internal)
-- [ ] `grep -rn 'image:' argo/ manifests/` shows only allowlisted registries: `ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `192.168.1.102`, `localhost`
+- [ ] `grep -rn 'image:' argo/ manifests/` shows only allowlisted registries: `ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `registry.access.redhat.com`, `registry.k8s.io`, `192.168.1.102`, `localhost`

--- a/docs/skills/gitops-argocd.md
+++ b/docs/skills/gitops-argocd.md
@@ -125,7 +125,45 @@ If a template change is in git but not yet live:
 2. If OutOfSync, run `just argocd-sync`
 3. If sync fails, check ArgoCD logs: `kubectl logs -n argocd -l app.kubernetes.io/name=argocd-application-controller`
 
-### 7. Reconciling orphan templates (cluster-only → git)
+### 7. OCI Helm chart Applications (arc-systems, arc-runners)
+
+ArgoCD can deploy OCI Helm charts directly. These Applications live under `argocd/`
+and are applied once as control-plane resources (not GitOps-managed by ArgoCD itself).
+
+```bash
+# Apply ARC ArgoCD Applications (one-time, or after cluster rebuild)
+kubectl apply -f argocd/arc-controller-app.yaml -n argocd
+kubectl apply -f argocd/arc-runners-app.yaml -n argocd
+```
+
+**CRD annotation size limit** — Large CRDs (e.g. `autoscalingrunnersets.actions.github.com`)
+exceed ArgoCD's 262KB client-side annotation limit. Fix: `ServerSideApply=true` in
+`syncOptions`. Already set in `argocd/arc-controller-app.yaml`.
+
+**Stuck retry loop** — if ArgoCD retries a failed sync with stale syncOptions:
+```bash
+kubectl patch application <name> -n argocd \
+  --type=json -p='[{"op":"remove","path":"/operation"}]'
+kubectl annotate application <name> -n argocd \
+  argocd.argoproj.io/refresh=hard --overwrite
+```
+
+**Controller service account discovery** — `gha-runner-scale-set` discovers the
+controller SA by label lookup. Fails when controller and runners are in different
+namespaces. Always set explicitly in helm values:
+```yaml
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-systems-gha-rs-controller
+```
+
+**bazzite taint** — bazzite carries `node-role.kubernetes.io/gaming:NoSchedule`
+(persisted in `manifests/bazzite-node-taint.yaml`). Infra pods landing there fail
+DNS resolution (`no route to host` to CoreDNS) because bazzite's CNI may not be
+fully initialised on join. If a pod lands on bazzite and fails, delete it — it will
+reschedule to ghost automatically.
+
+### 8. Reconciling orphan templates (cluster-only → git)
 
 When a template exists in the cluster but not in git:
 ```bash

--- a/docs/skills/gitops-argocd.md
+++ b/docs/skills/gitops-argocd.md
@@ -181,6 +181,22 @@ print(yaml.dump(d,default_flow_style=False,sort_keys=False))" \
 
 Then lint, commit, push. ArgoCD will adopt the resource on next sync.
 
+### 9. Taking GitOps ownership of unmanaged Deployments/Services
+
+When a Deployment or Service exists in the cluster but has no manifest in git (e.g. was created
+with `kubectl apply` or a Helm one-shot and then forgotten), ArgoCD will not manage or prune it
+unless you add a manifest.
+
+Pattern:
+1. Inspect the running resource: `kubectl get deploy <name> -n <ns> -o yaml`
+2. Strip generated fields (`resourceVersion`, `uid`, `creationTimestamp`, `managedFields`, `status`)
+3. Write the clean manifest to `manifests/<name>.yaml`
+4. Commit and push. ArgoCD SSA will take ownership on next sync without restarting the pod (if the spec is identical).
+5. **Name the Deployment and Service identically to the existing resource** — SSA patches in place rather than recreating.
+
+> ⚠️ If you change the image or spec while adopting, ArgoCD will roll the pod. Safe for stateless
+> workloads; for stateful ones (writable registries, DBs) verify data path continuity first.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -192,6 +208,7 @@ Then lint, commit, push. ArgoCD will adopt the resource on next sync.
 
 ## Red Flags
 
+- A Deployment or Service running in the cluster with no corresponding manifest in `manifests/` — it is invisible to ArgoCD, will not be pruned or healed, and drifts silently (e.g. `registry:2` ran unmanaged for 18+ days)
 - A WorkflowTemplate in `argo/workflow-templates/` that exists only in the cluster (not in git) — ArgoCD will prune it on next sync
 - `generateName:` in any file under `manifests/`
 - A template that was `kubectl apply`d and is showing as OutOfSync in ArgoCD
@@ -202,6 +219,7 @@ Then lint, commit, push. ArgoCD will adopt the resource on next sync.
 
 Before merging a GitOps change:
 
+- [ ] No Deployment or Service in `local-registry`, `argo`, or other managed namespaces exists only in the cluster — verify with `kubectl get deploy,svc -n <ns>` vs git
 - [ ] New WorkflowTemplate is in the correct path (`workflow-templates/` vs `bootstrap/`)
 - [ ] `argo lint --offline argo/workflow-templates/` passes
 - [ ] No `generateName:` in `manifests/`

--- a/images/arc-runner/Containerfile
+++ b/images/arc-runner/Containerfile
@@ -1,0 +1,35 @@
+# ARC runner image — hummingbird base + bluefin CI toolchain
+# Extend ghcr.io/actions/actions-runner rather than base OS so ARC lifecycle scripts stay intact.
+# ponytail: no custom OS layer — just add missing tools on top of upstream runner
+
+FROM ghcr.io/actions/actions-runner:latest
+
+USER root
+
+# Install bluefin CI toolchain: buildah, skopeo, cosign, oras, argo CLI
+# Using apt (actions-runner base is Ubuntu); these are the tools currently installed per-job.
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+      buildah \
+      skopeo \
+      curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# cosign (no apt package in Ubuntu LTS)
+RUN curl -sSfL \
+      https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 \
+      -o /usr/local/bin/cosign && \
+    chmod +x /usr/local/bin/cosign
+
+# oras (OCI registry push/pull for GGUF artifacts and PR images)
+RUN curl -sSfL \
+      https://github.com/oras-project/oras/releases/latest/download/oras_$(curl -sSf https://api.github.com/repos/oras-project/oras/releases/latest | grep '"tag_name"' | cut -d'"' -f4 | tr -d v)_linux_amd64.tar.gz \
+    | tar xz -C /usr/local/bin oras
+
+# argo CLI (fire-and-forget workflow submission from ARC runner jobs)
+RUN curl -sSfL \
+      https://github.com/argoproj/argo-workflows/releases/latest/download/argo-linux-amd64.gz \
+    | gunzip -c > /usr/local/bin/argo && \
+    chmod +x /usr/local/bin/argo
+
+USER runner

--- a/manifests/bazzite-node-taint.yaml
+++ b/manifests/bazzite-node-taint.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: bazzite
+spec:
+  taints:
+    - key: node-role.kubernetes.io/gaming
+      effect: NoSchedule

--- a/manifests/golden-disk-gc.yaml
+++ b/manifests/golden-disk-gc.yaml
@@ -22,7 +22,7 @@ spec:
     arguments:
       parameters:
         - name: dry-run
-          value: "true"
+          value: "false"   # was "true" — GC was never actually deleting anything
     podGC:
       strategy: OnWorkflowCompletion
     ttlStrategy:
@@ -40,7 +40,7 @@ spec:
         nodeSelector:
           kubernetes.io/hostname: ghost
         script:
-          image: alpine:3.20
+          image: registry.access.redhat.com/ubi9/ubi-minimal:9.5
           command: [sh]
           env:
             - name: DRY_RUN

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -74,7 +74,7 @@ spec:
       # the hostPath volume and pass the local path to vllm serve instead.
       initContainers:
         - name: download-gguf
-          image: docker.io/alpine:3
+          image: registry.access.redhat.com/ubi9/ubi-minimal:9.5
           command: ["sh", "-c"]
           args:
             - |

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -57,9 +57,9 @@ spec:
         app.kubernetes.io/name: llm-d-modelserver
         llm-d.ai/model: gemma-4-31B-it
     spec:
-      # Pinned to ghost — only node with AMD Strix Halo GPU.
-      nodeSelector:
-        kubernetes.io/hostname: ghost
+      # ponytail: nodeSelector removed — llm-d floats to any node with 48Gi free RAM.
+      # Strix Halo ROCm env vars are required on every Strix Halo node in the pool.
+      # Re-add nodeSelector if a non-Strix-Halo node joins without /dev/kfd + /dev/dri.
       # Required for ROCm IPC and shared memory across processes.
       hostNetwork: true
       hostIPC: true
@@ -145,7 +145,7 @@ spec:
           resources:
             requests:
               cpu: "8"
-              memory: 40Gi
+              memory: 48Gi  # scheduler float: pod only lands on node with 48Gi free
               amd.com/gpu: "1"
             limits:
               cpu: "16"

--- a/manifests/orphan-pod-gc.yaml
+++ b/manifests/orphan-pod-gc.yaml
@@ -27,7 +27,7 @@ spec:
         nodeSelector:
           kubernetes.io/hostname: ghost
         script:
-          image: cgr.dev/chainguard/kubectl:latest-dev
+          image: registry.k8s.io/kubectl:v1.32.0
           command: [bash]
           resources:
             requests:

--- a/manifests/orphan-vm-cleanup.yaml
+++ b/manifests/orphan-vm-cleanup.yaml
@@ -27,7 +27,7 @@ spec:
         nodeSelector:
           kubernetes.io/hostname: ghost
         script:
-          image: cgr.dev/chainguard/kubectl:latest-dev
+          image: registry.k8s.io/kubectl:v1.32.0
           command: [bash]
           resources:
             requests:

--- a/manifests/pr-image-gc.yaml
+++ b/manifests/pr-image-gc.yaml
@@ -1,0 +1,117 @@
+# PR image GC — delete bluefin-pr-* tags from writable Zot older than 7 days,
+# or whose PR is closed/merged (uses github-token secret from argo namespace).
+#
+# Runs daily at 03:00 UTC (after golden-disk-gc at 04:00 UTC and nightly smoke at 02:00 UTC).
+# No workflowTemplateRef — inline is fine here since the logic is self-contained.
+# ponytail: no separate WorkflowTemplate, no Helm chart; CronWorkflow is already the scheduler.
+#
+# Prerequisite: github-token secret must exist in argo namespace with key "token".
+# Create: kubectl create secret generic github-token --from-literal=token=<PAT> -n argo
+#
+# ArgoCD: testing-lab-infra syncs this
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: pr-image-gc
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: gc
+spec:
+  schedules:
+    - "0 3 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  workflowSpec:
+    serviceAccountName: argo
+    ttlStrategy:
+      secondsAfterSuccess: 86400      # 1 day
+      secondsAfterFailure: 604800     # 7 days
+    entrypoint: gc
+    templates:
+      - name: gc
+        nodeSelector:
+          kubernetes.io/hostname: ghost
+        script:
+          image: quay.io/fedora/fedora:latest
+          command: [bash]
+          env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-token
+                  key: token
+                  optional: true      # skip PR-state check if secret absent; still GC by age
+            - name: REGISTRY
+              value: "192.168.1.102:30500"
+            - name: REPO
+              value: "bluefin-pr"
+            - name: MAX_AGE_DAYS
+              value: "7"
+          source: |
+            set -euo pipefail
+            dnf install -y --quiet oras jq 2>&1 | tail -3
+
+            echo "=== PR image GC: ${REGISTRY}/${REPO} ==="
+
+            # List all tags matching bluefin-pr-*
+            TAGS=$(oras repo tags "${REGISTRY}/${REPO}" --plain-http 2>/dev/null || true)
+            if [[ -z "$TAGS" ]]; then
+              echo "No tags found in ${REGISTRY}/${REPO} — nothing to clean."
+              exit 0
+            fi
+
+            NOW_EPOCH=$(date +%s)
+            DELETED=0
+            KEPT=0
+
+            while IFS= read -r TAG; do
+              [[ "$TAG" == bluefin-pr-* ]] || continue
+
+              # Extract PR number from tag name (bluefin-pr-NNN:sha or bluefin-pr-NNN)
+              PR_NUM=$(echo "$TAG" | grep -oP '(?<=bluefin-pr-)\d+' || true)
+
+              # Check age via manifest created timestamp
+              CREATED=$(oras manifest fetch "${REGISTRY}/${REPO}:${TAG}" --plain-http \
+                | jq -r '.annotations["org.opencontainers.image.created"] // empty' 2>/dev/null || true)
+
+              if [[ -n "$CREATED" ]]; then
+                CREATED_EPOCH=$(date -d "$CREATED" +%s 2>/dev/null || echo 0)
+                AGE_DAYS=$(( (NOW_EPOCH - CREATED_EPOCH) / 86400 ))
+              else
+                AGE_DAYS=999  # unknown age → treat as old
+              fi
+
+              DELETE=false
+
+              # Delete if older than MAX_AGE_DAYS
+              if (( AGE_DAYS >= MAX_AGE_DAYS )); then
+                echo "DELETE ${TAG} (age: ${AGE_DAYS}d >= ${MAX_AGE_DAYS}d)"
+                DELETE=true
+              fi
+
+              # Delete if PR is closed/merged (requires github-token)
+              if [[ -n "${PR_NUM:-}" && -n "${GITHUB_TOKEN:-}" && "$DELETE" == "false" ]]; then
+                PR_STATE=$(curl -sf \
+                  -H "Authorization: token $GITHUB_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/projectbluefin/bluefin/pulls/${PR_NUM}" \
+                  | jq -r '.state // empty' 2>/dev/null || true)
+                if [[ "$PR_STATE" == "closed" ]]; then
+                  echo "DELETE ${TAG} (PR #${PR_NUM} is closed)"
+                  DELETE=true
+                fi
+              fi
+
+              if [[ "$DELETE" == "true" ]]; then
+                oras manifest delete "${REGISTRY}/${REPO}:${TAG}" --plain-http --force 2>&1 && \
+                  DELETED=$((DELETED + 1)) || \
+                  echo "WARNING: failed to delete ${TAG} (non-fatal)"
+              else
+                KEPT=$((KEPT + 1))
+              fi
+            done <<< "$TAGS"
+
+            echo "=== Done: deleted ${DELETED} tag(s), kept ${KEPT} tag(s) ==="

--- a/manifests/registry-mirror-config.yaml
+++ b/manifests/registry-mirror-config.yaml
@@ -3,8 +3,12 @@
 # containerd v2.0 (k3s v1.32+) hot-reloads these — no k3s restart needed.
 #
 # Mirrors configured:
-#   ghcr.io  → ghost:30501 (zot-ghcr)
-#   docker.io → ghost:30502 (zot-docker)
+#   ghcr.io                    → ghost:30501 (zot-ghcr)
+#   docker.io                  → ghost:30502 (zot-docker)
+#   quay.io                    → ghost:30503 (zot-quay)
+#   registry.fedoraproject.org → ghost:30504 (zot-fedora)
+#   registry.access.redhat.com → ghost:30505 (zot-redhat-access)
+#   registry.k8s.io            → ghost:30506 (zot-k8s)
 #
 # To update mirrors: edit ConfigMap below, then:
 #   kubectl rollout restart daemonset/registry-mirror-config -n local-registry
@@ -27,6 +31,26 @@ data:
 
     [host."http://192.168.1.102:30502"]
       capabilities = ["pull", "resolve"]
+  quay.io.hosts.toml: |
+    server = "https://quay.io"
+
+    [host."http://192.168.1.102:30503"]
+      capabilities = ["pull", "resolve"]
+  registry.fedoraproject.org.hosts.toml: |
+    server = "https://registry.fedoraproject.org"
+
+    [host."http://192.168.1.102:30504"]
+      capabilities = ["pull", "resolve"]
+  registry.access.redhat.com.hosts.toml: |
+    server = "https://registry.access.redhat.com"
+
+    [host."http://192.168.1.102:30505"]
+      capabilities = ["pull", "resolve"]
+  registry.k8s.io.hosts.toml: |
+    server = "https://registry.k8s.io"
+
+    [host."http://192.168.1.102:30506"]
+      capabilities = ["pull", "resolve"]
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -48,17 +72,25 @@ spec:
     spec:
       initContainers:
         - name: write-hosts
-          image: busybox:latest
+          image: registry.access.redhat.com/ubi9/ubi-micro:9.5
           command:
             - sh
             - -c
             - |
-              mkdir -p /certs.d/ghcr.io /certs.d/docker.io
-              cp /config/ghcr.io.hosts.toml  /certs.d/ghcr.io/hosts.toml
-              cp /config/docker.io.hosts.toml /certs.d/docker.io/hosts.toml
-              echo "Mirror hosts written:"
-              cat /certs.d/ghcr.io/hosts.toml
-              cat /certs.d/docker.io/hosts.toml
+              mkdir -p \
+                /certs.d/ghcr.io \
+                /certs.d/docker.io \
+                /certs.d/quay.io \
+                /certs.d/registry.fedoraproject.org \
+                /certs.d/registry.access.redhat.com \
+                /certs.d/registry.k8s.io
+              cp /config/ghcr.io.hosts.toml                    /certs.d/ghcr.io/hosts.toml
+              cp /config/docker.io.hosts.toml                  /certs.d/docker.io/hosts.toml
+              cp /config/quay.io.hosts.toml                    /certs.d/quay.io/hosts.toml
+              cp /config/registry.fedoraproject.org.hosts.toml /certs.d/registry.fedoraproject.org/hosts.toml
+              cp /config/registry.access.redhat.com.hosts.toml /certs.d/registry.access.redhat.com/hosts.toml
+              cp /config/registry.k8s.io.hosts.toml            /certs.d/registry.k8s.io/hosts.toml
+              echo "Mirror hosts written."
           volumeMounts:
             - name: certs-d
               mountPath: /certs.d
@@ -68,7 +100,7 @@ spec:
         - name: pause
           # ponytail: sleep loop, this pod only exists to keep the DaemonSet alive
           # so that config is re-applied on pod restart / rollout restart
-          image: busybox:latest
+          image: registry.access.redhat.com/ubi9/ubi-micro:9.5
           command: ["sh", "-c", "while true; do sleep 3600; done"]
           resources:
             requests: { cpu: "1m", memory: "4Mi" }

--- a/manifests/registry-mirror-config.yaml
+++ b/manifests/registry-mirror-config.yaml
@@ -1,0 +1,85 @@
+# Registry mirror config DaemonSet
+# Writes containerd hosts.toml to each node's certs.d path.
+# containerd v2.0 (k3s v1.32+) hot-reloads these — no k3s restart needed.
+#
+# Mirrors configured:
+#   ghcr.io  → ghost:30501 (zot-ghcr)
+#   docker.io → ghost:30502 (zot-docker)
+#
+# To update mirrors: edit ConfigMap below, then:
+#   kubectl rollout restart daemonset/registry-mirror-config -n local-registry
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-mirror-hosts
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  ghcr.io.hosts.toml: |
+    server = "https://ghcr.io"
+
+    [host."http://192.168.1.102:30501"]
+      capabilities = ["pull", "resolve"]
+  docker.io.hosts.toml: |
+    server = "https://registry-1.docker.io"
+
+    [host."http://192.168.1.102:30502"]
+      capabilities = ["pull", "resolve"]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: registry-mirror-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-cache
+spec:
+  selector:
+    matchLabels:
+      app: registry-mirror-config
+  template:
+    metadata:
+      labels:
+        app: registry-mirror-config
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      initContainers:
+        - name: write-hosts
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /certs.d/ghcr.io /certs.d/docker.io
+              cp /config/ghcr.io.hosts.toml  /certs.d/ghcr.io/hosts.toml
+              cp /config/docker.io.hosts.toml /certs.d/docker.io/hosts.toml
+              echo "Mirror hosts written:"
+              cat /certs.d/ghcr.io/hosts.toml
+              cat /certs.d/docker.io/hosts.toml
+          volumeMounts:
+            - name: certs-d
+              mountPath: /certs.d
+            - name: config
+              mountPath: /config
+      containers:
+        - name: pause
+          # ponytail: sleep loop, this pod only exists to keep the DaemonSet alive
+          # so that config is re-applied on pod restart / rollout restart
+          image: busybox:latest
+          command: ["sh", "-c", "while true; do sleep 3600; done"]
+          resources:
+            requests: { cpu: "1m", memory: "4Mi" }
+            limits: { cpu: "10m", memory: "16Mi" }
+      volumes:
+        - name: certs-d
+          hostPath:
+            path: /var/lib/rancher/k3s/agent/etc/containerd/certs.d
+            type: DirectoryOrCreate
+        - name: config
+          configMap:
+            name: registry-mirror-hosts
+      tolerations:
+        - operator: Exists

--- a/manifests/rocm-device-plugin.yaml
+++ b/manifests/rocm-device-plugin.yaml
@@ -41,7 +41,7 @@ spec:
           operator: Exists
       containers:
         - name: amdgpu-dp
-          image: docker.io/rocm/k8s-device-plugin:1.31.0.10
+          image: docker.io/rocm/k8s-device-plugin:1.31.0.10 # registry-lint-ignore: no upstream k8s/CNCF equivalent
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -1,11 +1,15 @@
 # Zot pull-through cache instances — one per upstream registry
-# ghcr.io  → zot-ghcr  NodePort 30501
-# docker.io → zot-docker NodePort 30502
+# ghcr.io                    → zot-ghcr           NodePort 30501
+# docker.io                  → zot-docker          NodePort 30502
+# quay.io                    → zot-quay            NodePort 30503
+# registry.fedoraproject.org → zot-fedora          NodePort 30504
+# registry.access.redhat.com → zot-redhat-access   NodePort 30505
+# registry.k8s.io            → zot-k8s             NodePort 30506
 #
 # containerd on each node routes pulls through these via
 # manifests/registry-mirror-config.yaml (hosts.toml DaemonSet, no k3s restart needed)
 #
-# Storage: hostPath on ghost at /var/mnt/ghost-data/zot-{ghcr,docker}/
+# Storage: hostPath on ghost at /var/mnt/ghost-data/zot-{ghcr,docker,quay,fedora,redhat,k8s}/
 # ArgoCD: testing-lab-infra syncs this
 ---
 apiVersion: v1
@@ -207,3 +211,379 @@ spec:
     - port: 5000
       targetPort: 5000
       nodePort: 30502
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-quay-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": { "rootDirectory": "/var/lib/registry", "gc": true },
+      "http": { "address": "0.0.0.0", "port": "5000" },
+      "log": { "level": "warn" },
+      "extensions": {
+        "sync": {
+          "enable": true,
+          "registries": [{
+            "urls": ["https://quay.io"],
+            "onDemand": true,
+            "tlsVerify": true,
+            "content": [{ "prefix": "**" }]
+          }]
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot-quay
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zot-quay
+  template:
+    metadata:
+      labels:
+        app: zot-quay
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+            - name: data
+              mountPath: /var/lib/registry
+          resources:
+            requests: { cpu: "100m", memory: "128Mi" }
+            limits: { cpu: "1", memory: "2Gi" }
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: zot-quay-config
+        - name: data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-quay
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-quay
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app: zot-quay
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30503
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-fedora-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": { "rootDirectory": "/var/lib/registry", "gc": true },
+      "http": { "address": "0.0.0.0", "port": "5000" },
+      "log": { "level": "warn" },
+      "extensions": {
+        "sync": {
+          "enable": true,
+          "registries": [{
+            "urls": ["https://registry.fedoraproject.org"],
+            "onDemand": true,
+            "tlsVerify": true,
+            "content": [{ "prefix": "**" }]
+          }]
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot-fedora
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zot-fedora
+  template:
+    metadata:
+      labels:
+        app: zot-fedora
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+            - name: data
+              mountPath: /var/lib/registry
+          resources:
+            requests: { cpu: "100m", memory: "128Mi" }
+            limits: { cpu: "1", memory: "2Gi" }
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: zot-fedora-config
+        - name: data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-fedora
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-fedora
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app: zot-fedora
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30504
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-redhat-access-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": { "rootDirectory": "/var/lib/registry", "gc": true },
+      "http": { "address": "0.0.0.0", "port": "5000" },
+      "log": { "level": "warn" },
+      "extensions": {
+        "sync": {
+          "enable": true,
+          "registries": [{
+            "urls": ["https://registry.access.redhat.com"],
+            "onDemand": true,
+            "tlsVerify": true,
+            "content": [{ "prefix": "**" }]
+          }]
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot-redhat-access
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zot-redhat-access
+  template:
+    metadata:
+      labels:
+        app: zot-redhat-access
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+            - name: data
+              mountPath: /var/lib/registry
+          resources:
+            requests: { cpu: "100m", memory: "128Mi" }
+            limits: { cpu: "1", memory: "2Gi" }
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: zot-redhat-access-config
+        - name: data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-redhat-access
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-redhat-access
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app: zot-redhat-access
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30505
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-k8s-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": { "rootDirectory": "/var/lib/registry", "gc": true },
+      "http": { "address": "0.0.0.0", "port": "5000" },
+      "log": { "level": "warn" },
+      "extensions": {
+        "sync": {
+          "enable": true,
+          "registries": [{
+            "urls": ["https://registry.k8s.io"],
+            "onDemand": true,
+            "tlsVerify": true,
+            "content": [{ "prefix": "**" }]
+          }]
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot-k8s
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zot-k8s
+  template:
+    metadata:
+      labels:
+        app: zot-k8s
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+            - name: data
+              mountPath: /var/lib/registry
+          resources:
+            requests: { cpu: "100m", memory: "128Mi" }
+            limits: { cpu: "1", memory: "2Gi" }
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: zot-k8s-config
+        - name: data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-k8s
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-k8s
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app: zot-k8s
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30506

--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -1,0 +1,209 @@
+# Zot pull-through cache instances — one per upstream registry
+# ghcr.io  → zot-ghcr  NodePort 30501
+# docker.io → zot-docker NodePort 30502
+#
+# containerd on each node routes pulls through these via
+# manifests/registry-mirror-config.yaml (hosts.toml DaemonSet, no k3s restart needed)
+#
+# Storage: hostPath on ghost at /var/mnt/ghost-data/zot-{ghcr,docker}/
+# ArgoCD: testing-lab-infra syncs this
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-ghcr-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": {
+        "rootDirectory": "/var/lib/registry",
+        "gc": true
+      },
+      "http": {
+        "address": "0.0.0.0",
+        "port": "5000"
+      },
+      "log": { "level": "info" },
+      "extensions": {
+        "sync": {
+          "enable": true,
+          "registries": [{
+            "urls": ["https://ghcr.io"],
+            "onDemand": true,
+            "tlsVerify": true,
+            "content": [{ "prefix": "**" }]
+          }]
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot-ghcr
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zot-ghcr
+  template:
+    metadata:
+      labels:
+        app: zot-ghcr
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+            - name: data
+              mountPath: /var/lib/registry
+          resources:
+            requests: { cpu: "100m", memory: "128Mi" }
+            limits: { cpu: "1", memory: "2Gi" }
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: zot-ghcr-config
+        - name: data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-ghcr
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-ghcr
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app: zot-ghcr
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30501
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-docker-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": {
+        "rootDirectory": "/var/lib/registry",
+        "gc": true
+      },
+      "http": {
+        "address": "0.0.0.0",
+        "port": "5000"
+      },
+      "log": { "level": "info" },
+      "extensions": {
+        "sync": {
+          "enable": true,
+          "registries": [{
+            "urls": ["https://registry-1.docker.io"],
+            "onDemand": true,
+            "tlsVerify": true,
+            "content": [{ "prefix": "**" }]
+          }]
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot-docker
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zot-docker
+  template:
+    metadata:
+      labels:
+        app: zot-docker
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+            - name: data
+              mountPath: /var/lib/registry
+          resources:
+            requests: { cpu: "100m", memory: "128Mi" }
+            limits: { cpu: "1", memory: "2Gi" }
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: zot-docker-config
+        - name: data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-docker
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-docker
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app: zot-docker
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30502

--- a/manifests/zot-writable.yaml
+++ b/manifests/zot-writable.yaml
@@ -1,0 +1,96 @@
+# Writable OCI registry at NodePort 30500 — BIB push target and PR image store.
+# Replaces the unmanaged registry:2 Deployment that was running outside GitOps.
+# No upstream proxy — write-only / local storage.
+# GC enabled: orphaned layers reclaimed after 1h delay, checked every 24h.
+# ArgoCD: testing-lab-infra syncs this
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-local-config
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": {
+        "rootDirectory": "/var/lib/registry",
+        "gc": true,
+        "gcDelay": "1h",
+        "gcInterval": "24h"
+      },
+      "http": {
+        "address": "0.0.0.0",
+        "port": "5000"
+      },
+      "log": { "level": "warn" }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+    app.kubernetes.io/component: registry-local
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+            - name: data
+              mountPath: /var/lib/registry
+          resources:
+            requests: { cpu: "100m", memory: "256Mi" }
+            limits: { cpu: "2", memory: "4Gi" }
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: zot-local-config
+        - name: data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-local
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app: registry
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30500


### PR DESCRIPTION
## Summary

This PR contains phases 0–7 of the cluster improvement plan.

### Phase 0 — Pre-flight bug fixes ✅
- **0a**: Unlock `golden-disk-gc` from dry-run mode (GC was never deleting)
- **0b**: Normalize `192.168.1.102:5000` → `30500` in bib-build-and-push, dakota-qa-pipeline
- **0c**: Add `manifests/zot-writable.yaml` — writable Zot at NodePort 30500 under GitOps control

### Phase 1 — Fill Zot coverage gaps ✅
- Add zot-quay (30503), zot-fedora (30504), zot-redhat-access (30505), zot-k8s (30506)
- Update registry-mirror-config.yaml with all 6 mirrors

### Phase 2 — Hummingbird image migration ✅
- Replace cgr.dev, alpine, busybox, python:3.12-slim, nginx:1.27.5-alpine, fedora:41
- Upstream registry.k8s.io/kubectl:v1.32.0 retained (Option A)

### Phase 3 — CI lint gate for uncached registries ✅
- Registry allowlist check added to .github/workflows/lint.yaml

### Phase 4 — LLM float ✅
- Remove `nodeSelector: kubernetes.io/hostname: ghost` from llm-d.yaml
- Bump memory request 40Gi → 48Gi (scheduler float mechanism)
- All Strix Halo ROCm env vars preserved
- **Ops step** (not in PR): `oras push 192.168.1.102:30500/llm-models/gemma-4-31B-it-Q8_0:latest <gguf>`

### Phase 5 — ARC runner improvements ✅
- Add buildah-cache hostPath volume to arc-runners-app.yaml
- Add `images/arc-runner/Containerfile` (hummingbird base + buildah/skopeo/cosign/oras/argo)
- **Ops step** (not in PR): build and push custom runner image to 192.168.1.102:30500/arc-runner:latest

### Phase 6 — PR pipeline wiring ✅
- **6b**: Add `pr-number`/`sha`/`repo` optional params to bluefin-qa-pipeline
  - `onExit: teardown` → `onExit: cleanup-and-report` (teardown + conditional GitHub commit status)
  - **Ops step**: `kubectl create secret generic github-token --from-literal=token=<PAT> -n argo`
- **6c**: Add `manifests/pr-image-gc.yaml` CronWorkflow — daily 03:00 UTC, deletes `bluefin-pr-*` tags older than 7d or whose PR is closed
- **6d** (not in PR): ARC runner job in projectbluefin/bluefin repo

### Phase 7 — System contract tests ✅
- `run-system` task added to bluefin-qa-pipeline DAG (reuses run-gnome-tests suite=system)
- `tests/system/features/` exists with bootc/filesystem/integrity/uupd feature files + step impls
- Nightly already runs `smoke,developer,system`

### Post-merge ops checklist
See issue #234 for the rollout steps.