### PR TITLE
fix(lab): unlock bluefin-test account and write key to correct path

### DIFF
--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -183,6 +183,7 @@ spec:
             # SSH keys are set up here rather than relying on disk injection.
             echo "Bootstrapping bluefin-test user and SSH access via root..." >&2
             SSH_PUBKEY="$(cat ${SSH_KEY}.pub)"
+            SSH_PUBKEY="$(cat ${SSH_KEY}.pub)"
             ${ROOT_SSH} "
               set -euo pipefail
               # Create bluefin-test user if not already present (uid 1001, wheel)
@@ -193,16 +194,23 @@ spec:
               else
                 echo '[ROOT] bluefin-test user exists'
               fi
+              # Unlock account: useradd without a password locks the account (!).
+              # With UsePAM no, sshd rejects locked accounts before checking keys.
+              passwd -u bluefin-test 2>/dev/null || usermod -p '*' bluefin-test
               # Ensure home directory and .ssh exist with correct ownership/permissions.
-              # KubeVirt qemuGuestAgent injects the key to ~/.ssh/authorized_keys for
-              # both root and bluefin-test (provision-bluefin-vm.yaml accessCredentials).
-              # We ensure the directory exists so the injection has a place to land.
-              mkdir -p /var/home/bluefin-test
-              chown 1001:1001 /var/home/bluefin-test
-              chmod 750 /var/home/bluefin-test
               mkdir -p /var/home/bluefin-test/.ssh
-              chown 1001:1001 /var/home/bluefin-test/.ssh
+              chown -R 1001:1001 /var/home/bluefin-test
+              chmod 750 /var/home/bluefin-test
               chmod 700 /var/home/bluefin-test/.ssh
+              # Write key to ~/.ssh/authorized_keys (KubeVirt accessCredentials target)
+              # and to /etc/ssh/test-authorized-keys (old containerdisk sshd config).
+              # Both paths covered so this works across all disk versions.
+              printf '%s\n' '${SSH_PUBKEY}' > /var/home/bluefin-test/.ssh/authorized_keys
+              chown 1001:1001 /var/home/bluefin-test/.ssh/authorized_keys
+              chmod 600 /var/home/bluefin-test/.ssh/authorized_keys
+              printf '%s\n' '${SSH_PUBKEY}' >> /etc/ssh/test-authorized-keys 2>/dev/null || true
+              mkdir -p /etc/ssh/authorized_keys
+              printf '%s\n' '${SSH_PUBKEY}' > /etc/ssh/authorized_keys/bluefin-test 2>/dev/null || true
               # Ensure sudoers entry
               echo 'bluefin-test ALL=(ALL) NOPASSWD:ALL' \
                 > /etc/sudoers.d/bluefin-test


### PR DESCRIPTION
Two root-cause bugs causing persistent Permission denied for bluefin-test SSH.

Bug 1: Account locked. useradd without a password creates a shadow entry with ! (locked). With UsePAM no in sshd, locked accounts are rejected before key checks. Traced via sshd journal: 'User bluefin-test not allowed because account is locked'.

Bug 2: Key in wrong location. KubeVirt accessCredentials writes to ~/.ssh/authorized_keys. The containerdisk sshd config uses AuthorizedKeysFile /etc/ssh/test-authorized-keys. Fix writes the key to both paths from the mounted SSH secret.

Fixes PR #725 gate blocker.