### PR TITLE
docs(skills): KubeStellar lifecycle skill suite

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -58,6 +58,9 @@ npm ci && npm run build
 | Astro dashboard pages, charts, visual design | [`docs/skills/astro-dashboard-pages/SKILL.md`](docs/skills/astro-dashboard-pages/SKILL.md) |
 | Cluster add-ons, k3s, registries, K8sGPT | [`docs/skills/cluster-tooling/SKILL.md`](docs/skills/cluster-tooling/SKILL.md) |
 | Flatcar node onboarding | [`docs/skills/flatcar-node-onboarding/SKILL.md`](docs/skills/flatcar-node-onboarding/SKILL.md) |
+| KubeStellar core, WECs, BindingPolicies | [`docs/skills/kubestellar/SKILL.md`](docs/skills/kubestellar/SKILL.md) |
+| KubeStellar Console deploy/auth/cards | [`docs/skills/console-dashboard/SKILL.md`](docs/skills/console-dashboard/SKILL.md) |
+| Add/remove nodes or WECs, BST grid scaling | [`docs/skills/node-lifecycle/SKILL.md`](docs/skills/node-lifecycle/SKILL.md) |
 | End of session write-back loop | [`docs/skills/meta-skill-improvement/SKILL.md`](docs/skills/meta-skill-improvement/SKILL.md) |
 | Workflow parameter contracts | [`docs/reference/WORKFLOWS.md`](docs/reference/WORKFLOWS.md) |
 | Release verdict / dashboard data contracts | [`docs/adr/0002-release-verdict-definition.md`](docs/adr/0002-release-verdict-definition.md), [`docs/reference/page-contracts.md`](docs/reference/page-contracts.md) |

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -138,6 +138,16 @@ Argo Workflow (argo namespace)
 | Service-catalog deploy step fails with "No manifests found" | Lane directory missing `manifests.yaml` | Create `tests/service_catalog/<lane>/manifests.yaml` per the contract |
 | Service-catalog test step fails with "No test suite" | Lane directory missing under `tests/service_catalog/` | Create the lane test directory with at least one `test_*.py` file |
 | Service-catalog namespace stuck terminating | Finalizer or PVC not released | Check for stuck PVCs or pods with `kubectl get all -n <ns>`, delete manually if needed |
+| `testing-lab-infra` sync wedged "waiting for healthy state of DaemonSet/..." | A DaemonSet pod is unhealthy on some node (e.g. hostPath missing on that host), blocking every subsequent manifests/ change | Fix or scope the DaemonSet (capability-label nodeSelector), then terminate the stuck operation so ArgoCD retries: `kubectl patch application testing-lab-infra -n argocd --type=merge -p '{"status":{"operationState":{"phase":"Terminating"}}}'` |
+| KubeStellar app sync stuck at kubeflex-controller-manager | Postgres hook deadlock under ArgoCD | Keep `installPostgreSQL: false` + separate `kubestellar-postgres` app; see `docs/skills/kubestellar/SKILL.md` |
+| Workflow pod rejected `failed quota: argo-quota` | Template missing resources requests/limits | Add explicit cpu+memory requests and limits to every container/script |
+
+### KubeStellar / Console failure modes
+
+See `docs/skills/kubestellar/SKILL.md` (downsync, WEC join, RBAC) and
+`docs/skills/console-dashboard/SKILL.md` (Console recovery, exposure policy).
+Upgrade order: KubeFlex/postgres -> core-chart -> Console; rerun
+`kubestellar-smoke-test` after every core upgrade.
 
 ## Historical notes
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -228,6 +228,35 @@ Lives in `manifests/`, applied via the `testing-lab-infra` ArgoCD app:
 
 ---
 
