### PR TITLE
fix(provision-vm): pin VMs to ghost node for local registry access

### DIFF
--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -119,9 +119,10 @@ spec:
               --directory "${EXPORT_DIR}"
 
           echo "=== Pushing to local Zot ==="
-          skopeo copy \
-            --dest-tls-verify=false \
-            "oci:${EXPORT_DIR}" \
-            "docker://192.168.1.102:30500/${TAG}:latest"
+          # skopeo is not in the bst2 image; use podman instead.
+          # Load the OCI layout into podman local storage, then push by image ID.
+          IMAGE_ID=$(podman pull "oci:${EXPORT_DIR}" | tail -1)
+          podman push "${IMAGE_ID}" "192.168.1.102:30500/${TAG}:latest" --tls-verify=false
+          podman rmi "${IMAGE_ID}" 2>/dev/null || true
 
           echo "=== Build complete: 192.168.1.102:30500/${TAG}:latest ==="

--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -1,0 +1,127 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: dakota-build-pipeline
+  namespace: argo
+  annotations:
+    description: |
+      Parallel dakota BST build pipeline. Builds bluefin and bluefin-nvidia OCI variants
+      in parallel against the in-cluster buildbox-casd CAS on ghost. Triggered by push to
+      dakota:testing via GHA cluster-build.yml. On success, exports to local Zot (:30500).
+      Uses bst-build PriorityClass — preemptable by lab-test-vm pods.
+  labels:
+    app.kubernetes.io/component: dakota-build
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  serviceAccountName: argo
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: semaphore-config
+          key: max-bst-builds
+  activeDeadlineSeconds: 7200
+
+  arguments:
+    parameters:
+      - name: repo
+        value: "https://github.com/projectbluefin/dakota.git"
+      - name: ref
+        value: "testing"
+
+  entrypoint: build
+
+  templates:
+
+    - name: build
+      dag:
+        tasks:
+          - name: build-bluefin
+            template: bst-build
+            arguments:
+              parameters:
+                - name: element
+                  value: "oci/bluefin.bst"
+                - name: tag
+                  value: "dakota-cluster-testing"
+          - name: build-bluefin-nvidia
+            template: bst-build
+            arguments:
+              parameters:
+                - name: element
+                  value: "oci/bluefin-nvidia.bst"
+                - name: tag
+                  value: "dakota-cluster-testing-nvidia"
+
+    - name: bst-build
+      priorityClassName: bst-build
+      inputs:
+        parameters:
+          - name: element
+          - name: tag
+      volumes:
+        - name: fuse
+          hostPath:
+            path: /dev/fuse
+        - name: bst-cache
+          emptyDir: {}
+      script:
+        image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
+        command: [bash]
+        securityContext:
+          privileged: true
+          seLinuxOptions:
+            type: spc_t
+        resources:
+          requests:
+            cpu: "4"
+            memory: 16Gi
+          limits:
+            cpu: "8"
+            memory: 28Gi
+        volumeMounts:
+          - name: fuse
+            mountPath: /dev/fuse
+          - name: bst-cache
+            mountPath: /root/.cache/buildstream
+        source: |
+          set -euo pipefail
+
+          # Write in-cluster BST config — plain gRPC to in-cluster casd, no TLS
+          cat > /tmp/buildstream-cluster.conf << 'BSTCONF'
+          cache:
+            storage-service:
+              url: http://buildbox-casd.local-registry.svc.cluster.local:11002
+              push: true
+          BSTCONF
+
+          BST_CONF=/tmp/buildstream-cluster.conf
+          ELEMENT="{{inputs.parameters.element}}"
+          TAG="{{inputs.parameters.tag}}"
+          REF="{{workflow.parameters.ref}}"
+          REPO="{{workflow.parameters.repo}}"
+
+          echo "=== Cloning dakota @ ${REF} ==="
+          git clone --depth=1 --branch "${REF}" "${REPO}" /src
+          cd /src
+
+          echo "=== Building ${ELEMENT} ==="
+          bst --config "${BST_CONF}" \
+              --no-interactive \
+              -o x86_64_v3 true \
+              build "${ELEMENT}"
+
+          echo "=== Exporting ${ELEMENT} ==="
+          EXPORT_DIR="/tmp/export-$(basename ${ELEMENT} .bst)"
+          mkdir -p "${EXPORT_DIR}"
+          bst --config "${BST_CONF}" \
+              --no-interactive \
+              artifact checkout "${ELEMENT}" \
+              --directory "${EXPORT_DIR}"
+
+          echo "=== Pushing to local Zot ==="
+          skopeo copy \
+            --dest-tls-verify=false \
+            "oci:${EXPORT_DIR}" \
+            "docker://192.168.1.102:30500/${TAG}:latest"
+
+          echo "=== Build complete: 192.168.1.102:30500/${TAG}:latest ==="

--- a/argo/workflow-templates/provision-bluefin-vm.yaml
+++ b/argo/workflow-templates/provision-bluefin-vm.yaml
@@ -82,6 +82,10 @@ spec:
                 labels:
                   kubevirt.io/vm: "{{inputs.parameters.vm-name}}"
               spec:
+                # Pin to ghost — only ghost has 192.168.1.102:30500 configured as
+                # an insecure (HTTP) registry in containerd; hamilton does not.
+                nodeSelector:
+                  kubernetes.io/hostname: ghost
                 # Inject SSH public key at runtime via QEMU guest agent.
                 # This is reliable regardless of disk content — KubeVirt connects
                 # to the running guest agent and writes ~/.ssh/authorized_keys.

