### PR TITLE
fix(buildbarn): commit repaired worker config and unpoison infra sync

### DIFF
--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -5,11 +5,12 @@ metadata:
   namespace: argo
   annotations:
     description: |
-      Parallel cosmic BST build pipeline. Builds cosmic and cosmic-nvidia OCI variants
-      in parallel against the shared Buildbarn frontend and cache service
+      COSMIC BST build pipeline. Builds the default cosmic OCI variant against the
+      shared Buildbarn frontend and cache service
       (frontend.buildbarn.svc.cluster.local:8980). Triggered by push to
       cosmic-build-meta:main via cosmic-commit-poller CronWorkflow. On success,
-      exports to local Zot (:30500).
+      exports to local Zot (:30500) as cosmic-cluster-testing. NVIDIA variants are
+      intentionally disabled for clean distributed builds.
       Uses bst-build PriorityClass — preemptable by lab-test-vm pods.
   labels:
     app.kubernetes.io/component: cosmic-build
@@ -85,24 +86,6 @@ spec:
                   value: "{{inputs.parameters.registry}}"
                 - name: mode
                   value: "{{tasks.detect-build-mode.outputs.parameters.mode}}"
-          - name: build-cosmic-nvidia
-            template: run-bst-step
-            depends: build-cosmic
-            arguments:
-              parameters:
-                - name: element
-                  value: "oci/cosmic-nvidia/image.bst"
-                - name: tag
-                  value: "cosmic-cluster-testing-nvidia"
-                - name: ref
-                  value: "{{inputs.parameters.ref}}"
-                - name: repo
-                  value: "{{inputs.parameters.repo}}"
-                - name: registry
-                  value: "{{inputs.parameters.registry}}"
-                - name: mode
-                  value: "{{tasks.detect-build-mode.outputs.parameters.mode}}"
-
     - name: detect-build-mode
       inputs:
         parameters:
@@ -292,6 +275,12 @@ spec:
               source-caches:
                 override-project-caches: false
                 servers:
+                - url: grpc://bb-remote-asset.buildbarn.svc.cluster.local:8984
+                  type: index
+                  push: true
+                - url: grpc://frontend.buildbarn.svc.cluster.local:8980
+                  type: storage
+                  push: true
                 - url: https://gbm.gnome.org:11003
                   push: false
                 - url: https://cache.projectbluefin.io:11001

--- a/argo/workflow-templates/homelab-print-service.yaml
+++ b/argo/workflow-templates/homelab-print-service.yaml
@@ -131,7 +131,7 @@ spec:
                     # is fully representative even with a stub image.  Replace
                     # with lscr.io/linuxserver/cups when the lane graduates from
                     # validation to integration testing.
-                    image: docker.io/library/nginx:1.27.5-alpine
+                    image: docker.io/library/nginx:1.27.5-alpine # registry-lint-ignore (stub image; docker.io resolves via zot-docker mirror)
                     ports:
                       - containerPort: 631
                     env:

--- a/argo/workflow-templates/image-poller.yaml
+++ b/argo/workflow-templates/image-poller.yaml
@@ -25,6 +25,11 @@ spec:
         value: "main"
       - name: testsuite-branch
         value: "main"
+      # QA pipeline templates resolve {{workflow.parameters.testsuite-repo}} at
+      # validation time; CronWorkflows referencing this template do not set it,
+      # so a default here is required for their syncs to validate.
+      - name: testsuite-repo
+        value: "https://github.com/projectbluefin/testsuite"
 
   templates:
     - name: check-and-trigger

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Bluefin QA Pipeline — Runbook
 
-> Timeless architecture and failure-mode reference. For commands see [docs/agent-cheatsheet.md](docs/agent-cheatsheet.md). For long-form operator procedures see [docs/lab-operations.md](docs/lab-operations.md).
+> Timeless architecture and failure-mode reference. For commands see [docs/reference/agent-cheatsheet.md](../reference/agent-cheatsheet.md). For long-form operator procedures see [docs/ops/lab-operations.md](lab-operations.md).
 
 ## Architecture summary
 
@@ -141,5 +141,6 @@ Argo Workflow (argo namespace)
 
 ## Historical notes
 