+## KubeStellar bootstrap runbooks
+
+One-shot WorkflowTemplates in `argo/bootstrap/` (NOT ArgoCD-managed; apply
+with `kubectl apply -f argo/bootstrap/ -n argo`). All run with explicit
+resources (argo-quota) and the `kubestellar-bootstrap` SA where noted.
+
+### `install-kubestellar`
+
+Applies the `kubestellar-postgres` and `kubestellar` ArgoCD Applications
+and waits for its1/wds1 ControlPlanes Ready. No parameters.
+
+### `register-wec`
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `wec-name` | `ghost` | Cluster name to register with the its1 OCM hub. Labels the ManagedCluster `name=<wec>` after accept. |
+
+SA: `kubestellar-bootstrap` (cluster-admin; klusterlet install writes CRDs).
+
+### `kubestellar-smoke-test`
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `wec-name` | `ghost` | Target WEC. Verifies BindingPolicy downsync and singleton status upsync via wds1 (`kubeconfig-incluster` key), then cleans up. |
+
+SA: `kubestellar-bootstrap`. Acceptance gate after any core upgrade.
+
+---
+
 ## Editing this contract
 
 When you add or rename a template, update this file in the same PR. Drift

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -9,10 +9,13 @@ Load the skill for the area you are touching, then stop.
 | [bluefin-server](bluefin-server/SKILL.md) | Building or troubleshooting the bluefin-server bootc image. |
 | [ci-tooling](ci-tooling/SKILL.md) | GitHub Actions workflow authoring and dashboard CI debugging. |
 | [cluster-tooling](cluster-tooling/SKILL.md) | Cluster add-ons, registries, k3s, external-secrets, or K8sGPT analysis. |
+| [console-dashboard](console-dashboard/SKILL.md) | KubeStellar Console deploy/upgrade, auth policy, cards, missions. |
 | [dakota-pr-review](dakota-pr-review/SKILL.md) | Reviewing Dakota PRs using the lab-backed QA workflow. |
 | [flatcar-node-onboarding](flatcar-node-onboarding/SKILL.md) | Onboarding a Flatcar Linux node into the k3s cluster. |
 | [frontend-design](frontend-design/SKILL.md) | Designing Astro dashboard pages, CSS, charts, or visual components. |
 | [gitops-argocd](gitops-argocd/SKILL.md) | ArgoCD sync, GitOps rules, bootstrap vs managed, sync failures. |
+| [kubestellar](kubestellar/SKILL.md) | KubeStellar install/upgrade, WEC registration, BindingPolicies, downsync issues. |
 | [kubevirt-vms](kubevirt-vms/SKILL.md) | KubeVirt VM provisioning, lifecycle, or debugging boot failures. |
 | [meta-skill-improvement](meta-skill-improvement/SKILL.md) | Self-improvement loop, nightly failure triage, and adding new skills. |
+| [node-lifecycle](node-lifecycle/SKILL.md) | Adding/removing nodes or WECs, second-PC expansion, BST grid scaling. |
 | [test-authoring](test-authoring/SKILL.md) | Writing or debugging behave/qecore/dogtail GNOME GUI tests. |

