### PR TITLE
feat(infra): add system-upgrade-controller and k3s node onboarding docs

### DIFF
--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -1,0 +1,127 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: dakota-build-pipeline
+  namespace: argo
+  annotations:
+    description: |
+      Parallel dakota BST build pipeline. Builds bluefin and bluefin-nvidia OCI variants
+      in parallel against the in-cluster buildbox-casd CAS on ghost. Triggered by push to
+      dakota:testing via GHA cluster-build.yml. On success, exports to local Zot (:30500).
+      Uses bst-build PriorityClass — preemptable by lab-test-vm pods.
+  labels:
+    app.kubernetes.io/component: dakota-build
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  serviceAccountName: argo
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: semaphore-config
+          key: max-bst-builds
+  activeDeadlineSeconds: 7200
+
+  arguments:
+    parameters:
+      - name: repo
+        value: "https://github.com/projectbluefin/dakota.git"
+      - name: ref
+        value: "testing"
+
+  entrypoint: build
+
+  templates:
+
+    - name: build
+      dag:
+        tasks:
+          - name: build-bluefin
+            template: bst-build
+            arguments:
+              parameters:
+                - name: element
+                  value: "oci/bluefin.bst"
+                - name: tag
+                  value: "dakota-cluster-testing"
+          - name: build-bluefin-nvidia
+            template: bst-build
+            arguments:
+              parameters:
+                - name: element
+                  value: "oci/bluefin-nvidia.bst"
+                - name: tag
+                  value: "dakota-cluster-testing-nvidia"
+
+    - name: bst-build
+      priorityClassName: bst-build
+      inputs:
+        parameters:
+          - name: element
+          - name: tag
+      volumes:
+        - name: fuse
+          hostPath:
+            path: /dev/fuse
+        - name: bst-cache
+          emptyDir: {}
+      script:
+        image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
+        command: [bash]
+        securityContext:
+          privileged: true
+          seLinuxOptions:
+            type: spc_t
+        resources:
+          requests:
+            cpu: "4"
+            memory: 16Gi
+          limits:
+            cpu: "8"
+            memory: 28Gi
+        volumeMounts:
+          - name: fuse
+            mountPath: /dev/fuse
+          - name: bst-cache
+            mountPath: /root/.cache/buildstream
+        source: |
+          set -euo pipefail
+
+          # Write in-cluster BST config — plain gRPC to in-cluster casd, no TLS
+          cat > /tmp/buildstream-cluster.conf << 'BSTCONF'
+          cache:
+            storage-service:
+              url: http://buildbox-casd.local-registry.svc.cluster.local:11002
+              push: true
+          BSTCONF
+
+          BST_CONF=/tmp/buildstream-cluster.conf
+          ELEMENT="{{inputs.parameters.element}}"
+          TAG="{{inputs.parameters.tag}}"
+          REF="{{workflow.parameters.ref}}"
+          REPO="{{workflow.parameters.repo}}"
+
+          echo "=== Cloning dakota @ ${REF} ==="
+          git clone --depth=1 --branch "${REF}" "${REPO}" /src
+          cd /src
+
+          echo "=== Building ${ELEMENT} ==="
+          bst --config "${BST_CONF}" \
+              --no-interactive \
+              -o x86_64_v3 true \
+              build "${ELEMENT}"
+
+          echo "=== Exporting ${ELEMENT} ==="
+          EXPORT_DIR="/tmp/export-$(basename ${ELEMENT} .bst)"
+          mkdir -p "${EXPORT_DIR}"
+          bst --config "${BST_CONF}" \
+              --no-interactive \
+              artifact checkout "${ELEMENT}" \
+              --directory "${EXPORT_DIR}"
+
+          echo "=== Pushing to local Zot ==="
+          skopeo copy \
+            --dest-tls-verify=false \
+            "oci:${EXPORT_DIR}" \
+            "docker://192.168.1.102:30500/${TAG}:latest"
+
+          echo "=== Build complete: 192.168.1.102:30500/${TAG}:latest ==="

