### PR TITLE
ci: teach actionlint about ghost-runners and install pyyaml in tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ghost-runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff pytest-cov
+          python -m pip install pytest ruff pytest-cov pyyaml
 
 
       - name: Run unit tests with coverage


### PR DESCRIPTION
- Adds `.github/actionlint.yaml` declaring the `ghost-runners` self-hosted ARC runner label so Lint CI passes.
- Installs `pyyaml` in Test Suite Validation so `tests/unit/test_workflow_defaults.py` can collect.

Reviewed by agent.