### PR TITLE
ci(lint): skip Argo-parameter image references in registry allowlist

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,6 +60,8 @@ jobs:
             echo "$line" | grep -q 'registry-lint-ignore' && continue
             imgref=$(echo "$line" | sed 's/.*image:[[:space:]]*//' | awk '{print $1}' | tr -d "\"'")
             [[ -z "$imgref" || "${imgref:0:1}" == "#" ]] && continue
+            # Skip Argo parameter interpolations; the real registry is resolved at runtime.
+            [[ "$imgref" == *'{{'* || "$imgref" == *'}}'* ]] && continue
             registry=$(echo "$imgref" | cut -d/ -f1)
             # skip bare names (no dot or colon = implicit docker.io, handled by zot-docker)
             echo "$registry" | grep -qE '[.:]' || continue


### PR DESCRIPTION
The registry allowlist check was flagging literal template parameters like `{{inputs.parameters.image}}:...`. Those are resolved at runtime, so ignore them.

Reviewed by agent.