### PR TITLE
fix(lab): pin bluefin test VMs to bazzite, add restorecon for authorized_keys

### DIFF
--- a/argo/workflow-templates/provision-bluefin-vm.yaml
+++ b/argo/workflow-templates/provision-bluefin-vm.yaml
@@ -82,6 +82,12 @@ spec:
                 labels:
                   kubevirt.io/vm: "{{inputs.parameters.vm-name}}"
               spec:
+                # Pin VMs to bazzite (dedicated test worker).
+                # When VMs land on ghost (control-plane), KubeVirt masquerade NAT
+                # is unreachable from workflow pods that also run on ghost — SSH
+                # port becomes inaccessible. Bazzite → ghost flannel path works.
+                nodeSelector:
+                  kubernetes.io/hostname: bazzite
                 # Inject SSH public key at runtime via QEMU guest agent.
                 # This is reliable regardless of disk content — KubeVirt connects
                 # to the running guest agent and writes ~/.ssh/authorized_keys.

--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -205,6 +205,10 @@ spec:
               printf '%s\n' '${SSH_PUBKEY}' > /var/home/bluefin-test/.ssh/authorized_keys
               chown 1001:1001 /var/home/bluefin-test/.ssh/authorized_keys
               chmod 600 /var/home/bluefin-test/.ssh/authorized_keys
+              # Restore SELinux file contexts so sshd can read authorized_keys.
+              # Files created by root in a user's homedir inherit the wrong context
+              # without restorecon (e.g. admin_home_t instead of ssh_home_t).
+              restorecon -Rv /var/home/bluefin-test/.ssh/ 2>/dev/null || true
               echo '[ROOT] bluefin-test authorized_keys written:'
               cat /var/home/bluefin-test/.ssh/authorized_keys
               # Enable user lingering so rootless Podman services survive login/logout.
@@ -215,7 +219,10 @@ spec:
             # Wait for bluefin-test SSH to work (short retry loop).
             echo "Verifying bluefin-test SSH..." >&2
             timeout 120 bash -c "
-              until ${SSH} 'echo ready' 2>/dev/null; do sleep 5; done
+              until ${SSH} 'echo ready' 2>&1; do
+                echo '[bluefin-test SSH] not ready, retrying...' >&2
+                sleep 5
+              done
             "
             echo "SSH ready (bluefin-test)." >&2
 


### PR DESCRIPTION
Two fixes for the persistent bluefin-test SSH failure (exit code 124/143) blocking PR promotion workflows:

**1. Pin VMs to bazzite (provision-bluefin-vm.yaml)**

When VMs land on ghost (control-plane), the KubeVirt masquerade NAT iptables rules live in the virt-launcher pod's netns on ghost. Workflow pods also run on ghost, so the ghost→ghost traffic path bypasses the expected flannel overlay and port 22 is unreachable. Pinning to bazzite ensures the path is always ghost→flannel→bazzite→VM which works.

**2. restorecon after writing authorized_keys (run-gnome-tests.yaml)**

Files created by root in /var/home/bluefin-test/.ssh/ get admin_home_t SELinux context. sshd refuses to read authorized_keys with that context. restorecon -Rv fixes it to ssh_home_t.

Also surfaces SSH errors in the verify loop (was 2>/dev/null, now 2>&1).

Seen failing in: blu-709 (8 runs), blu-725 (multiple runs). Both fixes needed.