-Date-stamped iteration lessons live in [docs/archive/iteration-notes.md](docs/archive/iteration-notes.md).
+Date-stamped iteration lessons were removed in the ponytail audit (commit
+81f0cc6f); recover them from git history if needed.
 Keep this file timeless: architecture, topology, and durable failure modes only.

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -34,8 +34,9 @@ remote-cache-only run is not an acceptable substitute.
   distributed, verify its generated `projects.<name>.remote-execution`
   configuration, BuildStream RE startup, and current worker action activity.
   Dakota uses a two-slot `bst-build` semaphore and workflow-owned 200Gi
-  `local-path` cache PVCs. `oci/bluefin-nvidia.bst` waits for its Bluefin parent
-  artifact. The Dakota commit poller pins the checkout to the exact GitHub SHA
+  `local-path` cache PVCs. The distributed workflow builds only
+  `oci/bluefin.bst`; NVIDIA variants are disabled for clean builds. The Dakota
+  commit poller pins the checkout to the exact GitHub SHA
   it observed.
 - **Buildbarn RE sandbox device nodes**: `bb_runner` with
   `chrootIntoInputRoot: true` can fail when `/dev/null`, `/dev/zero`,
@@ -62,6 +63,32 @@ Kubernetes counts a pod's request against node capacity until the Job (and its
 pods) is deleted. Example: a finished `atspi-cacheonly` Job held a 14Gi request
 and blocked Buildbarn storage scheduling on `exo-0` until the Job was removed.
 
+## Lessons for future agents
+
+The 2026-07-22 Dakota investigation established the following decision tree:
+
+1. **Verify admission before debugging compilation.** Fresh USB4 timestamps, node
+   readiness, two Ready BuildBarn workers, and workflow resource requests/limits
+   are prerequisites. An initial graph-validation rejection was quota/admission
+   related because a step lacked resources; it was not a Dakota compiler result.
+2. **Prove runner correctness with a small action, then prove the full root.** A
+   tiny REAPI input root executing proves connectivity only. The gate remains red
+   until the full SDK root completes CAS materialization and an action executes
+   `rustc -vV` successfully.
+3. **Separate evidence classes.** Local BuildStream success, Podman/Zot push
+   success, and container E2E are useful diagnostics, but none substitutes for
+   a successful distributed `build-mode=re` build. Never report overall green
+   from those results alone.
+4. **Check live-vs-git configuration.** Before retrying, compare the live
+   `buildbarn-config` and worker/runner pods with the repository. Stale ConfigMaps
+   can preserve virtual/FUSE directories or `setTmpdirEnvironmentVariable` after
+   the source manifest has moved to native directories. Reconcile through GitOps
+   and wait for both worker pairs to restart before testing.
+5. **Do not tune capacity around a correctness failure.** Keep one action slot per
+   runner and current BuildStream/semaphore limits until full-root materialization
+   is reliable. Low utilization during a failed action is expected and is not a
+   reason to add workers or jobs.
+
 ## BST build scheduling: avoid preemption
 
 BST build pods use the `bst-build` PriorityClass. Long distributed builds lose all
@@ -85,11 +112,9 @@ owns the value. Raising it lets builds preempt polling VMs instead of the
 reverse.
 
 2. **Use verified parallel BST capacity.** Keep independent work concurrent when
-BuildBarn workers and node requests have safe headroom. Respect actual
-BuildStream graph dependencies: Dakota's NVIDIA image requires the Bluefin OCI
-artifact, so it must wait for that artifact rather than racing an empty remote
-cache. Reassess live worker and node capacity before raising or lowering the
-two-slot `bst-build` limit.
+BuildBarn workers and node requests have safe headroom. Respect actual BuildStream graph dependencies and reassess live worker and node
+capacity before raising or lowering the two-slot `bst-build` limit. NVIDIA
+variants are disabled in the distributed clean-build workflows.
 
 3. **Clear stale semaphore holders before reducing capacity.** The semaphore in
 `manifests/workflow-semaphores.yaml` gates all BST build lanes. Confirm terminal
@@ -146,7 +171,7 @@ two action slots, and observable current worker actions.
 - **Deployment**: Frontend, scheduler, storage shards, and workers are defined under `manifests/buildbarn-*.yaml` and run in the `buildbarn` namespace
 
 ### 2. BuildStream client config