--- a/docs/agent-cheatsheet.md
+++ b/docs/agent-cheatsheet.md
@@ -391,3 +391,121 @@ If the file is missing, delete the pod and let the init container re-download it
 - `hostNetwork: true` + `hostIPC: true` required for ROCm IPC
 - `HSA_OVERRIDE_GFX_VERSION=11.5.1` required — gfx1151 is RDNA 3.5, not RDNA 4
 - Qwen3 uses chain-of-thought thinking by default; add `/no_think` prefix or increase `max_tokens`
+
+---
+
+## 14. Node onboarding — adding a worker to the cluster
+
+All nodes in this cluster run immutable Linux (Bluefin, Dakota, Bazzite — ostree-based).
+`/usr/local/bin` is a symlink to `/var/usrlocal/bin` (the writable overlay). The k3s install
+script must be told to use this path or it fails on a fresh system.
+
+### Get the join token (run from ghost or this workstation)
+
+```bash
+ssh jorge@192.168.1.102 "sudo cat /var/lib/rancher/k3s/server/node-token"
+```
+
+### Bootstrap a new worker node (run ON the new node, with sudo)
+
+```bash
+# 1. Ensure writable bin directory exists (required on ostree/immutable Linux)
+sudo mkdir -p /var/usrlocal/bin
+
+# 2. Install k3s agent — joins the cluster immediately
+curl -sfL https://get.k3s.io | \
+  K3S_URL="https://192.168.1.102:6443" \
+  K3S_TOKEN="<token from above>" \
+  INSTALL_K3S_BIN_DIR="/var/usrlocal/bin" \
+  sh -s -
+
+# 3. Disable auto-start — nodes opt in to the cluster (see Justfile below)
+sudo systemctl disable k3s-agent
+
+# 4. Install sleep inhibitor (prevents suspend while k3s is active — critical for laptops)
+sudo tee /etc/systemd/system/k3s-sleep-inhibit.service << 'EOF'
+[Unit]
+Description=Inhibit sleep while k3s agent is running
+BindsTo=k3s-agent.service
+After=k3s-agent.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/systemd-inhibit --what=sleep:handle-lid-switch --who=k3s --why="k3s running - use just k8s-off before travel" --mode=block sleep infinity
+Restart=on-failure
+RestartSec=5
+EOF
+
+sudo mkdir -p /etc/systemd/system/k3s-agent.service.d
+sudo tee /etc/systemd/system/k3s-agent.service.d/sleep-inhibit.conf << 'EOF'
+[Unit]
+Wants=k3s-sleep-inhibit.service
+EOF
+
+sudo systemctl daemon-reload
+```
+
+### Install the cluster Justfile in the node's home directory
+
+```bash
+cat > ~/Justfile << 'EOF'
+# Cluster controls — opt in/out of the ghost k3s cluster
+# k8s-on  — join the cluster (laptop stays awake while connected)
+# k8s-off — leave the cluster (safe to travel, close lid, suspend)
+
+k8s-on:
+    sudo systemctl enable --now k3s-agent
+    @echo "k3s agent started — sleep/lid inhibited while connected"
+
+k8s-off:
+    sudo systemctl stop k3s-agent
+    sudo systemctl disable k3s-agent
+    @echo "k3s agent stopped — normal sleep restored"
+
+k8s-status:
+    @systemctl is-active k3s-agent 2>/dev/null && echo "k8s: ON (inhibiting sleep)" || echo "k8s: OFF (normal sleep)"
+EOF
+```
+
+### Label the node and verify
+
+```bash
+# From workstation / ghost
+KUBECONFIG=~/.kube/bluespeed.yaml kubectl label node <hostname> \
+  node-role.kubernetes.io/worker=true --overwrite
+
+KUBECONFIG=~/.kube/bluespeed.yaml kubectl get nodes -o wide
+```
+
+Expected: new node appears as `Ready  worker`.
+
+### Passwordless sudo for agents (required for non-interactive SSH management)
+
+On the new node, the `jorge-nopasswd` sudoers file must sort AFTER `wheel` and include `!requiretty`:
+
+```bash
+sudo bash -c 'echo -e "Defaults:jorge !requiretty\njorge ALL=(ALL) NOPASSWD: ALL" \
+  > /etc/sudoers.d/zzz-jorge && chmod 440 /etc/sudoers.d/zzz-jorge'
+```
+
+### Node offboarding — removing a worker
+
+```bash
+# 1. Drain the node (from workstation)
+KUBECONFIG=~/.kube/bluespeed.yaml kubectl drain <hostname> \
+  --ignore-daemonsets --delete-emptydir-data
+
+# 2. Delete from cluster
+KUBECONFIG=~/.kube/bluespeed.yaml kubectl delete node <hostname>
+
+# 3. On the node itself (optional cleanup)
+sudo /var/usrlocal/bin/k3s-agent-uninstall.sh
+```
+
+### Key facts for immutable Linux nodes
+
+- **Binary path:** `/var/usrlocal/bin/k3s` — always set `INSTALL_K3S_BIN_DIR=/var/usrlocal/bin`
+- **Flannel backend:** `host-gw` — pure L2 routes, no VXLAN/WireGuard kernel modules needed
+- **All nodes must be on 192.168.1.0/24** for host-gw to work
+- **Upgrades:** handled by system-upgrade-controller via `manifests/k3s-upgrade-plans.yaml` — ArgoCD manages it
+- **Version skew rule:** agents must never be newer than the server (ghost)

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -12,7 +12,7 @@ safely.
 |---|---|
 | x86_64 bare metal | Minimum 16GB RAM, 256GB NVMe, btrfs root or separate btrfs volume for `/var/tmp` |
 | Fedora / Bluefin host OS | Tested on Bluefin (bootc, atomic). Any systemd-based distro works. |
