### PR TITLE
fix(kubestellar): live bring-up fixes from ghost deployment

### DIFF
--- a/argo/bootstrap/install-kubestellar.yaml
+++ b/argo/bootstrap/install-kubestellar.yaml
@@ -12,9 +12,17 @@ spec:
       command:
       - bash
       image: cgr.dev/chainguard/kubectl:latest-dev
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
       source: |
         set -euo pipefail
-        echo "-> Installing KubeStellar via ArgoCD Application (ADR-0003)..."
+        echo "-> Installing KubeStellar via ArgoCD Applications (ADR-0003)..."
+        kubectl apply -f https://raw.githubusercontent.com/projectbluefin/lab/main/argocd/kubestellar-postgres-app.yaml
         kubectl apply -f https://raw.githubusercontent.com/projectbluefin/lab/main/argocd/kubestellar-app.yaml
         echo "-> Waiting for ArgoCD to sync the core-chart..."
         kubectl -n argocd wait application/kubestellar \

--- a/argo/bootstrap/kubestellar-smoke-test.yaml
+++ b/argo/bootstrap/kubestellar-smoke-test.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: argo
 spec:
   entrypoint: smoke
-  serviceAccountName: argo
+  serviceAccountName: kubestellar-bootstrap
   arguments:
     parameters:
     - name: wec-name
@@ -20,6 +20,13 @@ spec:
       command:
       - bash
       image: cgr.dev/chainguard/kubectl:latest-dev
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
       source: |
         set -euo pipefail
         WEC="{{inputs.parameters.wec-name}}"

--- a/argo/bootstrap/register-wec.yaml
+++ b/argo/bootstrap/register-wec.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: argo
 spec:
   entrypoint: register
-  serviceAccountName: argo
+  serviceAccountName: kubestellar-bootstrap
   arguments:
     parameters:
     - name: wec-name
@@ -19,13 +19,25 @@ spec:
     script:
       command:
       - bash
-      image: cgr.dev/chainguard/kubectl:latest-dev
+      image: ghcr.io/projectbluefin/lab-runner:latest
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
       source: |
         set -euo pipefail
         WEC="{{inputs.parameters.wec-name}}"
-        echo "-> Installing clusteradm..."
-        curl -sL https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-        export PATH="$PATH:/usr/local/bin"
+        echo "-> Installing clusteradm (pinned, extracted via python tarfile)..."
+        CLUSTERADM_VERSION=0.10.1
+        curl -sSL -o /tmp/clusteradm.tar.gz \
+          "https://github.com/open-cluster-management-io/clusteradm/releases/download/v${CLUSTERADM_VERSION}/clusteradm_linux_amd64.tar.gz"
+        python3 -c "import tarfile; tarfile.open('/tmp/clusteradm.tar.gz').extractall('/tmp/clusteradm-bin')"
+        chmod +x /tmp/clusteradm-bin/clusteradm
+        export PATH="/tmp/clusteradm-bin:$PATH"
+        clusteradm version || true
 
         echo "-> Fetching its1 (hub) kubeconfig from KubeFlex secret..."
         # its1 is type host: the hub runs on this cluster's API server, but

--- a/argocd/kubestellar-app.yaml
+++ b/argocd/kubestellar-app.yaml
@@ -20,6 +20,14 @@ spec:
             type: host
         WDSes:
           - name: wds1
+        # The chart's hook-based postgres install Job (helm.sh/hook:
+        # post-install) deadlocks under ArgoCD: PostSync never fires while
+        # kubeflex-controller-manager's wait-postgresql init blocks the sync
+        # from becoming healthy. PostgreSQL is a separate Application
+        # (kubestellar-postgres-app.yaml) with release name "postgres" so the
+        # operator's readiness wait on postgres-postgresql-0 matches.
+        kubeflex-operator:
+          installPostgreSQL: false
         # External reachability deferred per ADR-0004: in-cluster Service
         # DNS suffices until external WECs exist. KubeFlex-generated nginx
         # Ingress objects are inert (no controller claims them).

--- a/argocd/kubestellar-postgres-app.yaml
+++ b/argocd/kubestellar-postgres-app.yaml
@@ -1,0 +1,34 @@
+# PostgreSQL backing store for KubeFlex-hosted control planes (wds1).
+# Split out of the core-chart because its hook-based install Job deadlocks
+# under ArgoCD (see kubestellar-app.yaml). Release name MUST be "postgres":
+# the kubeflex operator's init container waits for pod postgres-postgresql-0.
+# Chart/version/values mirror the core-chart's install job exactly.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubestellar-postgres
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  project: default
+  source:
+    repoURL: quay.io/kubestellar/charts
+    chart: postgresql
+    targetRevision: 13.1.5
+    helm:
+      releaseName: postgres
+      valuesObject:
+        primary:
+          extendedConfiguration: max_connections=1000
+          priorityClassName: system-node-critical
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kubeflex-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/manifests/argo-kubestellar-bootstrap-rbac.yaml
+++ b/manifests/argo-kubestellar-bootstrap-rbac.yaml
@@ -1,0 +1,38 @@
+# ServiceAccount for KubeStellar bootstrap runbooks (argo/bootstrap/
+# register-wec.yaml, kubestellar-smoke-test.yaml). clusteradm join installs
+# the klusterlet operator: CRDs, namespaces, cluster roles, deployments —
+# hub bootstrap is inherently cluster-admin. Confined to explicitly-run
+# one-shot bootstrap workflows; regular workflows keep the scoped argo SA.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubestellar-bootstrap
+  namespace: argo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubestellar-bootstrap-admin
+subjects:
+  - kind: ServiceAccount
+    name: kubestellar-bootstrap
+    namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
+# Argo emissary executor minimum for this SA (workflowtaskresults).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubestellar-bootstrap-executor
+  namespace: argo
+subjects:
+  - kind: ServiceAccount
+    name: kubestellar-bootstrap
+    namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-default-executor


### PR DESCRIPTION
Fixes discovered deploying phase 1 (#328) live on ghost:

- **Postgres deadlock**: core-chart installs PostgreSQL via a `helm.sh/hook: post-install` Job; under ArgoCD, PostSync never fires because kubeflex-controller-manager's wait-postgresql init container keeps the sync unhealthy. Split postgres into its own Application (`kubestellar-postgres-app.yaml`, release name `postgres` to match the operator's readiness wait) and set `kubeflex-operator.installPostgreSQL: false`.
- **argo-quota**: bootstrap templates now carry explicit resource requests/limits.
- **Image/toolchain**: register-wec uses `lab-runner` (chainguard kubectl lacks curl/tar); clusteradm pinned to 0.10.1 and extracted with python tarfile — removes the unpinned `curl | bash`.
- **RBAC**: new `kubestellar-bootstrap` SA (cluster-admin) for the one-shot bootstrap runbooks; klusterlet install writes CRDs/clusterroles/namespaces that the scoped `argo` SA correctly lacks.

Live evidence: `kubectl get controlplanes` shows its1 (host) and wds1 (k8s) SYNCED=True READY=True; postgres-postgresql-0 Running; register-wec/smoke-test rerun follows once the RBAC merges.