### PR TITLE
fix(ci): redact token from dakota PR workflow logs

### DIFF
--- a/argo/workflow-templates/dakota-pr-batch-pipeline.yaml
+++ b/argo/workflow-templates/dakota-pr-batch-pipeline.yaml
@@ -79,7 +79,8 @@ spec:
             mountPath: /dev/fuse
         source: |
           exec bash <<'SCRIPT_EOF'
-          set -euxo pipefail
+          # Do not trace authenticated GitHub API commands or token-bearing variables.
+          set -euo pipefail
 
           REPO_SLUG="{{workflow.parameters.repo-slug}}"
           REPO_URL="{{workflow.parameters.repo-url}}"


### PR DESCRIPTION
## Summary
- disable shell tracing in the Dakota PR batch workflow
- prevent GITHUB_TOKEN and authenticated curl commands from appearing in Argo logs

Fixes #305.

## Validation
- `git diff --check`
- pre-commit hook installed by repository commit flow: no linting errors

This workflow change must be synced before resuming Dakota PR batch reviews.