### PR TITLE
fix(ci): fail lint on standalone workflow files without server-side refs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,7 +40,9 @@ jobs:
             # Files that reference WorkflowTemplates cannot be linted offline because
             # the referenced templates are not loaded. Lint them as advisory only;
             # every standalone file that embeds its own templates must pass offline.
-            if grep -qE 'workflowTemplateRef|templateRef' "$f"; then
+            # Anchor to the start of a YAML key so comments/template names do not
+            # accidentally mark a self-contained workflow as advisory.
+            if grep -qE '^[[:space:]]*(workflowTemplateRef|templateRef):' "$f"; then
               echo "Advisory lint (server-side refs): $f"
               argo lint --offline "$f" || echo "WARNING: $f needs server-side template resolution"
             else
@@ -49,8 +51,6 @@ jobs:
             fi
           done
           exit "$FAIL"
-
-
       - name: Registry allowlist check
         run: |
           # Fail if any image: reference uses a registry not in the cluster cache.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,12 +33,23 @@ jobs:
       - name: Lint bootstrap templates (offline)
         run: argo lint --offline argo/bootstrap/
 
-      - name: Lint standalone submit Workflows (offline)
+      - name: Lint standalone submit Workflows (offline, strict)
         run: |
+          FAIL=0
           for f in argo/*.yaml; do
-            echo "Checking $f..."
-            argo lint --offline "$f" || echo "WARNING: $f needs server-side template resolution"
+            # Files that reference WorkflowTemplates cannot be linted offline because
+            # the referenced templates are not loaded. Lint them as advisory only;
+            # every standalone file that embeds its own templates must pass offline.
+            if grep -qE 'workflowTemplateRef|templateRef' "$f"; then
+              echo "Advisory lint (server-side refs): $f"
+              argo lint --offline "$f" || echo "WARNING: $f needs server-side template resolution"
+            else
+              echo "Strict lint: $f"
+              argo lint --offline "$f" || FAIL=1
+            fi
           done
+          exit "$FAIL"
+
 
       - name: Registry allowlist check
         run: |


### PR DESCRIPTION
Closes #188

- Standalone workflows that embed their own templates are now strictly linted offline.
- Files that reference WorkflowTemplates remain advisory because offline lint cannot resolve cross-file refs.
- The template-ref heuristic is anchored to the YAML key start.

Reviewed by agent.