### PR TITLE
fix(kubestellar): smoke-test hardening from live run

### DIFF
--- a/argo/bootstrap/kubestellar-smoke-test.yaml
+++ b/argo/bootstrap/kubestellar-smoke-test.yaml
@@ -32,7 +32,7 @@ spec:
         WEC="{{inputs.parameters.wec-name}}"
         echo "-> Fetching wds1 kubeconfig from KubeFlex secret..."
         kubectl get secret -n wds1-system admin-kubeconfig \
-          -o jsonpath='{.data.kubeconfig}' | base64 -d > /tmp/wds1.kubeconfig
+          -o jsonpath='{.data.kubeconfig-incluster}' | base64 -d > /tmp/wds1.kubeconfig
         WDS="kubectl --kubeconfig /tmp/wds1.kubeconfig"
 
         echo "-> Applying smoke BindingPolicy + Deployment to wds1..."
@@ -80,6 +80,15 @@ spec:
         EOF
 
         echo "-> Waiting for downsync to $WEC..."
+        for i in $(seq 1 30); do
+          kubectl get ns kubestellar-smoke >/dev/null 2>&1 && break
+          sleep 10
+        done
+        kubectl get ns kubestellar-smoke
+        for i in $(seq 1 30); do
+          kubectl get deploy smoke -n kubestellar-smoke >/dev/null 2>&1 && break
+          sleep 10
+        done
         kubectl wait -n kubestellar-smoke deploy/smoke \
           --for=condition=Available --timeout=300s
 

--- a/argo/bootstrap/register-wec.yaml
+++ b/argo/bootstrap/register-wec.yaml
@@ -65,6 +65,7 @@ spec:
         done
 
         echo "-> Verifying ManagedCluster..."
+        kubectl label managedcluster "$WEC" name="$WEC" --overwrite
         kubectl get managedclusters "$WEC" -o wide
         kubectl wait managedcluster/"$WEC" \
           --for=condition=ManagedClusterConditionAvailable --timeout=300s


### PR DESCRIPTION
- Use kubeconfig-incluster key from the KubeFlex admin secret (the plain
  kubeconfig points at wds1.localtest.me:9443, unreachable in-cluster).
- Poll for the downsynced namespace/deployment before kubectl wait —
  transport downsync is async and the immediate wait raced it.
- register-wec: label the ManagedCluster name=<wec> after accept; the
  smoke BindingPolicy selects on that label and OCM does not set it.

Live evidence: kubestellar-smoke-test-6l8hh Succeeded — downsync to ghost
and singleton status upsync into wds1 verified, cleanup confirmed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
