### PR TITLE
ci: run lint for merge queue checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   lint:

--- a/docs/skills/ci-tooling/SKILL.md
+++ b/docs/skills/ci-tooling/SKILL.md
@@ -56,6 +56,7 @@ metadata:
 22. **Use ARC container mode (`type: kubernetes`) to keep the runner controller small while heavy work runs in separate cluster pods.** Each workflow job must declare a `container:` image. Offload CPU/memory-intensive work (BST builds, large container builds) to existing Argo WorkflowTemplates via `argo submit --from workflowtemplate/<name> --wait` rather than running it directly in the small step container. Grant the runner service account only the RBAC it needs to create and watch workflows in the target namespace.
 23. **Route maintainers to `/docs/ops/maintainer-onboarding.md` for runner access.** The org `ghost-runners` scale set is bound to `https://github.com/projectbluefin` and cannot serve personal repos. A maintainer who wants `ghost-runners` on a personal repo must install the `bluefin-ghost-arc` GitHub App on their personal account and create a second scale set (`ghost-runners-personal`) with a different `githubConfigUrl` and installation secret.
 24. **Accumulate run-level history as git-tracked rolling NDJSON** when a page needs trends over time. Store the file under `docs/data/history/<name>.ndjson`, one JSON object per line. Append only terminal runs, deduplicate by `(plane, run_id)`, prune lines older than the maintainer-chosen retention window, and keep the schema stable (include null placeholders for fields that sources do not yet export).
+25. **Required pull-request checks must also trigger on merge groups.** Add `merge_group: {types: [checks_requested]}` beside `pull_request` for every workflow named in a branch ruleset's `required_status_checks`; a `pull_request` trigger alone leaves queued entries waiting forever because merge-queue refs do not emit ordinary pull-request events. Source: `/websites/github_en_actions`.
 
 ## Common Rationalizations
 
@@ -92,6 +93,7 @@ metadata:
 - The ARC runner service account is given broad cluster-admin permissions instead of a namespace-scoped Role for workflow submission.
 - A maintainer tries to use `runs-on: ghost-runners` from a personal repo instead of creating a separate `ghost-runners-personal` scale set with a personal GitHub App installation.
 - A personal-repo scale set reuses the org's `githubConfigUrl: https://github.com/projectbluefin` or the org's installation secret.
+- A ruleset requires a check whose workflow has no `merge_group` trigger; queued PRs remain in `AWAITING_CHECKS` with no merge-group workflow run.
 
 ## Verification
 
@@ -124,4 +126,5 @@ metadata:
 - [ ] A test container-mode workflow completes and produces the expected build artifact or cache seed.
 - [ ] New maintainers can follow `/docs/ops/maintainer-onboarding.md` to add `ghost-runners` to an org repo.
 - [ ] A personal-repo scale set uses a different `githubConfigUrl` and a different GitHub App installation secret from the org scale set.
+- [ ] Every required status check has a workflow trigger for `merge_group` with `types: [checks_requested]`.
 - [ ] `/docs/ops/maintainer-onboarding.md` is referenced from any skill or ops doc that discusses ARC runner access.


### PR DESCRIPTION
## Summary
- trigger the required lint check for GitHub merge-group refs
- document the merge queue workflow invariant in the CI skill

Without the `merge_group` trigger, queued PRs remain waiting for checks because `pull_request` does not run on merge queue refs.

Verified with `actionlint .github/workflows/lint.yaml`.

Assisted-by: GPT-5 via pi