### PR TITLE
fix(lab): add per-user sshd -T and authorized_keys dump diagnostics

### DIFF
--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -215,8 +215,16 @@ spec:
               printf '%s\n' '${SSH_PUBKEY}' > /etc/ssh/authorized_keys/bluefin-test 2>/dev/null || true
               chmod 600 /etc/ssh/test-authorized-keys /etc/ssh/authorized_keys/bluefin-test 2>/dev/null || true
               echo '[ROOT] bluefin-test authorized_keys written (all locations)'
-              echo '[ROOT] sshd AuthorizedKeysFile:'
-              sshd -T 2>/dev/null | grep -i 'authorizedkeysfile' | head -3 || echo 'sshd -T unavailable'
+              echo '[ROOT] /etc/ssh/test-authorized-keys contents:'
+              cat /etc/ssh/test-authorized-keys 2>/dev/null || echo '(file not found)'
+              echo '[ROOT] /etc/ssh/authorized_keys/bluefin-test:'
+              cat /etc/ssh/authorized_keys/bluefin-test 2>/dev/null || echo '(file not found)'
+              echo '[ROOT] sshd -T (global):'
+              sshd -T 2>/dev/null | grep -i 'authorizedkeysfile\|allowusers\|denyusers\|permituserenv\|usepam\|passwordauth' | head -10 || echo 'sshd -T unavailable'
+              echo '[ROOT] sshd -T -C user=bluefin-test (per-user):'
+              sshd -T -C user=bluefin-test,addr=127.0.0.1,host=localhost,laddr=127.0.0.1,lport=22 2>/dev/null | grep -i 'authorizedkeysfile\|allowusers\|denyusers\|passwordauth' | head -10 || echo 'sshd -T -C unavailable'
+              echo '[ROOT] sshd_config drop-ins:'
+              grep -r 'AuthorizedKeys\|AllowUsers\|DenyUsers' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null || echo '(none found)'
               # Enable user lingering so rootless Podman services survive login/logout.
               # Required by the developer suite 'User lingering is enabled' assertion.
               loginctl enable-linger bluefin-test 2>/dev/null || true


### PR DESCRIPTION
Authorized_keys write to all locations succeeds but bluefin-test SSH still fails. Adding deep diagnostics to find the real blocker: cat key files to verify write, sshd -T -C user=bluefin-test for per-user Match blocks, grep sshd_config for AllowUsers/DenyUsers.