### PR TITLE
docs: document lab merge queue operations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,10 @@ python3 scripts/validate-docs.py
 actionlint .github/workflows/*.yml .github/workflows/*.yaml
 ```
 - Push Git-tracked changes; ArgoCD reconciles them from `main`
+- All pull requests to `main` enter the GitHub merge queue after required checks pass; see [`docs/ops/merge-queue.md`](docs/ops/merge-queue.md)
 
 ## Pull requests
 - Open PRs against `main`
 - Keep changes scoped and explain the operational impact
+- Required-check workflows must include the `merge_group` trigger so queued PRs receive status results
 - Do not treat this repo like a general-purpose newcomer project; it assumes access to the Bluefin lab and knowledge of the workflow stack

--- a/agents.md
+++ b/agents.md
@@ -62,6 +62,7 @@ npm ci && npm run build
 | Workflow parameter contracts | [`docs/reference/WORKFLOWS.md`](docs/reference/WORKFLOWS.md) |
 | Release verdict / dashboard data contracts | [`docs/adr/0002-release-verdict-definition.md`](docs/adr/0002-release-verdict-definition.md), [`docs/reference/page-contracts.md`](docs/reference/page-contracts.md) |
 | Architecture / failure modes | [`docs/ops/RUNBOOK.md`](docs/ops/RUNBOOK.md) |
+| GitHub `main` merge queue / branch ruleset | [`docs/ops/merge-queue.md`](docs/ops/merge-queue.md) |
 | Human contributor workflow | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 
 ## Skill maintenance

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Quick pointers for agents and contributors.
 - **Agent entry point** → [`agents.md`](../agents.md)
 - **Skill index** → [`docs/skills/README.md`](skills/README.md)
 - **Operational runbook** → [`docs/ops/RUNBOOK.md`](ops/RUNBOOK.md)
+- **Merge queue operations** → [`docs/ops/merge-queue.md`](ops/merge-queue.md)
 - **Command cheat sheet** → [`docs/reference/agent-cheatsheet.md`](reference/agent-cheatsheet.md)
 - **Workflow contracts** → [`docs/reference/WORKFLOWS.md`](reference/WORKFLOWS.md)
 - **Full workflow reference** → [`docs/reference/workflow-reference.md`](reference/workflow-reference.md)

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -8,6 +8,7 @@ Long-form guidance for running, bootstrapping, and recovering the lab cluster.
 - [`maintainer-onboarding.md`](maintainer-onboarding.md) — joining the team that operates this repo
 - [`lab-operations.md`](lab-operations.md) — day-to-day procedures
 - [`k3s-tuning.md`](k3s-tuning.md) — cluster tuning
+- [`merge-queue.md`](merge-queue.md) — `main` branch ruleset and merge-queue operations
 
 These docs are intentionally environment-agnostic. Host-specific details (node
 names, IPs, credentials) belong in a private runbook that is not committed here.

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -1,0 +1,76 @@
+# Lab pull-request merge queue
+
+`main` is protected by the active `main — merge queue` GitHub Ruleset. Incoming
+pull requests must enter the queue; do not bypass the queue for routine merges.
+
+## Policy
+
+| Setting | Value |
+|---|---|
+| Target | `main` |
+| Required check | `lint` |
+| Required approvals | 0 (the lab's approved bot/dependency lane) |
+| Merge method | Squash only |
+| Queue grouping | `ALLGREEN` |
+| Queue capacity | 5 entries / 5 entries per group |
+| Queue wait | 0 minutes |
+| Queue check timeout | 30 minutes |
+| Branch updates | Non-fast-forward updates blocked; branch deletion enabled after merge |
+
+Path-filtered workflows such as `Docs` and `Test Suite Validation` are not
+required ruleset checks. The always-on `Lint` workflow is the queue gate.
+
+## Required workflow invariant
+
+Every workflow named in `required_status_checks` must run for both ordinary pull
+requests and merge groups:
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+```
+
+A `pull_request` trigger alone does not run on the temporary
+`gh-readonly-queue/main/...` ref. The queue then remains in `AWAITING_CHECKS`
+without a check run. See the [GitHub Actions `merge_group` documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group).
+
+## Queueing a PR
+
+Only queue a PR after its review/approval policy is satisfied and its required
+checks pass:
+
+```bash
+gh pr checks <number> --repo projectbluefin/lab
+gh pr merge <number> --repo projectbluefin/lab --auto --squash
+```
+
+Verify the queue entry through GraphQL when troubleshooting:
+
+```bash
+gh api graphql -f query='query { repository(owner:"projectbluefin", name:"lab") { pullRequest(number:<number>) { mergeQueueEntry { position state enqueuedAt } } } }'
+```
+
+Do not use `--admin` for routine dependency or feature PRs. The organization
+administrator bypass exists only for an emergency or for bootstrapping a
+configuration change that must land before the queue can validate itself.
+
+## Troubleshooting
+
+- `Protected branch rules not configured for this branch` means the Ruleset is
+  missing or inactive; inspect `gh api repos/projectbluefin/lab/rulesets`.
+- `AWAITING_CHECKS` with no `merge_group` Actions run means the required
+  workflow is missing the `merge_group` trigger.
+- `DIRTY` or `UNMERGEABLE` after an earlier queue merge means the PR branch is
+  stale. Update it against current `main`, rerun `lint`, and requeue it.
+- Never remove the required check just to make the queue advance.
+
+The Ruleset is configured in GitHub repository settings rather than in ArgoCD;
+validate it with:
+
+```bash
+gh api repos/projectbluefin/lab/rulesets --paginate
+gh api repos/projectbluefin/lab/rulesets/<id>
+```


### PR DESCRIPTION
## Summary
- document the active `main` ruleset and queue policy
- document the `merge_group` required-check invariant and troubleshooting
- link the runbook from contributor and agent entry points

Validation: `just lint`, `python3 scripts/validate-docs.py`, `git diff --check`.

Assisted-by: GPT-5 via pi