### PR TITLE
perf(buildbarn): tune workers for USB4 fabric and full-rootfs input roots

### DIFF
--- a/manifests/buildbarn-config.yaml
+++ b/manifests/buildbarn-config.yaml
@@ -243,15 +243,22 @@ data:
         native: {
           buildDirectoryPath: '/worker/build',
           cacheDirectoryPath: '/worker/cache',
-          maximumCacheFileCount: 20000,
-          maximumCacheSizeBytes: 64 * 1024 * 1024 * 1024,
+          // Dakota/BST actions chroot into full OS rootfs input roots with
+          // hundreds of thousands of files. 20k entries caused permanent cache
+          // thrash: every action refetched nearly its whole input root from CAS
+          // file-by-file (observed 10h inputFetch phases). Size the cache to
+          // hold several complete sysroots.
+          maximumCacheFileCount: 1000000,
+          maximumCacheSizeBytes: 96 * 1024 * 1024 * 1024,
           cacheReplacementPolicy: 'LEAST_RECENTLY_USED',
         },
         runners: [{
           endpoint: { address: 'unix:///worker/runner' },
-          // Keep one action slot per worker to stay within scheduler-admitted
-          // memory on lightweight cluster nodes.
-          concurrency: 1,
+          // Both nodes have 32 cores / 64 GiB and a 40Gb/s USB4 link to the
+          // CAS shards; one slot per node left both nodes ~idle. Four slots
+          // per worker keeps within the 16Gi pod memory limit (large BST link
+          // steps peak ~4G) while actually using the fabric.
+          concurrency: 4,
           // Match BuildStream REAPI action platform properties so workers
           // register into the same scheduler queue key.
           platform: {
@@ -266,11 +273,14 @@ data:
           },
         }],
       }],
-      inputDownloadConcurrency: 16,
-      outputUploadConcurrency: 8,
+      // The USB4 link is effectively local-bus latency; deep pipelines are
+      // free. Raise CAS transfer concurrency so input roots stream instead of
+      // trickling file-by-file.
+      inputDownloadConcurrency: 128,
+      outputUploadConcurrency: 64,
       directoryCache: {
-        maximumCount: 20000,
-        maximumSizeBytes: 128 * 1024 * 1024,
+        maximumCount: 200000,
+        maximumSizeBytes: 1024 * 1024 * 1024,
         cacheReplacementPolicy: 'LEAST_RECENTLY_USED',
       },
     }

--- a/manifests/buildbarn-worker.yaml
+++ b/manifests/buildbarn-worker.yaml
@@ -24,7 +24,7 @@ spec:
       labels:
         app: worker
       annotations:
-        buildbarn-config-revision: "2026-07-12-2"
+        buildbarn-config-revision: "2026-07-20-1"
         prometheus.io/scrape: "true"
         prometheus.io/port: "9980"
     spec:
@@ -65,11 +65,14 @@ spec:
               containerPort: 9980
           resources:
             requests:
-              cpu: 200m
-              memory: 512Mi
+              cpu: 500m
+              memory: 1Gi
             limits:
-              cpu: "2"
-              memory: 2Gi
+              # bb_worker does all CAS input-root fetching; with 128-way
+              # download concurrency over the USB4 fabric it needs real CPU
+              # for checksumming and more memory for in-flight blobs.
+              cpu: "8"
+              memory: 8Gi
           volumeMounts:
             - mountPath: /config/
               name: configs
@@ -92,8 +95,11 @@ spec:
               cpu: "8"
               memory: 16Gi
             limits:
-              cpu: "8"
-              memory: 16Gi
+              # 32-core nodes with 4 concurrent action slots: allow bursts up
+              # to 24 cores so parallel compiles saturate the node instead of
+              # being throttled at 8.
+              cpu: "24"
+              memory: 48Gi
           volumeMounts:
             - mountPath: /config/
               name: configs


### PR DESCRIPTION
Dakota BST remote-execution actions spent up to 10h in inputFetch and failed with `Shard N: context canceled` because the bb_worker file cache (20k entries) cannot hold an OS-rootfs input root — every action refetched nearly all files from CAS. Both 32-core nodes were also capped at 1 action slot each.

Changes (see commit for details):
- worker file cache 20k→1M entries, 64→96 GiB
- directory cache 20k→200k, 128Mi→1Gi
- per-node action concurrency 1→4
- inputDownloadConcurrency 16→128, outputUploadConcurrency 8→64
- container resource limits raised to actually use the 32-core nodes

No pinning/taints/locality bias; DaemonSet unchanged topologically. Validated with `just lint`.