### PR TITLE
fix(cron): cap nightly-dakota run time at 4 hours

### DIFF
--- a/manifests/nightly-dakota.yaml
+++ b/manifests/nightly-dakota.yaml
@@ -23,6 +23,7 @@ spec:
       bluefin.io/suite: smoke
   workflowSpec:
     serviceAccountName: argo
+    activeDeadlineSeconds: 14400  # 4h max — prevent stuck Dakota runs from holding ghost-heavy-compute
     podGC:
       strategy: OnWorkflowCompletion
     ttlStrategy:


### PR DESCRIPTION
Closes #216

Sets `workflowSpec.activeDeadlineSeconds: 14400` on the nightly-dakota CronWorkflow so a stuck run cannot hold the ghost-heavy-compute mutex indefinitely.