### PR TITLE
fix(post-github-status): replace jq with shell string interpolation

### DIFF
--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -390,12 +390,8 @@ spec:
                 key: token
         source: |
           STATE=$([ "{{workflow.status}}" = "Succeeded" ] && echo success || echo failure)
-          PAYLOAD=$(jq -n \
-            --arg state "$STATE" \
-            --arg ctx  "ghost-lab" \
-            --arg desc "Bluefin lab test $STATE" \
-            --arg url  "http://192.168.1.102:32746/workflows/argo/{{workflow.name}}" \
-            '{state:$state,context:$ctx,description:$desc,target_url:$url}')
+          URL="http://192.168.1.102:32746/workflows/argo/{{workflow.name}}"
+          PAYLOAD="{\"state\":\"${STATE}\",\"context\":\"ghost-lab\",\"description\":\"Bluefin lab test ${STATE}\",\"target_url\":\"${URL}\"}"
           curl -sf -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
jq is not present in quay.io/fedora/fedora:latest. The GitHub commit status was never posted, leaving ghost-lab permanently in 'pending' state after every workflow run.

Replace the jq JSON builder with direct shell string interpolation. The values (state=success/failure, context, description, URL) contain no special JSON characters so interpolation is safe and no external tool is needed.

This fixes the root blocker for automated PR promotion: with ghost-lab stuck at 'pending', the pr-label-poller never retests PRs and the merge queue gate never gets a result.