### PR TITLE
feat: add Botkube v1.14.0 for Discord ChatOps

### DIFF
--- a/argocd/botkube-app.yaml
+++ b/argocd/botkube-app.yaml
@@ -1,0 +1,98 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: botkube
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  project: default
+  source:
+    repoURL: https://charts.botkube.io
+    chart: botkube
+    targetRevision: v1.14.0
+    helm:
+      # ponytail: inline valuesObject keeps values co-located with the Application,
+      # avoids multi-source ArgoCD config (requires ArgoCD >= 2.6).
+      # Secret values injected via secretKeyRef — never in plaintext here.
+      valuesObject:
+        communications:
+          default-group:
+            discord:
+              enabled: true
+              token:
+                valueFrom:
+                  secretKeyRef:
+                    name: botkube-discord
+                    key: token
+              botID: "1519228970032169050"
+              channels:
+                default:
+                  id: "1519233261438631936"  # #factory channel
+                  bindings:
+                    executors:
+                      - kubectl-read-only
+                      - github-dispatch
+                    sources:
+                      - k8s-err-with-logs
+        settings:
+          clusterName: "bluefin-factory"
+        rbac:
+          groups: []
+        executors:
+          kubectl-read-only:
+            botkube/kubectl:
+              enabled: true
+              config:
+                allowedVerbs: ["get", "describe", "logs", "top"]
+                allowedResources:
+                  - nodes
+                  - pods
+                  - namespaces
+                  - workflows
+          github-dispatch:
+            botkube/github:
+              enabled: true
+              config:
+                github:
+                  auth:
+                    appID:
+                      valueFrom:
+                        secretKeyRef:
+                          name: botkube-github-app
+                          key: appID
+                    installationID:
+                      valueFrom:
+                        secretKeyRef:
+                          name: botkube-github-app
+                          key: installationID
+                    privateKey:
+                      valueFrom:
+                        secretKeyRef:
+                          name: botkube-github-app
+                          key: privateKey
+        sources:
+          k8s-err-with-logs:
+            botkube/kubernetes:
+              enabled: true
+              config:
+                event:
+                  types: ["error"]
+                resources:
+                  - type: v1/pods
+                  - type: batch/jobs
+                  - type: argoproj.io/v1alpha1/Workflows
+        plugins:
+          repositories:
+            botkube:
+              url: https://github.com/kubeshop/botkube-plugins/releases/download/v1.14.0/plugins-index.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: botkube
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/botkube/values.yaml
+++ b/botkube/values.yaml
@@ -1,0 +1,76 @@
+# Botkube v1.14.0 — Bluefin factory ChatOps
+# ponytail: minimal config — only Discord + GitHub + kubectl plugins enabled
+
+communications:
+  default-group:
+    discord:
+      enabled: true
+      # token injected from botkube-discord k8s secret at deploy time
+      token: "${DISCORD_TOKEN}"
+      botID: "1519228970032169050"
+      channels:
+        default:
+          id: "1519233261438631936"  # #factory channel
+          notification:
+            disabled: false
+          bindings:
+            executors:
+              - kubectl-read-only
+              - github-dispatch
+            sources:
+              - k8s-err-with-logs
+
+settings:
+  clusterName: "bluefin-factory"
+
+# RBAC note: Botkube v1.14 rbac.groups renders K8s ClusterRole objects, NOT
+# Discord-role auth. Authorization for github-dispatch is enforced via channel
+# isolation — only Maintainer role can see/post in the channel where
+# github-dispatch is bound (Task 3, Discord Developer Portal command permissions).
+rbac:
+  groups: []
+
+executors:
+  kubectl-read-only:
+    botkube/kubectl:
+      enabled: true
+      context:
+        defaultNamespace: default
+      config:
+        # read-only verbs; write access requires explicit Maintainer role gate
+        allowedVerbs: ["get", "describe", "logs", "top"]
+        allowedResources:
+          - nodes
+          - pods
+          - namespaces
+          - workflows  # Argo Workflows
+
+  github-dispatch:
+    botkube/github:
+      enabled: true
+      config:
+        github:
+          auth:
+            # GitHub App auth — no PAT
+            appID: "${GITHUB_APP_ID}"
+            installationID: "${GITHUB_APP_INSTALLATION_ID}"
+            privateKey: "${GITHUB_APP_PRIVATE_KEY}"
+
+sources:
+  k8s-err-with-logs:
+    botkube/kubernetes:
+      enabled: true
+      config:
+        event:
+          types:
+            - error
+          reason: ""
+        resources:
+          - type: v1/pods
+          - type: batch/jobs
+          - type: argoproj.io/v1alpha1/Workflows
+
+plugins:
+  repositories:
+    botkube:
+      url: https://github.com/kubeshop/botkube-plugins/releases/download/v1.14.0/plugins-index.yaml


### PR DESCRIPTION
Deploys Botkube on the ghost k3s cluster via ArgoCD for Discord ChatOps in #factory.

## Changes

- `argocd/botkube-app.yaml` — ArgoCD Application manifest (Helm chart from charts.botkube.io)
- `botkube/values.yaml` — Botkube Helm values (reference copy; ArgoCD uses inline valuesObject in app manifest)

## What this enables

- `@Bluefin kubectl get nodes/pods/logs` in #factory (all members, read-only)
- `@Bluefin github run-workflow` in #factory (Maintainer role only via channel isolation)
- k8s error alerts (pod crashes, job failures, Argo Workflow errors) → #factory

## Channel

#factory text channel ID: `1519233261438631936` (created and webhook configured)

## Human prereqs before merging/syncing

1. Create GitHub App "Bluefin Botkube": github.com/organizations/projectbluefin/settings/apps
   - Permissions: Actions read/write, Contents read-only
   - Install on: bluefin, bluefin-lts, dakota, common, actions
2. Store secrets on ghost k8s:
   ```bash
   kubectl create namespace botkube
   kubectl create secret generic botkube-discord --namespace botkube --from-literal=token=<BOT_TOKEN>
   kubectl create secret generic botkube-github-app --namespace botkube --from-literal=appID=<ID> --from-literal=installationID=<INSTALL_ID> --from-file=privateKey=bluefin-botkube.pem
   ```
3. After sync: restrict github-dispatch to Maintainer role via Discord Developer Portal

ArgoCD will auto-sync once the Application is committed and secrets exist.