### PR TITLE
docs: teach agents to use the lab merge queue

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,5 +15,7 @@ Keep only these repo-specific inline reminders:
 - Compare existing subdomains before DNS/TLS changes; keep static GitHub Pages hosts behind the established Cloudflare-proxied pattern unless GitHub cert issuance is confirmed.
 - If Cloudflare fronts a Pages site, opt the dashboard entry script out of Rocket Loader with `data-cfasync="false"` and verify the live HTML preserves the raw script tag.
 - PR queue work is only complete with real lab evidence.
+- `main` uses the GitHub merge queue; queue routine PRs with `gh pr merge <number> --auto --squash`, never `--admin`.
+- Any workflow named in the `main` ruleset's required checks must include `merge_group: {types: [checks_requested]}` as well as its normal `pull_request` trigger, or queued PRs wait forever in `AWAITING_CHECKS`.
 - ARC container-mode runners require a `container:` block on every job and offload heavy work to Argo Workflows; point maintainers to `/docs/ops/maintainer-onboarding.md` for access/auth and the personal-repo scale-set pattern.
 - At end of any non-trivial session, run the self-improvement loop in `/docs/skills/meta-skill-improvement/SKILL.md` and update the relevant skill file(s) with the durable pattern before handoff.


### PR DESCRIPTION
## Summary
- teach agents to queue routine PRs with auto-merge and squash
- make the required `merge_group` trigger invariant explicit in Copilot instructions

Validation: `python3 scripts/validate-docs.py`, `git diff --check`.

Assisted-by: GPT-5 via pi