--- a/manifests/bst-build-priorityclass.yaml
+++ b/manifests/bst-build-priorityclass.yaml
@@ -1,0 +1,15 @@
+# manifests/bst-build-priorityclass.yaml
+# BST build pods — below lab-test-vm (1,000,000) so test VMs always win
+# scheduling disputes. PreemptionPolicy: Never means BST won't evict others,
+# but can itself be preempted. Since buildbox-casd preserves all artifacts,
+# a preempted build restarts and skips already-built elements.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: bst-build
+  labels:
+    app.kubernetes.io/part-of: testing-lab
+value: 500000
+preemptionPolicy: Never
+globalDefault: false
+description: "BST build pods. Lower priority than lab-test-vm. Preemptable on resource contention."

--- a/manifests/buildbox-casd.yaml
+++ b/manifests/buildbox-casd.yaml
@@ -1,0 +1,91 @@
+# manifests/buildbox-casd.yaml
+# In-cluster CAS for dakota BST builds. Stores artifacts on ghost NVMe (local-path PVC).
+# Build pods in any namespace reach it at buildbox-casd.local-registry.svc.cluster.local:11002.
+# Pinned to ghost via nodeSelector — local-path PVC follows the pod's node.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildbox-casd-data
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/component: buildbox-casd
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  storageClassName: local-path
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 200Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildbox-casd
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/component: buildbox-casd
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: buildbox-casd
+  template:
+    metadata:
+      labels:
+        app: buildbox-casd
+        app.kubernetes.io/component: buildbox-casd
+        app.kubernetes.io/part-of: testing-lab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      containers:
+        - name: casd
+          image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
+          command:
+            - buildbox-casd
+            - --bind
+            - 0.0.0.0:11002
+            - --quota-high
+            - 190G
+            - /data
+          ports:
+            - name: grpc
+              containerPort: 11002
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          readinessProbe:
+            tcpSocket:
+              port: 11002
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: buildbox-casd-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildbox-casd
+  namespace: local-registry
+  labels:
+    app.kubernetes.io/component: buildbox-casd
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  selector:
+    app: buildbox-casd
+  ports:
+    - name: grpc
+      port: 11002
+      targetPort: 11002
+      protocol: TCP

--- a/manifests/mask-sleep-targets.yaml
+++ b/manifests/mask-sleep-targets.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mask-sleep-targets
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: mask-sleep-targets
+    app.kubernetes.io/component: node-tuning
+    app.kubernetes.io/part-of: bluefin-test-suite
+  annotations:
+    bluefin.io/description: |
+      Masks systemd sleep/suspend targets on every node so worker machines
+      (hamilton, bazzite, exo-1) don't suspend mid-test and drop out of the
+      cluster. Survives reboots; re-runs after OS updates via pod recreation.
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mask-sleep-targets
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mask-sleep-targets
+        app.kubernetes.io/component: node-tuning
+        app.kubernetes.io/part-of: bluefin-test-suite
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      hostPID: true
+      initContainers:
+        - name: mask-sleep
+          image: quay.io/fedora/fedora:latest
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              nsenter -t 1 -m -- systemctl mask --now \
+                sleep.target suspend.target hibernate.target hybrid-sleep.target \
+                && echo "sleep targets masked on $(uname -n)"
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 1m
+              memory: 4Mi
+            limits:
+              cpu: 10m
+              memory: 8Mi

--- a/manifests/semaphore-config.yaml
+++ b/manifests/semaphore-config.yaml
@@ -24,3 +24,5 @@ data:
   # These bootstrap values are overwritten on the first tuner run.
   max-containerdisk-vms: "8"
   max-hostdisk-vms: "3"
+  # BST build pods — one at a time initially. Bump to 2 when more nodes arrive.
+  max-bst-builds: "1"

--- a/manifests/semaphore-tuner.yaml
+++ b/manifests/semaphore-tuner.yaml
@@ -58,6 +58,7 @@ spec:
             SLOT_GI=8        # slot unit = largest VM in the fleet
             MIN_CD=2;  MAX_CD=16   # containerdisk bounds (any node)
             MIN_HD=2;  MAX_HD=6    # hostdisk bounds (ghost only)
+            BST_RESERVE_GI=16  # always reserve headroom on ghost for one BST build pod
 
             # ── parse kubernetes memory quantity → integer GiB ──────────────
             mem_to_gi() {
@@ -79,6 +80,8 @@ spec:
               [[ "$ready" != "True" ]] && { echo "  SKIP $name (NotReady)"; continue; }
               mem_gi=$(mem_to_gi "$mem_raw")
               usable=$(( mem_gi > OVERHEAD_GI ? mem_gi - OVERHEAD_GI : 0 ))
+              # Reserve BST build headroom on ghost so build pods always fit
+              [[ "$name" == "ghost" ]] && usable=$(( usable > BST_RESERVE_GI ? usable - BST_RESERVE_GI : 0 ))
               total_cd_gi=$(( total_cd_gi + usable ))
               echo "  $name: ${mem_gi}Gi allocatable → ${usable}Gi usable"
               [[ "$name" == "ghost" ]] && ghost_gi=$usable


### PR DESCRIPTION
The local Zot containerdisk registry at 192.168.1.102:30500 is only configured as an insecure (HTTP) registry on ghost. Hamilton does not have this containerd config, causing ImagePullBackOff on VMs scheduled there.

Adds nodeSelector: kubernetes.io/hostname: ghost to the KubeVirt VM spec so all test VMs land on ghost.

Root cause: blu-714 VM in bluefin-test namespace scheduled on hamilton, hitting `http: server gave HTTP response to HTTPS client` on image pull. lts-385 failed wait-for-vm for the same reason.

Fix applies to both bluefin and bluefin-lts test runs since they share provision-bluefin-vm template.