### PR TITLE
fix(zot-cache): scope DaemonSet to nodes with the cache data disk

### DIFF
--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -125,6 +125,14 @@ spec:
     spec:
       automountServiceAccountToken: false
       priorityClassName: system-cluster-critical
+      # Capability-based placement: only nodes carrying the zot-cache data
+      # disk run the cache (label ghost once:
+      #   kubectl label node ghost lab.projectbluefin.io/zot-cache-data=true).
+      # Without this the DaemonSet lands on every node and fails on hosts
+      # that lack /var/mnt/ghost-data (exo-0 sat in CreateContainerError for
+      # 14d and wedged every lab-infra sync at "waiting for healthy state").
+      nodeSelector:
+        lab.projectbluefin.io/zot-cache-data: "true"
       containers:
         - name: zot
           image: ghcr.io/project-zot/zot-linux-amd64:v2.1.1


### PR DESCRIPTION
The DaemonSet hardcodes ghost's /var/mnt/ghost-data hostPath; on exo-0
that path cannot be created (parent is a file), so zot-cache-qv855 sat in
CreateContainerError for 14 days and wedged every testing-lab-infra sync
at 'waiting for healthy state of apps/DaemonSet/zot-cache' — blocking all
manifests/ changes from reconciling.

Capability label (lab.projectbluefin.io/zot-cache-data=true, applied to
ghost) + nodeSelector keeps placement scheduler-driven while matching the
manifest's documented design: the cache lives on ghost's data disk.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