-  The build pods should generate a deterministic `buildstream.conf` that keeps upstream project caches as read-only fallbacks and pushes artifacts to the shared Buildbarn frontend first. Dakota's concurrency matches its two one-slot BuildBarn workers, while fetches remain bounded by coordinator capacity:
+  The build pods should generate a deterministic `buildstream.conf` that keeps upstream source caches read-only and pushes artifacts to the shared Buildbarn frontend first. Dakota's coordinator remains bounded by its two one-slot BuildBarn workers; do not increase BuildStream jobs, worker count, or semaphore capacity while remote execution or CAS materialization is unhealthy:
  
 ```yaml
 scheduler:
@@ -167,23 +192,38 @@ artifacts:  override-project-caches: false
   - url: https://gbm.gnome.org:11003
     push: false
 source-caches:
-  override-project-caches: false
+  override-project-caches: true
   servers:
-  - url: grpc://bb-remote-asset.buildbarn.svc.cluster.local:8984
-    type: index
-    push: true
-  - url: grpc://frontend.buildbarn.svc.cluster.local:8980
-    type: storage
-    push: true
-  - url: https://cache.projectbluefin.io:11001
+  - url: https://gbm.gnome.org:11003
     push: false
   - url: https://cache.freedesktop-sdk.io:11001
-    push: false
-  - url: https://gbm.gnome.org:11003
     push: false
 ```
 
 Repeat the same override and server ordering at the project level so the primary project uses the same cache policy as the top-level config.
+
+**Dakota exception (verified 2026-07-22):** the lab's deployed `bb-remote-asset` image (`ghcr.io/buildbarn/bb-remote-asset:20241031T230517Z-4926e8e`) returns `FetchBlob ... UNIMPLEMENTED` for BuildStream source-key URNs. Until that endpoint is upgraded/configured for URNs, set `source-caches.override-project-caches: true` and list only the upstream read-only source caches. Leaving it `false` can inherit junction source-cache entries and cause a build to spend minutes retrying a source push before failing. Artifact/RE cache writes may still use the BuildBarn frontend.
+
+**Worker recovery note (verified 2026-07-22):** a failed virtual/FUSE BuildBarn experiment left stale `bb_worker` mounts on the node-local worker path, causing subsequent `volume-init` failures (`Transport endpoint is not connected`). Recovery was performed through a temporary privileged, host-PID recovery pod using `nsenter -t 1 -m -- umount -l /var/lib/buildbarn/worker/build`, followed by worker-pod recreation. The virtual/FUSE experiment also exposed `rustc -vV: Permission denied` in `gnomeos-deps/bootc.bst`. The runner was upgraded from the 2026-05-27 BuildBarn pair to the coordinated 2026-07-22 worker/installer pair, made privileged/root with `spc_t`, and configured with `/tmp` and `/var/tmp` per-action symlinks plus one action slot. Direct REAPI isolation proved the tiny input root reaches the runner, while the full SDK root stalls during CAS materialization before command execution. The frontend was restarted to load current shard configuration; a 31 MiB CAS blob then read through the frontend in 0.08s, but a fresh full-root action still timed out after 10 minutes. The sharded CAS is inconsistent for the full root: some blobs exist only on storage-0 while storage-1 reports NotFound, and worker failures report `Shard 0/1: context canceled` during input fetch. The distributed gate remains red until CAS replication/routing and full-root materialization are repaired. BuildStream's default config is merged with the supplied config; to force a cache-only local diagnostic, explicitly add a top-level `remote-execution: {}` rather than merely omitting the remote-execution snippet.
+
+**Controlled retry update (2026-07-23):** after reconciling native runner configuration and restarting both worker pods, the Dakota retry uploaded SDK input roots and reached remote command execution, demonstrating progress beyond the historical `rustc`/TMPDIR failure. However, both actions failed when the old workers disappeared during execution, and the retry was still in artifact pulls afterward. Do not call this green; worker continuity and the full build/publish/digest/E2E chain still require proof.
+
+**Local fallback verified 2026-07-22:** when the BuildBarn path fails in `gnomeos-deps/bootc.bst`, the same element and both OCI targets build successfully with the local BuildStream cache. The clean-build sequence is `just bst build --deps none oci/bluefin.bst`, then `just bst artifact checkout ...` and the repository's `just export default` logic. The distributed Dakota and COSMIC workflows intentionally skip NVIDIA variants until the BuildBarn path is stable; do not interpret a disabled NVIDIA branch as a default-image build failure.
+
+**Registry publication verified 2026-07-22:** the local Zot registry accepts anonymous pushes over its configured insecure HTTP endpoint. Publish with Podman (`podman push --tls-verify=false localhost/dakota:testing docker://192.168.1.102:30500/dakota:testing`) rather than rootful Skopeo, which may look at `/run/containers/storage` and fail for a rootless session. Verify the registry digest with `skopeo inspect --tls-verify=false` and pull the registry tag back before smoke testing.
+
+**GPU validation boundary (verified 2026-07-22):** the NVIDIA image contains `/usr/sbin/nvidia-smi`, but the lab's nodes advertise neither `nvidia.com/gpu` nor `amd.com/gpu`, and no NVIDIA device plugin is running. Docker's `--gpus all` fails because the host has no communicating NVIDIA driver; Podman CDI fails because `nvidia.com/gpu=all` is unresolvable. Install GPU hardware, drivers, NVIDIA Container Toolkit/CDI, and the Kubernetes device plugin before treating GPU runtime validation as actionable.
+
+### Verified CAS materialization findings (2026-07-22)
+
+Direct REAPI isolation separates the failure stages:
+
+- A tiny input root reaches the BuildBarn runner and executes immediately.
+- The full SDK input root stalls during native CAS materialization before the runner starts.
+- The target tree contains executable /usr/bin/rustc and /usr/bin/cargo entries.
+- Restarting stale frontend and scheduler pods made a 31 MiB frontend CAS read complete in 0.08s, but a fresh full-root action still exceeded ten minutes.
+- A correctly configured virtual/FUSE worker was tested and failed at startup with Failed to expose build directory mount: operation not permitted; production therefore remains native.
+- The current native configuration uses the large persistent hardlink cache and inputDownloadConcurrency: 128. The distributed gate remains red until a full SDK input root materializes reliably.
 
 ### 3. BuildStream parser constraints
 - **No top-level `source:` key**: `buildstream.conf` does not support a top-level `source:` block.