--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: console-dashboard
+description: >
+  KubeStellar Console operations: deploy/upgrade via ArgoCD, auth and
+  exposure policy, marketplace cards, guided missions, and the GitOps vs
+  imperative action split. Use when working on the Console deployment or
+  wiring dashboard surfaces.
+metadata:
+  context7-sources:
+    - /kubestellar/console
+---
+
+# KubeStellar Console — lab Skill
+
+## When to Use
+
+- Deploying, upgrading, or recovering the Console
+- Wiring new dashboard surfaces (marketplace cards, missions)
+- Questions about auth, exposure, or which actions are GitOps vs imperative
+
+## When NOT to Use
+
+- Public read-only status site → `astro-dashboard-pages/SKILL.md` (the
+  Astro Pages site stays the reporting layer; Console is the control layer)
+- BindingPolicy/WEC mechanics → `kubestellar/SKILL.md`
+
+## Deployment
+
+ArgoCD Application `argocd/kubestellar-console-app.yaml` (applied manually
+once), chart `kubestellar-console` from
+`https://kubestellar.github.io/console`, pinned version. Namespace
+`kubestellar-console`.
+
+Lab-specific values (do not regress these):
+
+- `persistence.accessModes: [ReadWriteOnce]` + `deployment.strategy.type:
+  Recreate` — local-path has no RWX; Recreate avoids the chart-documented
+  RWO RollingUpdate mount deadlock.
+- `backup.enabled: false` — the chart's backup PVC hardcodes ReadWriteMany
+  which local-path cannot provision. DB protection belongs to the
+  storage/backup ADR (Velero, user-data-only).
+- `service.type: ClusterIP`, `ingress.enabled: false`.
+
+## Exposure and auth policy (locked, ADR-0003)
+
+Dev-mode = anonymous cluster-admin. It NEVER ships exposed. Current access:
+
+```bash
+kubectl -n kubestellar-console port-forward svc/kubestellar-console 8080:8080
+# http://localhost:8080
+```
+
+Before any ingress/Gateway exposure: create a GitHub OAuth app, store
+client id/secret in a Secret referenced via `github.existingSecret`, keep
+`auth.allowedGitHubLogins` / `adminGitHubLogins` tight. No exceptions.
+
+## Control model (dual-mode)
+
+- **GitOps actions**: anything declarative — app installs, BindingPolicy
+  changes, manifest edits — go through PRs to this repo; ArgoCD syncs;
+  KubeStellar downsyncs. The Console links/renders state.
+- **Imperative actions**: runtime operations — VM start/stop (KubeVirt
+  `spec.running` patch), workflow resubmit, pod logs/exec, rollout
+  actions — the Console performs directly via its ServiceAccount.
+- Rule of thumb: if it should survive a cluster rebuild, it goes through
+  git; if it's an operation on live state, imperative is fine.
+
+## Surfaces
+
+- Multi-cluster resource views cover CRDs generically: ArgoCD Applications,
+  Argo Workflows, KubeVirt VMs all appear as resources with status.
+- Marketplace cards (kubestellar/console-marketplace) fill dedicated views
+  (GitOps, networking, security). Prefer a marketplace card over custom UI.
+- **Missions** (`kc-mission-v1`): step sequences with `yaml` (one-click
+  apply) and `command` blocks; custom missions are shareable via built-in
+  PR flow. The "add your second PC" onboarding flow is a custom mission —
+  see `node-lifecycle/SKILL.md`.
+
+## Failure modes
+
+| Symptom | Cause / fix |
+|---|---|
+| Pod Pending, backups PVC Pending | backup re-enabled: its PVC is RWX-hardcoded; keep `backup.enabled: false` |
+| New pod stuck ContainerCreating on upgrade | strategy reverted to RollingUpdate with RWO PVC; keep Recreate |
+| `/api/health` returns "Missing authorization" | expected — auth is enforced; sign in or use a token |
+| Anonymous full access | dev-mode without OAuth config — acceptable ONLY via port-forward, never exposed |
+
+## Upgrade
+
+Bump `targetRevision` in argocd/kubestellar-console-app.yaml via PR. Order:
+KubeFlex/postgres → core-chart → Console. After upgrade verify pod
+Running, `/` returns 200, auth still enforced.

