### PR TITLE
fix(polling): pass testsuite-repo explicitly in image-poll CronWorkflows

### DIFF
--- a/manifests/image-poll-aurora-main.yaml
+++ b/manifests/image-poll-aurora-main.yaml
@@ -36,3 +36,5 @@ spec:
           value: "system"
         - name: variant
           value: "aurora"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-aurora-stable.yaml
+++ b/manifests/image-poll-aurora-stable.yaml
@@ -37,3 +37,5 @@ spec:
           value: "system"
         - name: variant
           value: "aurora"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-aurora-testing.yaml
+++ b/manifests/image-poll-aurora-testing.yaml
@@ -38,3 +38,5 @@ spec:
           value: "smoke,developer,software,system"
         - name: variant
           value: "aurora"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-bluefin-main.yaml
+++ b/manifests/image-poll-bluefin-main.yaml
@@ -36,3 +36,5 @@ spec:
           value: "smoke,common,developer,software,system"
         - name: variant
           value: "bluefin"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-bluefin-stable.yaml
+++ b/manifests/image-poll-bluefin-stable.yaml
@@ -36,3 +36,5 @@ spec:
           value: "smoke,common,developer,software,system"
         - name: variant
           value: "bluefin"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-bluefin-testing.yaml
+++ b/manifests/image-poll-bluefin-testing.yaml
@@ -36,3 +36,5 @@ spec:
           value: "smoke"
         - name: variant
           value: "bluefin"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-dakota.yaml
+++ b/manifests/image-poll-dakota.yaml
@@ -37,6 +37,8 @@ spec:
           value: "smoke"
         - name: variant
           value: "dakota"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"
         - name: branch
           value: "main"
     entrypoint: check-and-trigger

--- a/manifests/image-poll-fedora-bootc-latest.yaml
+++ b/manifests/image-poll-fedora-bootc-latest.yaml
@@ -36,3 +36,5 @@ spec:
           value: "smoke,common,developer,software,system"
         - name: variant
           value: "bluefin"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-fedora-bootc-rawhide.yaml
+++ b/manifests/image-poll-fedora-bootc-rawhide.yaml
@@ -36,3 +36,5 @@ spec:
           value: "smoke,common,developer,software,system"
         - name: variant
           value: "bluefin"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-lts-stable.yaml
+++ b/manifests/image-poll-lts-stable.yaml
@@ -36,3 +36,5 @@ spec:
           value: "smoke,common,developer,software,system"
         - name: variant
           value: "bluefin-lts"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-lts-testing.yaml
+++ b/manifests/image-poll-lts-testing.yaml
@@ -36,3 +36,5 @@ spec:
           value: "smoke"
         - name: variant
           value: "bluefin-lts"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"

--- a/manifests/image-poll-snosi-latest.yaml
+++ b/manifests/image-poll-snosi-latest.yaml
@@ -37,3 +37,5 @@ spec:
           value: "smoke,developer,system"
         - name: variant
           value: "snosi"
+        - name: testsuite-repo
+          value: "https://github.com/projectbluefin/testsuite"


### PR DESCRIPTION
Follow-up to #325. The template-level default does not satisfy CronWorkflow admission validation — Argo resolves `{{workflow.parameters.testsuite-repo}}` from the CronWorkflow's own arguments. All 11 pollers now set it explicitly (same value as the template default). This unblocks the testing-lab-infra sync so the wave-1 buildbarn worker DaemonSet (repaired config, revision 2026-07-23-1) can finally apply.

Evidence: sync attempt at 12:36Z failed on exactly these CronWorkflows with 'failed to resolve {{workflow.parameters.testsuite-repo}}'; worker DS never reached its sync wave. `just lint` clean, all image-poll manifests YAML-parse.