### PR TITLE
fix(iso): expose loop devices to lab builder

### DIFF
--- a/argo/workflow-templates/iso-build-e2e-pipeline.yaml
+++ b/argo/workflow-templates/iso-build-e2e-pipeline.yaml
@@ -48,8 +48,8 @@ spec:
       volumeMounts:
       - name: work
         mountPath: /work
-      - name: kvm
-        mountPath: /dev/kvm
+      - name: dev
+        mountPath: /dev
       source: |
         set -euo pipefail
 
@@ -111,7 +111,7 @@ spec:
     - name: work
       emptyDir:
         sizeLimit: 60Gi
-    - name: kvm
+    - name: dev
       hostPath:
-        path: /dev/kvm
-        type: CharDevice
+        path: /dev
+        type: Directory

--- a/argo/workflow-templates/iso-build-e2e-pipeline.yaml
+++ b/argo/workflow-templates/iso-build-e2e-pipeline.yaml
@@ -72,7 +72,8 @@ spec:
         git -C "${ISO_DIR}" checkout --detach FETCH_HEAD
 
         export BUILD_DIR
-        export PODMAN=podman
+        # Nested Podman cannot use overlay on the lab pod's overlay filesystem.
+        export PODMAN='podman --storage-driver=vfs'
         export GITHUB_REPOSITORY_OWNER=ublue-os
         bash "${ISO_DIR}/hack/local-iso-build.sh" "${VARIANT}" "${FLAVOR}" ghcr
 


### PR DESCRIPTION
Expose the host /dev tree to the privileged ISO build pod so Titanoboa can create loop devices while assembling the boot media.