### PR TITLE
fix(buildbarn): provide /dev/null and siblings in chroot input root

### DIFF
--- a/manifests/buildbarn-config.yaml
+++ b/manifests/buildbarn-config.yaml
@@ -271,6 +271,11 @@ data:
             pod: std.extVar('POD_NAME'),
             node: std.extVar('NODE_NAME'),
           },
+          // BuildStream actions (meson compiler detection) and many Unix
+          // utilities expect /dev/null, /dev/zero, /dev/random, etc. inside
+          // the sandbox. The runner chroots into the input root, so install
+          // minimal character device nodes there before each action.
+          inputRootCharacterDeviceNodes: ['null', 'zero', 'random', 'urandom', 'tty'],
         }],
       }],
       // The USB4 link is effectively local-bus latency; deep pipelines are

--- a/manifests/buildbarn-worker.yaml
+++ b/manifests/buildbarn-worker.yaml
@@ -24,7 +24,7 @@ spec:
       labels:
         app: worker
       annotations:
-        buildbarn-config-revision: "2026-07-20-1"
+        buildbarn-config-revision: "2026-07-20-2"
         prometheus.io/scrape: "true"
         prometheus.io/port: "9980"
     spec:


### PR DESCRIPTION
Buildbarn's `chrootIntoInputRoot` gives BuildStream actions an empty `/dev`, breaking meson compiler detection (`icx --version` redirects to `/dev/null`).

Use the upstream `inputRootCharacterDeviceNodes` option to inject `null`, `zero`, `random`, `urandom`, and `tty` into the action input root before execution.

Also bumps the `buildbarn-config-revision` annotation so the DaemonSet rolls out the new config.

Validation:
- `python3 -m yaml` parses `manifests/buildbarn-config.yaml` and `manifests/buildbarn-worker.yaml`.
- Pre-commit/actionlint hook passes.

Closes #271.