### PR TITLE
fix(qa): publish digest-pinned test results and add stable smoke cronworkflows

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -92,6 +92,14 @@ spec:
         value: "{{inputs.parameters.variant}}"
       - name: BEHAVE_TAGS
         value: "{{inputs.parameters.behave-tags}}"
+      - name: IMAGE_TAG
+        value: "{{inputs.parameters.image-tag}}"
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-token
+            key: token
+            optional: true
       volumeMounts:
       - mountPath: /workspace
         name: workspace
@@ -104,6 +112,27 @@ spec:
       command: [bash]
       source: |
         set -euo pipefail
+        # Build slug used to identify QA evidence in the lab repo.
+        IMG_SLUG="${VARIANT}-${IMAGE_TAG}"
+
+        # Resolve the digest of the target OCI image for digest-pinned QA evidence.
+        if ! command -v skopeo >/dev/null 2>&1; then
+          echo "skopeo not found; installing for digest resolution..." >&2
+          dnf install -y skopeo >/dev/null 2>&1 || true
+        fi
+        DIGEST=""
+        if command -v skopeo >/dev/null 2>&1; then
+          SKOPEO_ARGS=()
+          if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+            SKOPEO_ARGS+=(--creds "_token:${GITHUB_TOKEN}")
+          fi
+          DIGEST=$(skopeo inspect "${SKOPEO_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE}" 2>/dev/null || true)
+        fi
+        if [[ -z "${DIGEST:-}" ]]; then
+          echo "Warning: could not resolve digest for ${IMAGE}; result will still be published but may fall back to tag-based matching." >&2
+        else
+          echo "Resolved digest ${DIGEST} for ${IMAGE}" >&2
+        fi
         TARGET_NAME="bluefin-qa-target"
         STORAGE_CONF=/tmp/storage.conf
         cat >"${STORAGE_CONF}" <<'EOF'
@@ -269,6 +298,28 @@ spec:
         PY
         else
           printf 'Execution failed' >/tmp/results/result-summary.txt
+        fi
+
+
+        # Publish digest-pinned test results back to the lab repo.
+        if [[ -n "${GITHUB_TOKEN:-}" && -f /tmp/results/results.json ]]; then
+          if ! command -v git >/dev/null 2>&1; then
+            echo "git not found; installing git-core before result publication..." >&2
+            dnf install -y git-core >/dev/null 2>&1 || true
+          fi
+          PUBLISH_RC=0
+          {
+            rm -rf /tmp/lab-code
+            git clone --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" /tmp/lab-code
+            python3 /tmp/lab-code/scripts/publish_test_results.py /tmp/results/results.json "${IMG_SLUG}" "${SUITE}" "{{workflow.name}}" "${GITHUB_TOKEN}" "${DIGEST}"
+          } || PUBLISH_RC=$?
+          if [[ "${PUBLISH_RC}" -ne 0 ]]; then
+            echo "Warning: failed to publish test results (rc=${PUBLISH_RC})" >&2
+          fi
+        elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
+          echo "No GITHUB_TOKEN - skipping test results publication" >&2
+        else
+          echo "Skipping publication: /tmp/results/results.json not found" >&2
         fi
 
         exit "${BEHAVE_RC}"

--- a/docs/skills/argo-workflows.md
+++ b/docs/skills/argo-workflows.md
@@ -633,6 +633,17 @@ Key rules:
   root-backed hostPath
 - Concurrent pipeline exits conflict on SHA → last writer wins; 409 = silent skip. Acceptable for metrics files.
 