--- a/docs/skills/kubestellar/SKILL.md
+++ b/docs/skills/kubestellar/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: kubestellar
+description: >
+  KubeStellar multi-cluster control plane on the lab: WDS/ITS/WEC model,
+  install/upgrade via ArgoCD, WEC registration, BindingPolicy authoring,
+  smoke testing, and failure modes. Use when working with KubeStellar,
+  KubeFlex control planes, OCM ManagedClusters, or BindingPolicies.
+metadata:
+  context7-sources:
+    - /kubestellar/kubestellar
+---
+
+# KubeStellar — lab Skill
+
+## When to Use
+
+- Installing, upgrading, or recovering KubeStellar core
+- Registering or removing a WEC (Workload Execution Cluster)
+- Authoring or debugging BindingPolicies and downsync
+- Diagnosing "workload didn't reach the WEC" or "status never came back"
+
+## When NOT to Use
+
+- Console UI operations → `console-dashboard/SKILL.md`
+- Adding a k3s node to the shared cluster → `node-lifecycle/SKILL.md`
+- General ArgoCD sync issues → `gitops-argocd/SKILL.md`
+
+## Model (30 seconds)
+
+- **WDS** (Workload Description Space, `wds1`): a KubeFlex-hosted API
+  server where desired manifests live. ArgoCD and install workflows write
+  here, never directly to WECs.
+- **ITS** (Inventory & Transport Space, `its1`): the OCM hub — cluster
+  registry (`ManagedCluster`) plus transport. Type `host` on this lab: it
+  IS the ghost cluster's API server.
+- **WEC**: any registered execution cluster. `ghost` self-registers as the
+  first WEC. Egress-only from the WEC side (home-firewall friendly).
+- **BindingPolicy** (`control.kubestellar.io/v1alpha1`, lives in the WDS):
+  `clusterSelectors` (match ManagedCluster labels) x `downsync`
+  objectSelectors. Set `wantSingletonReportedState: true` so real WEC
+  status upsyncs into the WDS object — without it ArgoCD/Console see specs,
+  not truth.
+
+## Install (GitOps, ADR-0003)
+
+Two ArgoCD Applications, applied manually once (argocd/ convention):
+
+```bash
+kubectl apply -f argocd/kubestellar-postgres-app.yaml   # MUST exist first
+kubectl apply -f argocd/kubestellar-app.yaml
+```
+
+Or run the runbook: `argo submit --from workflowtemplate/install-kubestellar -n argo --wait`
+
+**Critical gotcha — postgres deadlock**: the core-chart installs PostgreSQL
+via a `helm.sh/hook: post-install` Job. Under ArgoCD that hook maps to
+PostSync, which never fires because kubeflex-controller-manager's
+`wait-postgresql` init container keeps the sync from turning healthy.
+Hence: `kubeflex-operator.installPostgreSQL: false` in the core app and a
+separate `kubestellar-postgres` Application whose Helm release name MUST be
+`postgres` (the operator waits for pod `postgres-postgresql-0`).
+
+Verify:
+
+```bash
+kubectl get controlplanes           # its1 + wds1 SYNCED=True READY=True
+kubectl get pods -n kubeflex-system # operator 2/2, postgres-postgresql-0 1/1
+kubectl get pods -n wds1-system     # apiserver, controller-manager, kubestellar + transport controllers
+```
+
+## Reaching wds1 from inside the cluster
+
+Use the `kubeconfig-incluster` key — the plain `kubeconfig` key points at
+`wds1.localtest.me:9443`, unreachable in-cluster:
+
+```bash
+kubectl get secret -n wds1-system admin-kubeconfig \
+  -o jsonpath='{.data.kubeconfig-incluster}' | base64 -d > /tmp/wds1.kubeconfig
+kubectl --kubeconfig /tmp/wds1.kubeconfig get bindingpolicies
+```
+
+ClusterIPs are not routable from workstations; do wds1 operations from
+in-cluster pods (workflows) only.
+
+## WEC registration
+
+```bash
+argo submit --from workflowtemplate/register-wec -n argo --wait --log \
+  -p wec-name=<cluster-name>
+```
+
+What it does (argo/bootstrap/register-wec.yaml): pinned clusteradm download
+(python tarfile extract — lab-runner has no tar), `clusteradm get token` →
+`join --singleton --force-internal-endpoint-lookup` → `accept` → labels the
+ManagedCluster `name=<wec>` (OCM does NOT set this; lab BindingPolicies
+select on it). Runs as the `kubestellar-bootstrap` SA (cluster-admin;
+klusterlet install writes CRDs/clusterroles — the scoped `argo` SA cannot).
+
+Verify: `kubectl get managedclusters` → JOINED=True AVAILABLE=True.
+
+## Smoke test (acceptance gate)
+
+```bash
+argo submit --from workflowtemplate/kubestellar-smoke-test -n argo --wait --log
+```
+
+Applies a BindingPolicy + Namespace + Deployment to wds1, polls for the
+downsynced objects on the WEC (downsync is async — never `kubectl wait`
+immediately), verifies `readyReplicas` upsyncs back into the wds1 object,
+cleans up. Green = downsync AND status upsync both work.
+
+## BindingPolicy authoring rules
+
+- Select clusters by ManagedCluster labels (`name: ghost`, later
+  `location-group: ...`). Scheduler-driven; never pin by hostname fields.
+- Always `wantSingletonReportedState: true` for singleton placements.
+- Workload objects need labels the `objectSelectors` match — namespace AND
+  the objects, or the namespace arrives without contents.
+- BindingPolicies live in the WDS, committed to git like any manifest once
+  the GitOps lane for wds1 exists.
+
+## Failure modes
+
+| Symptom | Cause / fix |
+|---|---|
+| App sync stuck "waiting for healthy state of kubeflex-controller-manager" | postgres deadlock — see install section; check `kubestellar-postgres` app is Synced/Healthy |
+| `clusteradm get token` forbidden | workflow ran as `argo` SA; needs `serviceAccountName: kubestellar-bootstrap` |
+| Workflow pod rejected "failed quota: argo-quota" | missing resources requests/limits on the template |
+| Downsynced namespace exists but is empty | objectSelectors don't match the inner objects' labels |
+| Status never upsyncs | `wantSingletonReportedState` missing, or >1 cluster matched (singleton means one) |
+| ManagedCluster stuck JOINED empty | CSR not accepted — rerun `clusteradm accept --clusters <wec>` |
+| BindingPolicy matches nothing | ManagedCluster lacks the `name=<wec>` label (register-wec adds it; manual joins must too) |
+
+## Upgrade order
+
+KubeFlex/postgres → core-chart (bump `targetRevision` in
+argocd/kubestellar-app.yaml via PR) → Console. Rerun the smoke test after
+every core upgrade.

