### PR TITLE
fix(lab): chcon fallback + diagnostics for bluefin-test SSH auth

### DIFF
--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -206,11 +206,18 @@ spec:
               chown 1001:1001 /var/home/bluefin-test/.ssh/authorized_keys
               chmod 600 /var/home/bluefin-test/.ssh/authorized_keys
               # Restore SELinux file contexts so sshd can read authorized_keys.
-              # Files created by root in a user's homedir inherit the wrong context
-              # without restorecon (e.g. admin_home_t instead of ssh_home_t).
-              restorecon -Rv /var/home/bluefin-test/.ssh/ 2>/dev/null || true
+              # Falls back to chcon if restorecon is not available.
+              restorecon -Rv /var/home/bluefin-test/.ssh/ 2>/dev/null || \
+                chcon -t ssh_home_t /var/home/bluefin-test/.ssh/ \
+                               /var/home/bluefin-test/.ssh/authorized_keys 2>/dev/null || true
               echo '[ROOT] bluefin-test authorized_keys written:'
               cat /var/home/bluefin-test/.ssh/authorized_keys
+              echo '[ROOT] SELinux context and permissions:'
+              ls -laZ /var/home/bluefin-test/.ssh/ 2>&1 || ls -la /var/home/bluefin-test/.ssh/
+              echo '[ROOT] bluefin-test passwd entry:'
+              getent passwd bluefin-test
+              echo '[ROOT] sshd AuthorizedKeysFile config:'
+              sshd -T 2>/dev/null | grep -i 'authorizedkeys\|strictmodes\|pubkeyauthentication' | head -5
               # Enable user lingering so rootless Podman services survive login/logout.
               # Required by the developer suite 'User lingering is enabled' assertion.
               loginctl enable-linger bluefin-test 2>/dev/null || true


### PR DESCRIPTION
restorecon may not be in all images. Add chcon fallback to set ssh_home_t on .ssh/ and authorized_keys directly.

Also add diagnostic output (ls -laZ, getent passwd, sshd -T) to surface root cause when SSH auth still fails.