+#### Container-only QA runner: publish digest-pinned results
+
+`run-container-tests` runs inside a privileged `quay.io/podman/stable:latest` container, which does not include `git` or `skopeo`. When publishing BDD evidence back to the lab repo:
+
+1. Install tooling if it is missing: `command -v skopeo >/dev/null || dnf install -y skopeo` and `command -v git >/dev/null || dnf install -y git-core`.
+2. Resolve the digest of `{{inputs.parameters.image}}:{{inputs.parameters.image-tag}}` with `skopeo inspect --no-tags --format '{{.Digest}}' "docker://${IMAGE}"`. Treat a missing digest as a non-fatal warning.
+3. Compute the image slug as `IMG_SLUG="${VARIANT}-${IMAGE_TAG}"` so the result file name matches the contract used by `run-gnome-tests` (e.g. `bluefin-stable-smoke.json`).
+4. Perform the git push-back in a best-effort block: log a warning if `git clone` or `publish_test_results.py` fails, but do not let a publication error fail the test workflow.
+5. Pass the resolved digest as the optional sixth positional argument to `publish_test_results.py` so the collector can match QA evidence to the currently published image digest.
+
+
 **Why no inline Python or heredocs (root cause):** YAML `source: |` literal blocks use indentation to determine block extent. Any line at column 0 (including unindented `python3 -c "...\nimport json\n..."` continuation lines, or heredoc bodies like `<<'EOF'\nimport json\n`) terminates the block — YAML treats those lines as new top-level keys. The `yaml: could not find expected ':'` error is the symptom. Fix: use `jq` one-liners, keep everything on the same indented line, or `--rawfile` to read from a pre-staged file.
 
 **onExit dashboard update pattern (bluefin-qa-pipeline + dakota-qa-pipeline):**

--- a/manifests/nightly-smoke-lts-stable.yaml
+++ b/manifests/nightly-smoke-lts-stable.yaml
@@ -1,0 +1,41 @@
+# CronWorkflow: nightly Bluefin LTS stable smoke suite at 03:30 UTC.
+# Runs the container-only bluefin-qa-pipeline against the published :stable LTS image.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: nightly-smoke-lts-stable
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  suspend: false
+  schedules:
+    - "30 3 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  workflowMetadata:
+    labels:
+      app.kubernetes.io/part-of: bluefin-test-suite
+      bluefin.io/trigger: nightly
+      bluefin.io/suite: smoke
+      bluefin.io/variant: bluefin-lts
+  workflowSpec:
+    serviceAccountName: argo
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterSuccess: 86400
+      secondsAfterFailure: 604800
+    workflowTemplateRef:
+      name: bluefin-qa-pipeline
+    arguments:
+      parameters:
+        - name: image
+          value: "ghcr.io/projectbluefin/bluefin-lts"
+        - name: image-tag
+          value: "stable"
+        - name: suites
+          value: "smoke"
+        - name: variant
+          value: "bluefin-lts"

--- a/manifests/nightly-smoke-stable.yaml
+++ b/manifests/nightly-smoke-stable.yaml
@@ -1,0 +1,41 @@
+# CronWorkflow: nightly Bluefin stable smoke suite at 03:00 UTC.
+# Runs the container-only bluefin-qa-pipeline against the published :stable image.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: nightly-smoke-stable
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  suspend: false
+  schedules:
+    - "0 3 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  workflowMetadata:
+    labels:
+      app.kubernetes.io/part-of: bluefin-test-suite
+      bluefin.io/trigger: nightly
+      bluefin.io/suite: smoke
+      bluefin.io/variant: bluefin
+  workflowSpec:
+    serviceAccountName: argo
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterSuccess: 86400
+      secondsAfterFailure: 604800
+    workflowTemplateRef:
+      name: bluefin-qa-pipeline
+    arguments:
+      parameters:
+        - name: image
+          value: "ghcr.io/projectbluefin/bluefin"
+        - name: image-tag
+          value: "stable"
+        - name: suites
+          value: "smoke"
+        - name: variant
+          value: "bluefin"


### PR DESCRIPTION
Closes #275

- `run-container-tests` now resolves the tested image digest with skopeo and publishes digest-pinned results back to the lab repo via `scripts/publish_test_results.py`.
- Added `nightly-smoke-stable` and `nightly-smoke-lts-stable` CronWorkflows so the stable lanes get a nightly smoke suite.
- Updated `docs/skills/argo-workflows.md` with the digest-pinned publication pattern.

Reviewed by agent.