--- a/docs/skills/node-lifecycle/SKILL.md
+++ b/docs/skills/node-lifecycle/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: node-lifecycle
+description: >
+  Add, drain, and remove capacity in the Bluefin Server home cluster:
+  k3s node join (shared-cluster expansion), WEC cluster join, and the
+  elastic BuildStream grid checks. Agent-executable counterpart of the
+  GUI onboarding flow. Use when adding a second PC, removing a node, or
+  verifying builds scale with new capacity.
+metadata:
+  context7-sources:
+    - /k3s-io/k3s
+    - /kubestellar/kubestellar
+---
+
+# Node & Cluster Lifecycle — lab Skill
+
+## When to Use
+
+- User adds a PC to the home cluster ("second PC" killer feature)
+- Registering an entire separate cluster as a WEC
+- Draining/removing a node or WEC
+- Verifying the BST build grid expanded with new capacity
+
+## When NOT to Use
+
+- Flatcar-specific onboarding → `flatcar-node-onboarding/SKILL.md`
+- KubeStellar install/BindingPolicy mechanics → `kubestellar/SKILL.md`
+
+## Decision: node join vs WEC join (ADR-0003)
+
+- **Default: shared-cluster node join.** A new PC at the same site joins
+  the existing k3s cluster as an agent. One scheduling domain, live
+  migration possible, zero extra control-plane overhead.
+- **WEC join** is for a *separate cluster* (another site, a machine that
+  must stay autonomous offline). KubeStellar federates clusters, not PCs.
+
+## Node join (shared cluster)
+
+On the server (ghost): get the join token from the k3s server config
+(never commit it). On the new machine running Bluefin Server:
+
+```bash
+# On the new node
+sudo k3s agent --server https://<server-lan-ip>:6443 --token <token>
+# or via config file /etc/rancher/k3s/config.yaml + systemctl enable k3s-agent
+```
+
+Verify from any kubectl:
+
+```bash
+kubectl get nodes -o wide          # new node Ready
+kubectl get pods -A -o wide | grep <node>   # scheduler placing pods
+```
+
+Post-join checklist:
+
+1. **No pinning** — do not add node selectors/affinities for the new node;
+   scheduler-driven placement picks it up (user policy).
+2. **Storage labels** — if the node carries a data disk for a hostPath
+   workload (e.g. zot-cache), apply the capability label
+   (`lab.projectbluefin.io/zot-cache-data=true` style). Never hostPath onto
+   root disks.
+3. **local-path config** — add the node's data-disk path to the
+   local-path-provisioner nodePathMap (manifests/, via PR) so PVCs land on
+   the data disk, not the root disk.
+
+## WEC join (separate cluster)
+
+From a workflow/agent with hub access:
+
+```bash
+argo submit --from workflowtemplate/register-wec -n argo --wait --log \
+  -p wec-name=<cluster-name>
+```
+
+For remote clusters the join runs *on the remote side* (egress-only):
+`clusteradm join --hub-token ... --hub-apiserver <reachable-endpoint>
+--singleton`, then accept on the hub. External reachability of its1 is a
+prerequisite (Gateway API TLSRoute or LoadBalancer — ADR-0004); in-LAN
+clusters can use the node IP.
+
+Zero-touch option: bootstrap tokens + `ManagedClusterAutoApproval` feature
+gate with `--cluster-auto-approval-users=` lets a Bluefin Server image
+join with no admin action.
+
+## Drain / remove
+
+```bash
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+kubectl delete node <node>
+# WEC removal:
+kubectl delete managedcluster <wec>    # after evacuating BindingPolicies
+```
+
+Check before draining: PVCs with local-path volumes on that node (data does
+not move — reprovision or restore), KubeVirt VMIs (migrate or stop), BST
+workers (grid shrinks; builds slow but continue).
+
+## Elastic BST grid check (the payoff)
+
+After adding capacity, verify builds actually got faster:
+
+```bash
+kubectl get pods -n buildbarn -o wide       # workers spread onto new node
+argo submit --from workflowtemplate/dakota-build-pipeline -n argo ...
+# Compare wall time and parallel job count against the previous run
+```
+
+BuildBarn workers scale with cluster capacity; bb-remote-asset:8984 +
+frontend:8980 CAS pattern is grid-ready (see BuildStream source cache
+memory/ADR). Cross-WEC grid joins via Tailscale CAS mesh.
+
+## GUI flow
+
+The Console hosts this as a guided mission ("Add a node") wrapping the
+same steps: token display, agent config, verification queries. Keep the
+mission and this skill in sync — the mission is the GUI counterpart, this
+file is the agent-executable truth.


### PR DESCRIPTION
Agent-executable documentation for the new control plane, per the
in-repo-docs directive: an agent starting cold from agents.md can
install, expand, upgrade, and recover the platform.

- docs/skills/kubestellar/SKILL.md: WDS/ITS/WEC model, ArgoCD install
  with the postgres-deadlock split, kubeconfig-incluster access,
  register-wec/smoke-test runbooks, BindingPolicy rules, failure table
- docs/skills/console-dashboard/SKILL.md: Console deploy values that
  must not regress (RWO+Recreate, backup off), exposure/auth policy,
  GitOps vs imperative action split, missions
- docs/skills/node-lifecycle/SKILL.md: node join vs WEC join decision,
  join/drain/remove flows, elastic BST grid verification
- RUNBOOK: wedged lab-infra sync recovery, argo-quota, KubeStellar
  failure-mode pointers; WORKFLOWS: bootstrap runbook contracts;
  skills README + agents.md tables updated

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