-| `k3s` installed | See [k3s.io/docs](https://docs.k3s.io/quick-start) — single node or multi-node |
+| `k3s` installed | See [k3s.io/docs](https://docs.k3s.io/quick-start) — single node or multi-node. **On immutable Linux (Bluefin/Dakota/Bazzite):** always set `INSTALL_K3S_BIN_DIR=/var/usrlocal/bin` |
 | ArgoCD installed | `kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml` in `argocd` namespace |
 | Argo Workflows installed | See [argo-workflows install](https://argoproj.github.io/argo-workflows/installation/) |
 | `kubectl`, `argo`, `argocd`, `just` CLIs | On workstation or admin pod |
@@ -171,7 +171,25 @@ Loki listens at `http://192.168.1.102:30100` and scrapes pods labeled
 
 ---
 
-## 9. Verify the Setup
+## 9. Add Worker Nodes (optional)
+
+This cluster uses an opt-in model: worker nodes join the cluster manually and can
+leave at any time (useful for laptops and gaming machines).
+
+**Full onboarding steps: `docs/agent-cheatsheet.md` section 14.**
+
+Quick summary:
+1. Get join token: `ssh jorge@192.168.1.102 "sudo cat /var/lib/rancher/k3s/server/node-token"`
+2. On the new node: `sudo mkdir -p /var/usrlocal/bin` then run the k3s install script with `INSTALL_K3S_BIN_DIR=/var/usrlocal/bin`
+3. Disable auto-start: `sudo systemctl disable k3s-agent`
+4. Install `~/Justfile` with `just k8s-on/off/status` commands
+5. Label from workstation: `kubectl label node <name> node-role.kubernetes.io/worker=true`
+
+**Flannel backend is `host-gw`** — requires all nodes on 192.168.1.0/24 flat L2.
+
+---
+
+## 10. Verify the Setup
 
 ```bash
 # ArgoCD applications are healthy and synced

--- a/manifests/bst-build-priorityclass.yaml
+++ b/manifests/bst-build-priorityclass.yaml
@@ -1,0 +1,15 @@
+# manifests/bst-build-priorityclass.yaml
+# BST build pods — below lab-test-vm (1,000,000) so test VMs always win
+# scheduling disputes. PreemptionPolicy: Never means BST won't evict others,
+# but can itself be preempted. Since buildbox-casd preserves all artifacts,
+# a preempted build restarts and skips already-built elements.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: bst-build
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+value: 500000
+preemptionPolicy: Never
+globalDefault: false
+description: "BST build pods. Lower priority than lab-test-vm. Preemptable on resource contention."

--- a/manifests/buildbox-casd.yaml
+++ b/manifests/buildbox-casd.yaml
@@ -1,0 +1,91 @@
+# manifests/buildbox-casd.yaml
+# In-cluster CAS for dakota BST builds. Stores artifacts on ghost NVMe (local-path PVC).
+# Build pods in any namespace reach it at buildbox-casd.local-registry.svc.cluster.local:11002.
+# Pinned to ghost via nodeSelector — local-path PVC follows the pod's node.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildbox-casd-data
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/component: buildbox-casd
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  storageClassName: local-path
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 200Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildbox-casd
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/component: buildbox-casd
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: buildbox-casd
+  template:
+    metadata:
+      labels:
+        app: buildbox-casd
+        app.kubernetes.io/component: buildbox-casd
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: casd
+          image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
+          command:
+            - buildbox-casd
+            - --bind
+            - 0.0.0.0:11002
+            - --quota-high
+            - 190G
+            - /data
+          ports:
+            - name: grpc
+              containerPort: 11002
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          readinessProbe:
+            tcpSocket:
+              port: 11002
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: buildbox-casd-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildbox-casd
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/component: buildbox-casd
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  selector:
+    app: buildbox-casd
+  ports:
+    - name: grpc
+      port: 11002
+      targetPort: 11002
+      protocol: TCP

--- a/manifests/k3s-upgrade-plans.yaml
+++ b/manifests/k3s-upgrade-plans.yaml
@@ -1,0 +1,63 @@
+# k3s cluster upgrade Plans for system-upgrade-controller
+#
+# Upgrade order enforced: server (ghost) first, then agents.
+# Agent plan waits for server-plan to complete before starting.
+#
+# All nodes use /var/usrlocal/bin — the writable overlay path on ostree/immutable
+# Linux (Bluefin, Dakota, Bazzite). /usr/local/bin -> /var/usrlocal/bin via symlink.
+# INSTALL_K3S_BIN_DIR must be set or the install script fails on a missing directory.
+#
+# To trigger an upgrade: push a change to this file (e.g. bump channel or pin version).
+# ArgoCD applies it; system-upgrade-controller executes the plans.
+#
+# Channel "stable" tracks the latest stable k3s release automatically.
+# To pin a specific version instead:
+#   version: v1.35.5+k3s1
+# and remove the channel field.
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: server-plan
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: In
+        values:
+          - "true"
+  serviceAccountName: system-upgrade
+  channel: https://update.k3s.io/v1-release/channels/stable
+  upgrade:
+    image: rancher/k3s-upgrade
+    env:
+      - name: INSTALL_K3S_BIN_DIR
+        value: /var/usrlocal/bin
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: agent-plan
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+  serviceAccountName: system-upgrade
+  channel: https://update.k3s.io/v1-release/channels/stable
+  prepare:
+    image: rancher/k3s-upgrade
+    args:
+      - prepare
+      - server-plan
+  upgrade:
+    image: rancher/k3s-upgrade
+    env:
+      - name: INSTALL_K3S_BIN_DIR
+        value: /var/usrlocal/bin

--- a/manifests/mask-sleep-targets.yaml
+++ b/manifests/mask-sleep-targets.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mask-sleep-targets
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: mask-sleep-targets
+    app.kubernetes.io/component: node-tuning
+    app.kubernetes.io/part-of: bluefin-test-suite
+  annotations:
+    bluefin.io/description: |
+      Masks systemd sleep/suspend targets on every node so worker machines
+      (hamilton, bazzite, exo-1) don't suspend mid-test and drop out of the
+      cluster. Survives reboots; re-runs after OS updates via pod recreation.
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mask-sleep-targets
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mask-sleep-targets
+        app.kubernetes.io/component: node-tuning
+        app.kubernetes.io/part-of: bluefin-test-suite
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      hostPID: true
+      initContainers:
+        - name: mask-sleep
+          image: quay.io/fedora/fedora:latest
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              nsenter -t 1 -m -- systemctl mask --now \
+                sleep.target suspend.target hibernate.target hybrid-sleep.target \
+                && echo "sleep targets masked on $(uname -n)"
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 1m
+              memory: 4Mi
+            limits:
+              cpu: 10m
+              memory: 8Mi

--- a/manifests/semaphore-config.yaml
+++ b/manifests/semaphore-config.yaml
@@ -24,3 +24,5 @@ data:
   # These bootstrap values are overwritten on the first tuner run.
   max-containerdisk-vms: "8"
   max-hostdisk-vms: "3"
+  # BST build pods — one at a time initially. Bump to 2 when more nodes arrive.
+  max-bst-builds: "1"

--- a/manifests/semaphore-tuner.yaml
+++ b/manifests/semaphore-tuner.yaml
@@ -58,6 +58,7 @@ spec:
             SLOT_GI=8        # slot unit = largest VM in the fleet
             MIN_CD=2;  MAX_CD=16   # containerdisk bounds (any node)
             MIN_HD=2;  MAX_HD=6    # hostdisk bounds (ghost only)
+            BST_RESERVE_GI=16  # always reserve headroom on ghost for one BST build pod
 
             # ── parse kubernetes memory quantity → integer GiB ──────────────
             mem_to_gi() {
@@ -79,6 +80,8 @@ spec:
               [[ "$ready" != "True" ]] && { echo "  SKIP $name (NotReady)"; continue; }
               mem_gi=$(mem_to_gi "$mem_raw")
               usable=$(( mem_gi > OVERHEAD_GI ? mem_gi - OVERHEAD_GI : 0 ))
+              # Reserve BST build headroom on ghost so build pods always fit
+              [[ "$name" == "ghost" ]] && usable=$(( usable > BST_RESERVE_GI ? usable - BST_RESERVE_GI : 0 ))
               total_cd_gi=$(( total_cd_gi + usable ))
               echo "  $name: ${mem_gi}Gi allocatable → ${usable}Gi usable"
               [[ "$name" == "ghost" ]] && ghost_gi=$usable

--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -1,0 +1,1637 @@
+# system-upgrade-controller — manages k3s node upgrades via Plan CRDs
+# Source: https://github.com/rancher/system-upgrade-controller/releases/latest
+# Do not edit inline — re-fetch from upstream on version bumps.
+# Plans are in k3s-upgrade-plans.yaml
+---
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: plans.upgrade.cattle.io
+spec:
+  group: upgrade.cattle.io
+  names:
+    kind: Plan
+    listKind: PlanList
+    plural: plans
+    singular: plan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.upgrade.image
+      name: Image
+      type: string
+    - jsonPath: .spec.channel
+      name: Channel
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Complete')].status
+      name: Complete
+      type: string
+    - jsonPath: .status.conditions[?(@.message!='')].message
+      name: Message
+      type: string
+    - jsonPath: .status.applying
+      name: Applying
+      priority: 10
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Plan represents a set of Jobs to apply an upgrade (or other operation)
+          to set of Nodes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlanSpec represents the user-configurable details of a Plan.
+            properties:
+              channel:
+                description: A URL that returns HTTP 302 with the last path element
+                  of the value returned in the Location header assumed to be an image
+                  tag (after munging "+" to "-").
+                type: string
+              concurrency:
+                description: The maximum number of concurrent nodes to apply this
+                  update on.
+                format: int64
+                type: integer
+              cordon:
+                description: |-
+                  If Cordon is true, the node is cordoned before the upgrade container is run.
+                  If drain is specified, the value for cordon is ignored, and the node is cordoned.
+                  If neither drain nor cordon are specified and the node is marked as schedulable=false it will not be marked as schedulable=true when the Job completes.
+                type: boolean
+              drain:
+                description: Configuration for draining nodes prior to upgrade. If
+                  left unspecified, no drain will be performed.
+                properties:
+                  deleteEmptydirData:
+                    type: boolean
+                  deleteLocalData:
+                    type: boolean
+                  disableEviction:
+                    type: boolean
+                  force:
+                    type: boolean
+                  gracePeriod:
+                    format: int32
+                    type: integer
+                  ignoreDaemonSets:
+                    type: boolean
+                  podSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  skipWaitForDeleteTimeout:
+                    type: integer
+                  timeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      If a string, this is passed through directly to the `kubectl drain` command.
+                      If an int, this represents the duration as a count of nanoseconds, and will be converted to a duration string when passed to the `kubectl drain` command.
+                    x-kubernetes-int-or-string: true
+                type: object
+              exclusive:
+                description: Jobs for exclusive plans cannot be run alongside any
+                  other exclusive plan.
+                type: boolean
+              imagePullSecrets:
+                description: Image Pull Secrets, used to pull images for the Job.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              jobActiveDeadlineSecs:
+                description: |-
+                  Sets ActiveDeadlineSeconds on Jobs generated to apply this Plan.
+                  If the Job does not complete within this time, the Plan will stop processing until it is updated to trigger a redeploy.
+                  If set to 0, Jobs have no deadline. If not set, the controller default value is used.
+                format: int64
+                type: integer
+              nodeSelector:
+                description: Select which nodes this plan can be applied to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              postCompleteDelay:
+                description: Time after a Job for one Node is complete before a new
+                  Job will be created for the next Node.
+                type: string
+              postCompleteLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Label key-value pairs to apply to a node when the job for this plan completes successfully.
+                  Values may contain `$(LATEST_HASH)` or `$(LATEST_VERSION)`, which will be expanded from the plan status.
+                type: object
+              prepare:
+                description: The prepare init container, if specified, is run before
+                  cordon/drain which is run before the upgrade container.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext holds security configuration that will be applied to a container.
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When both
+                      are set, the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default value is Default which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              priorityClassName:
+                description: Priority Class Name of Job, if specified.
+                type: string
+              secrets:
+                description: Secrets to be mounted into the Job Pod.
+                items:
+                  description: SecretSpec describes a Secret to be mounted for prepare/upgrade
+                    containers.
+                  properties:
+                    defaultMode:
+                      description: Mode to mount the Secret volume with.
+                      format: int32
+                      type: integer
+                    ignoreUpdates:
+                      description: If set to true, the Secret contents will not be
+                        hashed, and changes to the Secret will not trigger new application
+                        of the Plan.
+                      type: boolean
+                    name:
+                      description: Secret name
+                      type: string
+                    path:
+                      description: Path to mount the Secret volume within the Pod.
+                      type: string
+                  required:
+                  - name
+                  - path
+                  type: object
+                type: array
+              serviceAccountName:
+                description: The service account for the pod to use. As with normal
+                  pods, if not specified the default service account from the namespace
+                  will be assigned.
+                type: string
+              tolerations:
+                description: |-
+                  Specify which node taints should be tolerated by pods applying the upgrade.
+                  Anything specified here is appended to the default of:
+                  - `{key: node.kubernetes.io/unschedulable, effect: NoSchedule, operator: Exists}`
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              upgrade:
+                description: The upgrade container; must be specified.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext holds security configuration that will be applied to a container.
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When both
+                      are set, the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default value is Default which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              version:
+                description: Providing a value for version will prevent polling/resolution
+                  of the channel if specified.
+                type: string
+              window:
+                description: |-
+                  A time window in which to execute Jobs for this Plan.
+                  Jobs will not be generated outside this time window, but may continue executing into the window once started.
+                properties:
+                  days:
+                    description: Days that this time window is valid for
+                    items:
+                      enum:
+                      - "0"
+                      - su
+                      - sun
+                      - sunday
+                      - "1"
+                      - mo
+                      - mon
+                      - monday
+                      - "2"
+                      - tu
+                      - tue
+                      - tuesday
+                      - "3"
+                      - we
+                      - wed
+                      - wednesday
+                      - "4"
+                      - th
+                      - thu
+                      - thursday
+                      - "5"
+                      - fr
+                      - fri
+                      - friday
+                      - "6"
+                      - sa
+                      - sat
+                      - saturday
+                      type: string
+                    minItems: 1
+                    type: array
+                  endTime:
+                    description: End of the time window.
+                    type: string
+                  startTime:
+                    description: Start of the time window.
+                    type: string
+                  timeZone:
+                    description: Time zone for the time window; if not specified UTC
+                      will be used.
+                    type: string
+                type: object
+            required:
+            - upgrade
+            type: object
+          status:
+            description: PlanStatus represents the resulting state from processing
+              Plan events.
+            properties:
+              applying:
+                description: List of Node names that the Plan is currently being applied
+                  on.
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: |-
+                  `LatestResolved` indicates that the latest version as per the spec has been determined.
+                  `Validated` indicates that the plan spec has been validated.
+                  `Complete` indicates that the latest version of the plan has completed on all selected nodes. If any Jobs for the Plan fail to complete, this condition will remain false, and the reason and message will reflect the source of the error.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of cluster condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              latestHash:
+                description: The hash of the most recently applied plan .spec.
+                type: string
+              latestVersion:
+                description: The latest version, as resolved from .spec.version, or
+                  the channel server.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  name: system-upgrade
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - system-upgrade-controller
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - upgrade.cattle.io
+  resources:
+  - plans
+  - plans/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller-drainer
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system-upgrade
+  namespace: system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade-drainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller-drainer
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: v1
+data:
+  SYSTEM_UPGRADE_CONTROLLER_DEBUG: "false"
+  SYSTEM_UPGRADE_CONTROLLER_LEADER_ELECT: "true"
+  SYSTEM_UPGRADE_CONTROLLER_THREADS: "2"
+  SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: "900"
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: "99"
+  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: Always
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: rancher/kubectl:v1.30.3
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE_WINDOWS: ""
+  SYSTEM_UPGRADE_JOB_PRIVILEGED: "true"
+  SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: "900"
+  SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: 15m
+kind: ConfigMap
+metadata:
+  name: default-controller-env
+  namespace: system-upgrade
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+spec:
+  selector:
+    matchLabels:
+      upgrade.cattle.io/controller: system-upgrade-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: system-upgrade-controller
+        upgrade.cattle.io/controller: system-upgrade-controller
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - system-upgrade-controller
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - env:
+        - name: SYSTEM_UPGRADE_CONTROLLER_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['upgrade.cattle.io/controller']
+        - name: SYSTEM_UPGRADE_CONTROLLER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SYSTEM_UPGRADE_CONTROLLER_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - configMapRef:
+            name: default-controller-env
+        image: rancher/system-upgrade-controller:v0.19.2
+        imagePullPolicy: IfNotPresent
+        name: system-upgrade-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/ssl
+          name: etc-ssl
+          readOnly: true
+        - mountPath: /etc/pki
+          name: etc-pki
+          readOnly: true
+        - mountPath: /etc/ca-certificates
+          name: etc-ca-certificates
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+      serviceAccountName: system-upgrade
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/controlplane
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
+        key: node-role.kubernetes.io/etcd
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /etc/ssl
+          type: DirectoryOrCreate
+        name: etc-ssl
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: etc-pki
+      - hostPath:
+          path: /etc/ca-certificates
+          type: DirectoryOrCreate
+        name: etc-ca-certificates
+      - emptyDir: {}
+        name: tmp


### PR DESCRIPTION
## Changes

- Add system-upgrade-controller to `manifests/` (ArgoCD-managed, namespace: system-upgrade)
- Add `manifests/k3s-upgrade-plans.yaml`: server plan upgrades ghost first, agent plan waits, both track stable channel with `INSTALL_K3S_BIN_DIR=/var/usrlocal/bin`
- Switch flannel backend to `host-gw` (already applied to ghost config — no VXLAN kernel module required, pure L2 routes)
- Exo-1 (192.168.1.239) added as worker node running Dakota
- Document full node onboarding/offboarding in `docs/agent-cheatsheet.md` section 14
- Document opt-in `just k8s-on/off/status` pattern for worker nodes (laptops, gaming machines)
- Update `docs/bootstrap.md` with worker node section
- Update k3s-cluster-ops skill with current 3-node topology

## Key design decisions
- All immutable Linux nodes use `/var/usrlocal/bin` for k3s binary (ostree writable overlay)
- `host-gw` flannel works without kernel tunnel modules — scales to any node on 192.168.1.0/24
- Nodes opt in to the cluster via `just k8s-on` — sleep inhibited while connected
- Version skew will be fixed automatically by system-upgrade-controller after this merges to main