### PR TITLE
fix(lab): set PYTHONPATH for behave so tests.shared resolves

### DIFF
--- a/argo/workflow-templates/run-gnome-tests.yaml
+++ b/argo/workflow-templates/run-gnome-tests.yaml
@@ -309,6 +309,7 @@ spec:
             if [[ "${SUITE}" == "system" ]]; then
               ${SSH} "
                 export PATH=\$HOME/.local/bin:\$PATH
+                export PYTHONPATH=/tmp/bluefin-tests
                 python3 -m behave /tmp/bluefin-tests/${SUITE}/features/ --format json.pretty --outfile /tmp/results/results.json --no-capture ${TAGS_ARG}
               " || BEHAVE_RC=$?
             else
@@ -316,6 +317,7 @@ spec:
               # when passing compound commands to qecore-headless.
               ${SSH} "printf '%s\n' '#!/bin/bash' 'set -euo pipefail' \
                 'export PATH=\$HOME/.local/bin:\$PATH' \
+                'export PYTHONPATH=/tmp/bluefin-tests' \
                 'python3 /tmp/bluefin-tests/${SUITE}/wait_for_shell.py' \
                 '# Start gnome-ponytail-daemon after GNOME Shell is ready.' \
                 '# D-Bus cannot auto-activate it (ServiceUnknown) in the qecore-headless' \


### PR DESCRIPTION
environment.py imports from tests.shared (tests.shared.timing etc.). tests/shared/ is copied to /tmp/bluefin-tests/tests/shared/ but Python needs PYTHONPATH=/tmp/bluefin-tests to resolve the tests package root.