### PR TITLE
fix(ci): restore nested systemd runtime mounts

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -152,6 +152,9 @@ spec:
         }
         mkdir -p /tmp/results
         podman run --detach --systemd=always --network host --privileged \
+          --cgroupns=host \
+          --security-opt seccomp=unconfined \
+          --tmpfs /run:rw,nosuid,nodev,mode=755,size=256m \
           --name "${TARGET_NAME}" \
           --mount type=bind,source=/sys,destination=/sys,ro,bind-propagation=rprivate \
           --mount type=bind,source=/run/udev,destination=/run/udev,ro,bind-propagation=rprivate \


### PR DESCRIPTION
## Summary
Restore the runtime flags required by nested systemd in `run-container-tests`: writable `/run` tmpfs, host cgroup namespace, and unconfined seccomp.

Without these flags, smoke runners fail before tests with `Read-only file system` for systemd-resolved and `No such device` for systemd-logind.

## Verification
- `just lint`
- pre-commit hook