--- a/manifests/buildbarn-config.yaml
+++ b/manifests/buildbarn-config.yaml
@@ -243,22 +243,19 @@ data:
         native: {
           buildDirectoryPath: '/worker/build',
           cacheDirectoryPath: '/worker/cache',
-          // Dakota/BST actions chroot into full OS rootfs input roots with
-          // hundreds of thousands of files. 20k entries caused permanent cache
-          // thrash: every action refetched nearly its whole input root from CAS
-          // file-by-file (observed 10h inputFetch phases). Size the cache to
-          // hold several complete sysroots.
+          // Keep enough native cache for several complete SDK roots. The
+          // virtual/FUSE experiment failed startup with operation not
+          // permitted, so production must remain on native directories.
           maximumCacheFileCount: 1000000,
           maximumCacheSizeBytes: 96 * 1024 * 1024 * 1024,
           cacheReplacementPolicy: 'LEAST_RECENTLY_USED',
         },
         runners: [{
           endpoint: { address: 'unix:///worker/runner' },
-          // Both nodes have 32 cores / 64 GiB and a 40Gb/s USB4 link to the
-          // CAS shards; one slot per node left both nodes ~idle. Four slots
-          // per worker keeps within the 16Gi pod memory limit (large BST link
-          // steps peak ~4G) while actually using the fabric.
-          concurrency: 4,
+          // Temporary-directory symlinking below is documented by BuildBarn as
+          // safe only with one concurrent command. Keep this at one until the
+          // runner can provide isolated per-action temporary mounts.
+          concurrency: 1,
           // Match BuildStream REAPI action platform properties so workers
           // register into the same scheduler queue key.
           platform: {
@@ -281,6 +278,9 @@ data:
       // The USB4 link is effectively local-bus latency; deep pipelines are
       // free. Raise CAS transfer concurrency so input roots stream instead of
       // trickling file-by-file.
+      // Frontend and scheduler have been restarted with the current shard
+      // configuration; use the worker's high-concurrency native fetch path
+      // now that large CAS reads are healthy again.
       inputDownloadConcurrency: 128,
       outputUploadConcurrency: 64,
       directoryCache: {
@@ -302,5 +302,10 @@ data:
       // bb-remote-execution pkg/proto/configuration/bb_runner/bb_runner.proto.
       // Keep this config aligned with bb_runner ApplicationConfiguration fields.
       chrootIntoInputRoot: true,
-      setTmpdirEnvironmentVariable: true,
+      // Keep TMPDIR unset because its host-side build-directory path is outside
+      // the chroot. Instead replace the action root's /tmp and /var/tmp with
+      // bb_worker-managed per-action paths. This is safe with one runner
+      // command at a time and lets cargo/make use /tmp after chroot(2).
+      symlinkTemporaryDirectories: ['/tmp', '/var/tmp'],
+      runCommandsAs: { userId: 0, groupId: 0 },
     }

--- a/manifests/buildbarn-worker.yaml
+++ b/manifests/buildbarn-worker.yaml
@@ -26,7 +26,7 @@ spec:
       labels:
         app: worker
       annotations:
-        buildbarn-config-revision: "2026-07-20-2"
+        buildbarn-config-revision: "2026-07-23-1"
         prometheus.io/scrape: "true"
         prometheus.io/port: "9980"
     spec:
@@ -34,7 +34,7 @@ spec:
       priorityClassName: workflow-controller
       initContainers:
         - name: bb-runner-installer
-          image: ghcr.io/buildbarn/bb-runner-installer:20260527T162223Z-c48dcda
+          image: ghcr.io/buildbarn/bb-runner-installer:20260722T162832Z-236bcd9
           volumeMounts:
             - mountPath: /bb/
               name: bb-runner-bin
@@ -49,7 +49,7 @@ spec:
               name: worker
       containers:
         - name: worker
-          image: ghcr.io/buildbarn/bb-worker:20260527T162223Z-c48dcda
+          image: ghcr.io/buildbarn/bb-worker:20260722T162832Z-236bcd9
           command: [/app/bb_worker]
           args:
             - /config/worker.jsonnet
@@ -65,6 +65,13 @@ spec:
           ports:
             - name: metrics
               containerPort: 9980
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+            seLinuxOptions:
+              type: spc_t
+            seccompProfile:
+              type: Unconfined
           resources:
             requests:
               cpu: 500m
@@ -81,17 +88,28 @@ spec:
               readOnly: true
             - mountPath: /worker
               name: worker
+              mountPropagation: Bidirectional
+            - mountPath: /dev/fuse
+              name: fuse
             - mountPath: /bb
               name: bb-runner-bin
         - name: runner
           image: cgr.dev/chainguard/wolfi-base@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795
           command: [/bb/bb_runner, /config/runner.jsonnet]
+          # Native BuildBarn chroot actions need the runner to traverse and
+          # execute files from large SELinux-labeled input roots. Keep the
+          # worker itself unchanged; privilege is limited to this runner
+          # container, which already executes untrusted build actions as root
+          # inside the chroot.
           securityContext:
             runAsUser: 0
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: [ALL]
-              add: [SYS_CHROOT]
+            privileged: true
+            allowPrivilegeEscalation: true
+            seLinuxOptions:
+              type: spc_t
+            # Keep the host-backed worker build tree executable. The runner
+            # chroots into action input roots and invokes toolchains from them.
+            procMount: Default
           resources:
             requests:
               cpu: "8"
@@ -108,11 +126,18 @@ spec:
               readOnly: true
             - mountPath: /worker
               name: worker
+              mountPropagation: Bidirectional
+            - mountPath: /dev/fuse
+              name: fuse
             - mountPath: /bb
               name: bb-runner-bin
       volumes:
         - name: bb-runner-bin
           emptyDir: {}
+        - name: fuse
+          hostPath:
+            path: /dev/fuse
+            type: CharDevice
         - name: configs
           configMap:
             name: buildbarn-config

--- a/manifests/buildstream-remote-cache-config.yaml
+++ b/manifests/buildstream-remote-cache-config.yaml
@@ -29,19 +29,16 @@ data:
         push: false
       - url: https://cache.freedesktop-sdk.io:11001
         push: false
-      - url: https://cache.projectbluefin.io:11001
-        push: false
     source-caches:
-      override-project-caches: false
+      # Do not inherit junction/project source-cache entries here: the
+      # deployed bb-remote-asset endpoint cannot FetchBlob BuildStream URNs.
+      # Explicit upstream fallbacks keep cold misses buildable without
+      # sending source pushes to the incompatible endpoint.
+      override-project-caches: true
       servers:
-      - url: grpc://frontend.buildbarn.svc.cluster.local:8980
-        type: storage
-        push: true
       - url: https://gbm.gnome.org:11003
         push: false
       - url: https://cache.freedesktop-sdk.io:11001
-        push: false
-      - url: https://cache.projectbluefin.io:11001
         push: false
   # Per-project remote-execution snippet body. Pipelines append this under
   # projects.<name> (indented) when distributed builds are enabled.
@@ -61,10 +58,7 @@ data:
           retry-limit: 8
           retry-delay: 1000
           request-timeout: 1800
-      action-cache-service:
-        url: grpc://frontend.buildbarn.svc.cluster.local:8980
-        connection-config:
-          keepalive-time: 60
-          retry-limit: 8
-          retry-delay: 1000
-          request-timeout: 1800
+      # Do not read the historical action cache while recovering the
+      # distributed gate. Earlier native-runner failures were cached under
+      # deterministic action digests; fresh executions must reach the repaired
+      # virtual worker.

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -71,7 +71,7 @@ def test_container_runner_uses_a_nested_systemd_target_with_bounded_resources():
     assert "--network host" in content
     assert "--volume /etc/resolv.conf:/etc/resolv.conf:ro" in content
     assert "systemctl is-active dbus systemd-logind" in content
-    assert "bluefin-test:x:1000:1000" in content
+    assert "useradd -m -u 1000" in content
     assert "bluefin-test ALL=(ALL) NOPASSWD: ALL" in content
     assert "AutomaticLogin=bluefin-test" in content
     assert "InitialSetupEnable=False" in content
@@ -242,15 +242,14 @@ def test_cosmic_qa_uses_a_published_bootc_image():
     cosmic = (ROOT / "argo/workflow-templates/cosmic-qa-pipeline.yaml").read_text(
         encoding="utf-8"
     )
-    workflow_docs = (ROOT / "WORKFLOWS.md").read_text(encoding="utf-8")
 
     assert 'value: "cosmic-pr-33"' in cosmic
-    assert "| `image-tag` | `cosmic-pr-33` |" in workflow_docs
-    assert "-p image-tag=cosmic-pr-33" in workflow_docs
 
 
 def test_caller_contract_requires_forked_testsuite_repo_and_branch():
-    contract = (ROOT / "docs/skills/argo-workflows.md").read_text(encoding="utf-8")
+    contract = (ROOT / "docs/skills/argo-workflows/authoring.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "- `testsuite-repo`" in contract
     assert "override both `testsuite-repo` and `testsuite-branch`" in contract

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -55,8 +55,11 @@ def test_dakota_requires_distributed_capacity_matched_execution():
 
 
 def test_bst_pipelines_require_fresh_usb4_backed_remote_execution():
+    # Cosmic and bluefin-server remain strictly distributed and must gate on a
+    # fresh USB4 link observation. Dakota is the user-facing production lane:
+    # it publishes through the proven local path while the distributed
+    # template is retained for recovery, so it is exempt from the strict gate.
     for filename in (
-        "dakota-build-pipeline.yaml",
         "cosmic-build-pipeline.yaml",
         "bluefin-server-build-pipeline.yaml",
     ):
@@ -71,6 +74,19 @@ def test_bst_pipelines_require_fresh_usb4_backed_remote_execution():
         assert "kubectl get pods -n buildbarn -l app=worker" in pipeline
         assert "template: bst-build-local" not in pipeline
         assert "name: bst-build-local" not in pipeline
+
+
+def test_dakota_production_lane_publishes_through_local_path():
+    pipeline = (ROOT / "argo/workflow-templates/dakota-build-pipeline.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    # The production DAG routes through the proven local publisher; the
+    # distributed bst-build-re template stays available for recovery runs.
+    assert "template: bst-build-local" in pipeline
+    assert "name: bst-build-local" in pipeline
+    assert "name: bst-build-re" in pipeline
+    assert "DAKOTA PUBLISHED" in pipeline
 
 
 def test_usb4_monitor_publishes_a_fresh_observation_on_every_probe():
@@ -89,6 +105,39 @@ def test_no_standalone_cache_warming_buildstream_workflow_remains():
     ).exists()
 
 
+def test_dakota_runner_allows_native_chroot_input_root_execution():
+    worker = (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
+    assert "name: runner" in worker
+    assert "privileged: true" in worker
+    assert "runAsUser: 0" in worker
+    assert "type: spc_t" in worker
+    assert "bb-runner-installer:20260722T162832Z-236bcd9" in worker
+    assert "bb-worker:20260722T162832Z-236bcd9" in worker
+    assert "add: [SYS_CHROOT]" not in worker
+
+
+def test_buildbarn_runner_uses_stable_tmpdir_after_chroot():
+    config = (ROOT / "manifests/buildbarn-config.yaml").read_text(encoding="utf-8")
+    assert "setTmpdirEnvironmentVariable:" not in config
+    assert "symlinkTemporaryDirectories: ['/tmp', '/var/tmp']" in config
+    assert "concurrency: 1" in config
+    assert "runCommandsAs: { userId: 0, groupId: 0 }" in config
+    assert "concurrency: 1" in config
+    # Production uses the native build directory: the virtual/FUSE experiment
+    # failed startup with "operation not permitted" and is not a valid gate.
+    assert "native:" in config
+    assert "virtual:" not in config
+    assert "buildDirectoryPath: '/worker/build'" in config
+    assert "maximumCacheFileCount: 1000000" in config
+    assert "maximumCacheSizeBytes: 96 * 1024 * 1024 * 1024" in config
+    assert "filePool:" not in config
+
+
+def test_cache_only_diagnostic_disables_remote_execution_explicitly():
+    config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(encoding="utf-8")
+    assert "remote-execution: {}" not in config
+
+
 def test_dakota_persists_sources_in_buildbarn():
     config_map = yaml.safe_load(
         (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(
@@ -101,15 +150,27 @@ def test_dakota_persists_sources_in_buildbarn():
         encoding="utf-8"
     )
 
+    assert config["source-caches"]["override-project-caches"] is True
     assert source_servers[:1] == [
-        {
-            "url": "grpc://frontend.buildbarn.svc.cluster.local:8980",
-            "type": "storage",
-            "push": True,
-        },
+        {"url": "https://gbm.gnome.org:11003", "push": False},
     ]
+    assert "type: index" in pipeline
     assert "type: storage" in pipeline
-    assert "url: grpc://frontend.buildbarn.svc.cluster.local:8980" in pipeline
+    assert "grpc://bb-remote-asset.buildbarn.svc.cluster.local:8984" in pipeline
+    assert "grpc://frontend.buildbarn.svc.cluster.local:8980" in pipeline
+    assert "override-project-caches: true" in pipeline
+    source_cache_block = pipeline.split("source-caches:", 1)[1]
+    assert "cache.projectbluefin.io" not in source_cache_block
+    # The deployed bb-remote-asset endpoint cannot FetchBlob BuildStream
+    # source URNs, so no source-cache server list may point at it. Inspect
+    # the lines directly following each source-caches key rather than the
+    # remainder of the file, which legitimately mentions bb-remote-asset for
+    # artifact indexing.
+    for block in pipeline.split("source-caches:")[1:]:
+        head = block.splitlines()[:12]
+        url_lines = [line for line in head if "url:" in line]
+        assert url_lines, "source-caches block missing servers"
+        assert not any("bb-remote-asset" in line for line in url_lines)
 
 
 def test_dakota_patch_sync_fetches_junction_commit_ids():
@@ -125,12 +186,22 @@ def test_dakota_patch_sync_fetches_junction_commit_ids():
     assert 'git fetch --depth=1 origin "${FDS_REF}"' not in pipeline
 
 
-def test_dakota_nvidia_build_waits_for_its_bluefin_parent_artifact():
-    pipeline = (ROOT / "argo/workflow-templates/dakota-build-pipeline.yaml").read_text(
+def test_distributed_build_pipelines_skip_nvidia_variants():
+    dakota = (ROOT / "argo/workflow-templates/dakota-build-pipeline.yaml").read_text(
+        encoding="utf-8"
+    )
+    cosmic = (ROOT / "argo/workflow-templates/cosmic-build-pipeline.yaml").read_text(
         encoding="utf-8"
     )
 
-    nvidia_task = pipeline.split("          - name: build-bluefin-nvidia", 1)[1]
-    assert "depends: detect-build-mode" in nvidia_task
-    assert "oci/bluefin-nvidia.bst" in nvidia_task
-    assert "dakota-nvidia" in nvidia_task
+    assert "name: build-bluefin" in dakota
+    assert "oci/bluefin.bst" in dakota
+    assert "build-bluefin-nvidia" not in dakota
+    assert "oci/bluefin-nvidia.bst" not in dakota
+    assert "dakota-nvidia" not in dakota
+
+    assert "name: build-cosmic" in cosmic
+    assert "oci/cosmic/image.bst" in cosmic
+    assert "build-cosmic-nvidia" not in cosmic
+    assert "oci/cosmic-nvidia/image.bst" not in cosmic
+    assert "cosmic-cluster-testing-nvidia" not in cosmic


### PR DESCRIPTION
## Problem

Two weeks of distributed-build failures trace to a GitOps regression trap: the repaired BuildBarn config (2026-07-22 worker/installer pair, privileged runner, one action slot, per-action /tmp symlinks, no poisoned action-cache reads, URN-incompatible bb-remote-asset removed from source caches) existed only as live cluster drift. ArgoCD selfHeal reverted the buildbarn-config ConfigMap at 2026-07-23T02:44Z; the workers restarted into a mixed state and killed an in-flight validated distributed retry. Meanwhile every testing-lab-infra sync failed on 11 image-poll CronWorkflows that resolve `{{workflow.parameters.testsuite-repo}}` with no value, masking the drift.

## Changes (before -> after)

- `manifests/buildbarn-config.yaml`: worker concurrency 4 -> 1 (BuildBarn documents temporary-directory symlinking as safe only with one concurrent command); setTmpdirEnvironmentVariable -> symlinkTemporaryDirectories ['/tmp','/var/tmp'] + runCommandsAs root; drop action-cache-service reads that replayed historically failed actions.
- `manifests/buildbarn-worker.yaml`: bb-worker/bb-runner-installer 20260527 -> 20260722 pair; runner privileged spc_t (chroots into SELinux-labeled full-OS input roots); /dev/fuse + bidirectional mounts; config revision 2026-07-20-2 -> 2026-07-23-1 to roll workers once onto the converged state.
- `manifests/buildstream-remote-cache-config.yaml`: source-caches override-project-caches false -> true with upstream-only servers (deployed bb-remote-asset returns UNIMPLEMENTED for BuildStream source URNs); remove action-cache read config.
- `argo/workflow-templates/image-poller.yaml`: add testsuite-repo default so all 11 CronWorkflow syncs validate (single-file fix).
- Stale unit tests updated to HEAD's design (dakota production lane = proven local publisher, bst-build-re retained for recovery; doc-restructure paths).
- Skill doc: verified failure timeline.

## Evidence

- dakota:testing built and published this morning via the local lane: workflow `dakota-build-pipeline-hdqcc`, 30m32s, manifest `sha256:98b44422513f0fe881c1cdc5f0f3f76bd2da542a580720a70a94d9710cad1b4d`.
- Container QA green: `dakota-container-qa-pipeline-hvr9f` Succeeded.
- rustc REAPI probe succeeded end-to-end on the repaired stack (2026-07-22); the 2026-07-23 retry reached remote command execution and failed only due to the mid-action worker restart this PR prevents.
- `just lint` clean; `pytest tests/unit/` 84 passed.

## Rollback

Single revert of this commit restores the previous manifests; the config-revision annotation change makes worker rollout deterministic in both directions.