### PR TITLE
feat(catalog): linuxserver.io catalog index poller and schema

### DIFF
--- a/docs/data/catalog/linuxserver.json
+++ b/docs/data/catalog/linuxserver.json
@@ -1,0 +1,3364 @@
+{
+  "provider": "linuxserver",
+  "generated_at": "2026-07-25T03:18:52Z",
+  "source_api": "https://api.linuxserver.io/api/v1/images?include_config=true",
+  "apps": [
+    {
+      "name": "adguardhome-sync",
+      "description": "adguardhome-sync is a tool to synchronize AdGuardHome config to replica instances.",
+      "category": "Network,DNS",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/adguardhomesync-icon.png",
+      "image_ref": "lscr.io/linuxserver/adguardhome-sync",
+      "monthly_pulls": 100951,
+      "stars": 65,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-adguardhome-sync?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "airsonic-advanced",
+      "description": "airsonic-advanced is a free, web-based media streamer, providing ubiquitious access to your music. Use it to share your music with friends, or to listen to your own music while at work. You can stream to multiple players simultaneously, for instance to one player in your kitchen and another in your living room.",
+      "category": "Media Servers,Music",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/airsonic-banner.png",
+      "image_ref": "lscr.io/linuxserver/airsonic-advanced",
+      "monthly_pulls": 21254,
+      "stars": 48,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-airsonic-advanced?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "altus",
+      "description": "[Altus] is an Electron-based WhatsApp client with themes and multiple account support.",
+      "category": "Chat",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/altus-logo.png",
+      "image_ref": "lscr.io/linuxserver/altus",
+      "monthly_pulls": 281753,
+      "stars": 8,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-altus?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "apprise-api",
+      "description": "apprise-api Takes advantage of [Apprise](https://github.com/caronc/apprise) through your network with a user-friendly API.  * Send notifications to more than 100 services. * An incredibly lightweight gateway to Apprise. * A production ready micro-service at your disposal. * A Simple Website to verify and test your configuration with.  Apprise API was designed to easily fit into existing (and new) eco-systems that are looking for a simple notification solution.",
+      "category": "Monitoring",
+      "logo_url": "https://raw.githubusercontent.com/caronc/apprise-api/master/apprise_api/static/logo.png",
+      "image_ref": "lscr.io/linuxserver/apprise-api",
+      "monthly_pulls": 202938,
+      "stars": 48,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/caronc/apprise-api",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "ardour",
+      "description": "[Ardour] is an open source, collaborative effort of a worldwide team including musicians, programmers, and professional recording engineers.",
+      "category": "Audio Processing",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ardour-logo.png",
+      "image_ref": "lscr.io/linuxserver/ardour",
+      "monthly_pulls": 1406,
+      "stars": 15,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ardour?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "audacity",
+      "description": "[Audacity] is an easy-to-use, multi-track audio editor and recorder. Developed by a group of volunteers as open source.",
+      "category": "Audio Processing",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/audacity-logo.png",
+      "image_ref": "lscr.io/linuxserver/audacity",
+      "monthly_pulls": 2223,
+      "stars": 29,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-audacity?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "azahar",
+      "description": "[Azahar] is an open-source 3DS emulator based on Citra.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/azahar-logo.png",
+      "image_ref": "lscr.io/linuxserver/azahar",
+      "monthly_pulls": 1448,
+      "stars": 2,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-azahar?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "babybuddy",
+      "description": "babybuddy is a buddy for babies! Helps caregivers track sleep, feedings, diaper changes, tummy time and more to learn about and predict baby's needs without (as much) guess work.",
+      "category": "Family",
+      "logo_url": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/babybuddy-logo.png",
+      "image_ref": "lscr.io/linuxserver/babybuddy",
+      "monthly_pulls": 68681,
+      "stars": 46,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-babybuddy?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "bambustudio",
+      "description": "[Bambu Studio] is an open-source, cutting-edge, feature-rich slicing software. It contains project-based workflows, systematically optimized slicing algorithms, and an easy-to-use graphical interface, bringing users an incredibly smooth printing experience.",
+      "category": "3D Printing",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bambustudio-logo.png",
+      "image_ref": "lscr.io/linuxserver/bambustudio",
+      "monthly_pulls": 53734,
+      "stars": 91,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-bambustudio?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "bazarr",
+      "description": "bazarr is a companion application to Sonarr and Radarr. It can manage and download subtitles based on your requirements. You define your preferences by TV show or movie and Bazarr takes care of everything for you.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bazarr.png",
+      "image_ref": "lscr.io/linuxserver/bazarr",
+      "monthly_pulls": 4594164,
+      "stars": 394,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-bazarr?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "beets",
+      "description": "beets is a music library manager and not, for the most part, a music player. It does include a simple player plugin and an experimental Web-based player, but it generally leaves actual sound-reproduction to specialized tools.",
+      "category": "Music",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/beets-icon.png",
+      "image_ref": "lscr.io/linuxserver/beets",
+      "monthly_pulls": 230589,
+      "stars": 182,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-beets?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "bitcoin-knots",
+      "description": "[Bitcoin Knots] can be used as a desktop client for regular payments or as a full node server utility for merchants and other payment services.",
+      "category": "Finance",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bitcoin-knots-logo.png",
+      "image_ref": "lscr.io/linuxserver/bitcoin-knots",
+      "monthly_pulls": 1903,
+      "stars": 4,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-bitcoin-knots?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "blade-of-agony",
+      "description": "[Wolfenstein: Blade of Agony] is a story-driven WWII shooter inspired by Wolfenstein and Doom.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/boa-logo.png",
+      "image_ref": "lscr.io/linuxserver/blade-of-agony",
+      "monthly_pulls": 2204,
+      "stars": 3,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-blade-of-agony?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "blender",
+      "description": "[Blender] is a free and open-source 3D computer graphics software toolset used for creating animated films, visual effects, art, 3D printed models, motion graphics, interactive 3D applications, virtual reality, and computer games. **This image does not support GPU rendering out of the box only accelerated workspace experience**",
+      "category": "3D Modeling",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/blender-logo.png",
+      "image_ref": "lscr.io/linuxserver/blender",
+      "monthly_pulls": 7226,
+      "stars": 113,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-blender?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "boinc",
+      "description": "[BOINC] is a platform for high-throughput computing on a large scale (thousands or millions of computers). It can be used for volunteer computing (using consumer devices) or grid computing (using organizational resources). It supports virtualized, parallel, and GPU-based applications.",
+      "category": "Science",
+      "logo_url": "https://raw.githubusercontent.com/BOINC/boinc/master/doc/logo/boinc_logo_black.jpg",
+      "image_ref": "lscr.io/linuxserver/boinc",
+      "monthly_pulls": 4650,
+      "stars": 28,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-boinc?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "bookstack",
+      "description": "bookstack is a free and open source Wiki designed for creating beautiful documentation. Featuring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.  Powered by SQL and including a Markdown editor for those who prefer it, BookStack is geared towards making documentation more of a pleasure than a chore.  For more information on BookStack visit their website and check it out: https://www.bookstackapp.com",
+      "category": "Content Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bookstack-logo.png",
+      "image_ref": "lscr.io/linuxserver/bookstack",
+      "monthly_pulls": 986412,
+      "stars": 996,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-bookstack?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "brave",
+      "description": "[The Brave browser] is a fast, private and secure web browser for PC, Mac and mobile.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/brave-logo.png",
+      "image_ref": "lscr.io/linuxserver/brave",
+      "monthly_pulls": 51672,
+      "stars": 22,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-brave?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "budge",
+      "description": "budge is an open source 'budgeting with envelopes' personal finance app.",
+      "category": "Finance",
+      "logo_url": "",
+      "image_ref": "lscr.io/linuxserver/budge",
+      "monthly_pulls": 3499,
+      "stars": 62,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-budge?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "calibre",
+      "description": "calibre is a powerful and easy to use e-book manager. Users say it's outstanding and a must-have. It'll allow you to do nearly everything and it takes things a step beyond normal e-book software. It's also completely free and open source and great for both casual users and computer experts.",
+      "category": "Books",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/calibre-logo.png",
+      "image_ref": "lscr.io/linuxserver/calibre",
+      "monthly_pulls": 942968,
+      "stars": 543,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-calibre?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "calibre-web",
+      "description": "calibre-web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.   It is also possible to integrate google drive and edit metadata and your calibre library through the app itself.  This software is a fork of library and licensed under the GPL v3 License.",
+      "category": "Books",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/calibre-web-icon.png",
+      "image_ref": "lscr.io/linuxserver/calibre-web",
+      "monthly_pulls": 1107767,
+      "stars": 1403,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-calibre-web?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "calligra",
+      "description": "[Calligra] is an office and graphic art suite by KDE. It is available for desktop PCs, tablet computers, and smartphones. It contains applications for word processing, spreadsheets, presentation, vector graphics, and editing databases.",
+      "category": "Documents",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/calligra-logo.png",
+      "image_ref": "lscr.io/linuxserver/calligra",
+      "monthly_pulls": 154,
+      "stars": 3,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-calligra?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "changedetection.io",
+      "description": "changedetection.io provides free, open-source web page monitoring, notification and change detection.",
+      "category": "Web Tools,Automation",
+      "logo_url": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/changedetection-icon.png",
+      "image_ref": "lscr.io/linuxserver/changedetection.io",
+      "monthly_pulls": 241786,
+      "stars": 85,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-changedetection.io?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "chrome",
+      "description": "[Chrome] is the official web browser from Google, built to be fast, secure, and customizable.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/chrome-logo.png",
+      "image_ref": "lscr.io/linuxserver/chrome",
+      "monthly_pulls": 72939,
+      "stars": 56,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-chrome?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "chromium",
+      "description": "[Chromium] is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/chromium-logo.png",
+      "image_ref": "lscr.io/linuxserver/chromium",
+      "monthly_pulls": 1666285,
+      "stars": 381,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-chromium?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "code-server",
+      "description": "code-server is VS Code running on a remote server, accessible through the browser. - Code on your Chromebook, tablet, and laptop with a consistent dev environment. - If you have a Windows or Mac workstation, more easily develop for Linux. - Take advantage of large cloud servers to speed up tests, compilations, downloads, and more. - Preserve battery life when you're on the go. - All intensive computation runs on your server. - You're no longer running excess instances of Chrome.",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/code-server-banner.png",
+      "image_ref": "lscr.io/linuxserver/code-server",
+      "monthly_pulls": 1724828,
+      "stars": 1975,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-code-server?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "cops",
+      "description": "cops by Sébastien Lucas, now maintained by MikesPub, stands for Calibre OPDS (and HTML) Php Server.  COPS links to your Calibre library database and allows downloading and emailing of books directly from a web browser and provides a OPDS feed to connect to your devices.  Changes in your Calibre library are reflected immediately in your COPS pages.  See : [COPS's home] for more details.  Don't forget to check the [Wiki](https://github.com/mikespub-org/seblucas-cops/wiki).  ## Why? (taken from the author's site)  In my opinion Calibre is a marvelous tool but is too big and has too much dependencies to be used for its content server.  That's the main reason why I coded this OPDS server. I needed a simple tool to be installed on a small server (Seagate Dockstar in my case).  I initially thought of Calibre2OPDS but as it generate static file no search was possible.  Later I added an simple HTML catalog that should be usable on my Kobo.  So COPS's main advantages are :  * No need for many dependencies.  * No need for a lot of CPU or RAM.  * Not much code.  * Search is available.  * With Dropbox / owncloud it's very easy to have an up to date OPDS server.  * It was fun to code.  If you want to use the OPDS feed don't forget to specify /feed at the end of your URL.",
+      "category": "Books",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/cops-icon.png",
+      "image_ref": "lscr.io/linuxserver/cops",
+      "monthly_pulls": 12508,
+      "stars": 48,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-cops?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "cura",
+      "description": "[UltiMaker Cura] is free, easy-to-use 3D printing software trusted by millions of users. Fine-tune your 3D model with 400+ settings for the best slicing and printing results.",
+      "category": "3D Printing",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/cura-logo.png",
+      "image_ref": "lscr.io/linuxserver/cura",
+      "monthly_pulls": 23789,
+      "stars": 40,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-cura?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "darktable",
+      "description": "[darktable] is an open source photography workflow application and raw developer. A virtual lighttable and darkroom for photographers. It manages your digital negatives in a database, lets you view them through a zoomable lighttable and enables you to develop raw images and enhance them.",
+      "category": "Photos",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/darktable-logo.png",
+      "image_ref": "lscr.io/linuxserver/darktable",
+      "monthly_pulls": 3374,
+      "stars": 37,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-darktable?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "davos",
+      "description": "davos is an FTP automation tool that periodically scans given host locations for new files. It can be configured for various purposes, including listening for specific files to appear in the host location, ready for it to download and then move, if required. It also supports completion notifications as well as downstream API calls, to further the workflow.",
+      "category": "FTP",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/davos/master/docs/list.PNG",
+      "image_ref": "lscr.io/linuxserver/davos",
+      "monthly_pulls": 40,
+      "stars": 14,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-davos?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "ddclient",
+      "description": "ddclient is a Perl client used to update dynamic DNS entries for accounts on Dynamic DNS Network Service Provider. It was originally written by Paul Burry and is now mostly by wimpunk. It has the capability to update more than just dyndns and it can fetch your WAN-ipaddress in a few different ways.",
+      "category": "Network,DNS",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ddclient-logo.png",
+      "image_ref": "lscr.io/linuxserver/ddclient",
+      "monthly_pulls": 166880,
+      "stars": 180,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ddclient?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "deluge",
+      "description": "deluge is a lightweight, Free Software, cross-platform BitTorrent client.  * Full Encryption * WebUI * Plugin System * Much more...",
+      "category": "Downloaders",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/deluge-logo.png",
+      "image_ref": "lscr.io/linuxserver/deluge",
+      "monthly_pulls": 369889,
+      "stars": 294,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-deluge?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "digikam",
+      "description": "[digiKam]: Professional Photo Management with the Power of Open Source",
+      "category": "Photos",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/digikam.png",
+      "image_ref": "lscr.io/linuxserver/digikam",
+      "monthly_pulls": 16094,
+      "stars": 78,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-digikam?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "diskover",
+      "description": "diskover is an open source file system indexer that uses Elasticsearch to index and manage data across heterogeneous storage systems.",
+      "category": "Storage,Monitoring",
+      "logo_url": "https://raw.githubusercontent.com/diskoverdata/diskover-community/master/diskover-web/public/images/diskover.png",
+      "image_ref": "lscr.io/linuxserver/diskover",
+      "monthly_pulls": 25181,
+      "stars": 109,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-diskover?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "dogwalk",
+      "description": "[DOGWALK] is Blender Studio's long awaited second game project, focused on creating a bite-sized interactive storytelling playground. Play as a big adorable dog and explore the winter woods with a little kid.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/dogwalk-logo.png",
+      "image_ref": "lscr.io/linuxserver/dogwalk",
+      "monthly_pulls": 725,
+      "stars": 0,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-dogwalk?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "dokuwiki",
+      "description": "dokuwiki is a simple to use and highly versatile Open Source wiki software that doesn't require a database. It is loved by users for its clean and readable syntax. The ease of maintenance, backup and integration makes it an administrator's favorite. Built in access controls and authentication connectors make DokuWiki especially useful in the enterprise context and the large number of plugins contributed by its vibrant community allow for a broad range of use cases beyond a traditional wiki.",
+      "category": "Content Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/dokuwiki-icon.png",
+      "image_ref": "lscr.io/linuxserver/dokuwiki",
+      "monthly_pulls": 52317,
+      "stars": 123,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-dokuwiki?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "dolphin",
+      "description": "[Dolphin Emulator] lets you play GameCube and Wii games with various graphical enhancements and other features are available to improve your game experience.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/dolphin-logo.png",
+      "image_ref": "lscr.io/linuxserver/dolphin",
+      "monthly_pulls": 1018534,
+      "stars": 11,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-dolphin?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "doplarr_rs",
+      "description": "doplarr_rs is a Discord bot for requesting media through *arr backends, written in Rust.",
+      "category": "Media Requesters",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/doplarr_rs-logo.png",
+      "image_ref": "lscr.io/linuxserver/doplarr_rs",
+      "monthly_pulls": 397,
+      "stars": 1,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-doplarr_rs?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "dosbox-staging",
+      "description": "[DOSBox Staging] is a modern continuation of DOSBox a free and open-source emulator that enables the execution of MS-DOS software, especially video games.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/dosbox-logo.png",
+      "image_ref": "lscr.io/linuxserver/dosbox-staging",
+      "monthly_pulls": 1733,
+      "stars": 2,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-dosbox-staging?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "doublecommander",
+      "description": "[Double Commander] is a free cross platform open source file manager with two panels side by side. It is inspired by Total Commander and features some new ideas.",
+      "category": "Administration,Storage",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/doublecommander-icon.png",
+      "image_ref": "lscr.io/linuxserver/doublecommander",
+      "monthly_pulls": 20715,
+      "stars": 43,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-doublecommander?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "duckdns",
+      "description": "duckdns is a free service which will point a DNS (sub domains of duckdns.org) to an IP of your choice. The service is completely free, and doesn't require reactivation or forum posts to maintain its existence.",
+      "category": "Network,DNS",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/duckdns.png",
+      "image_ref": "lscr.io/linuxserver/duckdns",
+      "monthly_pulls": 339414,
+      "stars": 375,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-duckdns?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "duckstation",
+      "description": "[DuckStation] is a PS1 Emulator aiming for the best accuracy and game support.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/duckstation-logo.png",
+      "image_ref": "lscr.io/linuxserver/duckstation",
+      "monthly_pulls": 1993,
+      "stars": 2,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-duckstation?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "duplicati",
+      "description": "duplicati is a backup client that securely stores encrypted, incremental, compressed backups on local storage, cloud storage services and remote file servers. It works with standard protocols like FTP, SSH, WebDAV as well as popular services like Microsoft OneDrive, Amazon S3, Google Drive, box.com, Mega, B2, and many others.",
+      "category": "Backup",
+      "logo_url": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/duplicati-icon.png",
+      "image_ref": "lscr.io/linuxserver/duplicati",
+      "monthly_pulls": 622329,
+      "stars": 447,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-duplicati?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "eden",
+      "description": "[Eden] is an experimental open-source emulator for the Nintendo Switch, built with performance and stability in mind.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/eden-logo.png",
+      "image_ref": "lscr.io/linuxserver/eden",
+      "monthly_pulls": 1844,
+      "stars": 11,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-eden?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "emby",
+      "description": "emby organizes video, music, live TV, and photos from personal media libraries and streams them to smart TVs, streaming boxes and mobile devices. This container is packaged as a standalone emby Media Server.",
+      "category": "Media Servers,Music,Audiobooks",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/emby-logo.png",
+      "image_ref": "lscr.io/linuxserver/emby",
+      "monthly_pulls": 229745,
+      "stars": 148,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-emby?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "fail2ban",
+      "description": "fail2ban is a daemon to ban hosts that cause multiple authentication errors.",
+      "category": "Network,Security",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/fail2ban-logo.png",
+      "image_ref": "lscr.io/linuxserver/fail2ban",
+      "monthly_pulls": 81935,
+      "stars": 97,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-fail2ban?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "faster-whisper",
+      "description": "faster-whisper is a reimplementation of OpenAI's Whisper model using CTranslate2, which is a fast inference engine for Transformer models. This container provides a Wyoming protocol server for faster-whisper.",
+      "category": "Machine Learning",
+      "logo_url": "",
+      "image_ref": "lscr.io/linuxserver/faster-whisper",
+      "monthly_pulls": 202511,
+      "stars": 231,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-faster-whisper?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "ferdium",
+      "description": "[Ferdium] is a desktop app that helps you organize how you use your favourite apps by combining them into one application.",
+      "category": "Chat,Social",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ferdium-logo.png",
+      "image_ref": "lscr.io/linuxserver/ferdium",
+      "monthly_pulls": 4211,
+      "stars": 12,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ferdium?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "ffmpeg",
+      "description": "A complete, cross-platform solution to record, convert and stream audio and video.",
+      "category": "Media Tools",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ffmpeg.png",
+      "image_ref": "lscr.io/linuxserver/ffmpeg",
+      "monthly_pulls": 173531,
+      "stars": 206,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ffmpeg",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "filezilla",
+      "description": "[FIleZilla] Client is a fast and reliable cross-platform FTP, FTPS and SFTP client with lots of useful features and an intuitive graphical user interface.",
+      "category": "FTP",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/filezilla-logo.png",
+      "image_ref": "lscr.io/linuxserver/filezilla",
+      "monthly_pulls": 1061202,
+      "stars": 41,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-filezilla?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "firefox",
+      "description": "[Firefox] Browser, also known as Mozilla Firefox or simply Firefox, is a free and open-source web browser developed by the Mozilla Foundation and its subsidiary, the Mozilla Corporation. Firefox uses the Gecko layout engine to render web pages, which implements current and anticipated web standards.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/firefox-logo.png",
+      "image_ref": "lscr.io/linuxserver/firefox",
+      "monthly_pulls": 3720416,
+      "stars": 321,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-firefox?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "flexget",
+      "description": "flexget is a multipurpose automation tool for all of your media.",
+      "category": "Downloaders",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/flexget-banner.png",
+      "image_ref": "lscr.io/linuxserver/flexget",
+      "monthly_pulls": 13359,
+      "stars": 15,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-flexget?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "flycast",
+      "description": "[Flycast] is a multi-platform Sega Dreamcast, Naomi, Naomi 2, and Atomiswave emulator derived from reicast.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/flycast-logo.png",
+      "image_ref": "lscr.io/linuxserver/flycast",
+      "monthly_pulls": 747,
+      "stars": 2,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-flycast?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "foldingathome",
+      "description": "[Folding@home] is a distributed computing project for simulating protein dynamics, including the process of protein folding and the movements of proteins implicated in a variety of diseases. It brings together citizen scientists who volunteer to run simulations of protein dynamics on their personal computers. Insights from this data are helping scientists to better understand biology, and providing new opportunities for developing therapeutics.",
+      "category": "Science",
+      "logo_url": "https://foldingathome.org/wp-content/uploads/2016/09/folding-at-home-logo.png",
+      "image_ref": "lscr.io/linuxserver/foldingathome",
+      "monthly_pulls": 12644,
+      "stars": 53,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-foldingathome?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "freecad",
+      "description": "[FreeCAD] is a general-purpose parametric 3D computer-aided design (CAD) modeler and a building information modeling (BIM) software application with finite element method (FEM) support.",
+      "category": "3D Modeling",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freecad-logo.png",
+      "image_ref": "lscr.io/linuxserver/freecad",
+      "monthly_pulls": 11071,
+      "stars": 61,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-freecad?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "freshrss",
+      "description": "freshrss is a free, self-hostable aggregator for rss feeds.",
+      "category": "RSS",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freshrss-banner.png",
+      "image_ref": "lscr.io/linuxserver/freshrss",
+      "monthly_pulls": 285658,
+      "stars": 230,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-freshrss?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "gimp",
+      "description": "[GIMP] is a free and open-source raster graphics editor used for image manipulation (retouching) and image editing, free-form drawing, transcoding between different image file formats, and more specialized tasks. It is extensible by means of plugins, and scriptable.",
+      "category": "Image Editor",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/gimp-logo.png",
+      "image_ref": "lscr.io/linuxserver/gimp",
+      "monthly_pulls": 5558,
+      "stars": 28,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-gimp?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "github-desktop",
+      "description": "[Github Desktop] is an open source Electron-based GitHub app. It is written in TypeScript and uses React.",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/github-desktop-icon.png",
+      "image_ref": "lscr.io/linuxserver/github-desktop",
+      "monthly_pulls": 6429430,
+      "stars": 29,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-github-desktop?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "gitqlient",
+      "description": "[GitQlient] is a multi-platform Git client originally forked from QGit. Nowadays it goes beyond of just a fork and adds a lot of new functionality.",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/gitqlient-icon.png",
+      "image_ref": "lscr.io/linuxserver/gitqlient",
+      "monthly_pulls": 560,
+      "stars": 2,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-gitqlient?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "grav",
+      "description": "grav is a Fast, Simple, and Flexible, file-based Web-platform.",
+      "category": "Content Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/grav-logo.png",
+      "image_ref": "lscr.io/linuxserver/grav",
+      "monthly_pulls": 25533,
+      "stars": 40,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-grav?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "grocy",
+      "description": "grocy is an ERP system for your kitchen! Cut down on food waste, and manage your chores with this brilliant utility.  Keep track of your purchases, how much food you are wasting, what chores need doing and what batteries need charging with this proudly Open Source tool  For more information on grocy visit their website and check it out: https://grocy.info",
+      "category": "Recipes",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/grocy-logo.png",
+      "image_ref": "lscr.io/linuxserver/grocy",
+      "monthly_pulls": 975898,
+      "stars": 438,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-grocy?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "gzdoom",
+      "description": "[GZDoom] is a feature centric port for all Doom engine games, based on ZDoom, adding an OpenGL renderer and powerful scripting capabilities.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/gzdoom-logo.png",
+      "image_ref": "lscr.io/linuxserver/gzdoom",
+      "monthly_pulls": 1795,
+      "stars": 5,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-gzdoom?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "habridge",
+      "description": "habridge emulates Philips Hue API to other home automation gateways such as an Amazon Echo/Dot Gen 1 (gen 2 has issues discovering ha-bridge) or other systems that support Philips Hue. The Bridge handles basic commands such as On, Off and brightness commands of the hue protocol. This bridge can control most devices that have a distinct API.",
+      "category": "Home Automation",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/habridge-logo.png",
+      "image_ref": "lscr.io/linuxserver/habridge",
+      "monthly_pulls": 550,
+      "stars": 18,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-habridge?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "handbrake",
+      "description": "[HandBrake] is an open-source tool, built by volunteers, for converting video from nearly any format to a selection of modern, widely supported codecs.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/handbrake-logo.png",
+      "image_ref": "lscr.io/linuxserver/handbrake",
+      "monthly_pulls": 12088,
+      "stars": 9,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-handbrake?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "healthchecks",
+      "description": "healthchecks is a watchdog for your cron jobs. It's a web server that listens for pings from your cron jobs, plus a web interface.",
+      "category": "Monitoring",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/healthchecks-logo.png",
+      "image_ref": "lscr.io/linuxserver/healthchecks",
+      "monthly_pulls": 68207,
+      "stars": 199,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-healthchecks?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "hedgedoc",
+      "description": "[HedgeDoc] gives you access to all your files wherever you are.  HedgeDoc is a real-time, multi-platform collaborative markdown note editor.  This means that you can write notes with other people on your desktop, tablet or even on the phone.  You can sign-in via multiple auth providers like Facebook, Twitter, GitHub and many more on the homepage.",
+      "category": "Content Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hedgedoc-banner.png",
+      "image_ref": "lscr.io/linuxserver/hedgedoc",
+      "monthly_pulls": 8291,
+      "stars": 50,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-hedgedoc?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "heimdall",
+      "description": "heimdall is a way to organise all those links to your most used web sites and web applications in a simple way.  Simplicity is the key to Heimdall.  Why not use it as your browser start page? It even has the ability to include a search bar using either Google, Bing or DuckDuckGo.",
+      "category": "Dashboard",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/heimdall-banner.png",
+      "image_ref": "lscr.io/linuxserver/heimdall",
+      "monthly_pulls": 1196641,
+      "stars": 362,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-heimdall?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "helium",
+      "description": "[Helium] is a Chromium-based web browser made for people, with love. Privacy-first with unbiased ad-blocking.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/helium-logo.png",
+      "image_ref": "lscr.io/linuxserver/helium",
+      "monthly_pulls": 8669,
+      "stars": 5,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-helium?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "hishtory-server",
+      "description": "[hiSHtory] is a better shell history. It stores your shell history in context (what directory you ran the command in, whether it succeeded or failed, how long it took, etc). This is all stored locally and end-to-end encrypted for syncing to to all your other computers.",
+      "category": "Administration",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hishtory-server-icon.png",
+      "image_ref": "lscr.io/linuxserver/hishtory-server",
+      "monthly_pulls": 22527,
+      "stars": 30,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-hishtory-server?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "homeassistant",
+      "description": "[Home Assistant Core] - Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts. Perfect to run on a Raspberry Pi or a local server",
+      "category": "Home Automation",
+      "logo_url": "https://github.com/home-assistant/home-assistant.io/raw/next/source/images/favicon-192x192-full.png",
+      "image_ref": "lscr.io/linuxserver/homeassistant",
+      "monthly_pulls": 1431220,
+      "stars": 279,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-homeassistant?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "htpcmanager",
+      "description": "htpcmanager is a front end for many htpc related applications.",
+      "category": "Media Tools",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/htpcmanager-icon.png",
+      "image_ref": "lscr.io/linuxserver/htpcmanager",
+      "monthly_pulls": 58,
+      "stars": 31,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-htpcmanager?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "inkscape",
+      "description": "[Inkscape] is professional quality vector graphics software which runs on Linux, Mac OS X and Windows desktop computers.",
+      "category": "3D Modeling",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/inkscape-logo.png",
+      "image_ref": "lscr.io/linuxserver/inkscape",
+      "monthly_pulls": 30924,
+      "stars": 18,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-inkscape?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "intellij-idea",
+      "description": "[IntelliJ IDEA] helps you write code faster with tools that eliminate tedious tasks and let you focus on what matters – building great software.",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/intellij-idea-logo.png",
+      "image_ref": "lscr.io/linuxserver/intellij-idea",
+      "monthly_pulls": 101,
+      "stars": 6,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-intellij-idea?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "jackett",
+      "description": "jackett works as a proxy server: it translates queries from apps (Sonarr, SickRage, CouchPotato, Mylar, etc) into tracker-site-specific http queries, parses the html response, then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.",
+      "category": "Indexers",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/jackett-banner.png",
+      "image_ref": "lscr.io/linuxserver/jackett",
+      "monthly_pulls": 1798383,
+      "stars": 487,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-jackett?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "jellyfin",
+      "description": "jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it.",
+      "category": "Media Servers,Music,Audiobooks",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/jellyfin-logo.png",
+      "image_ref": "lscr.io/linuxserver/jellyfin",
+      "monthly_pulls": 2955411,
+      "stars": 888,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-jellyfin?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "joplin",
+      "description": "[Joplin] is a free, open source note taking and to-do application, which can handle a large number of notes organised into notebooks.",
+      "category": "Content Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/joplin-logo.png",
+      "image_ref": "lscr.io/linuxserver/joplin",
+      "monthly_pulls": 8173,
+      "stars": 8,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-joplin?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "kali-linux",
+      "description": "kali-linux - is an Advanced Penetration Testing Linux distribution used for Penetration Testing, Ethical Hacking and network security assessments. KALI LINUX ™ is a trademark of OffSec.",
+      "category": "Remote Desktop,Security",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kali-logo.png",
+      "image_ref": "lscr.io/linuxserver/kali-linux",
+      "monthly_pulls": 13475,
+      "stars": 63,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-kali-linux?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "kasm",
+      "description": "kasm Workspaces is a docker container streaming platform for delivering browser-based access to desktops, applications, and web services. Kasm uses devops-enabled Containerized Desktop Infrastructure (CDI) to create on-demand, disposable, docker containers that are accessible via web browser. Example use-cases include Remote Browser Isolation (RBI), Data Loss Prevention (DLP), Desktop as a Service (DaaS), Secure Remote Access Services (RAS), and Open Source Intelligence (OSINT) collections.  The rendering of the graphical-based containers is powered by the open-source project [KasmVNC](https://www.kasmweb.com/kasmvnc.html?utm_campaign=LinuxServer&utm_source=kasmvnc).",
+      "category": "Remote Desktop,Business",
+      "logo_url": "https://kasm-ci.s3.amazonaws.com/kasm_wide.png",
+      "image_ref": "lscr.io/linuxserver/kasm",
+      "monthly_pulls": 228702,
+      "stars": 482,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-kasm?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "kavita",
+      "description": "kavita is a fast, feature rich, cross platform reading server. Built with a focus for being a full solution for all your reading needs. Setup your own server and share your reading collection with your friends and family!",
+      "category": "Books",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kavita-logo.png",
+      "image_ref": "lscr.io/linuxserver/kavita",
+      "monthly_pulls": 498170,
+      "stars": 46,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-kavita?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "kdenlive",
+      "description": "[Kdenlive] is a powerful free and open source cross-platform video editing program made by the KDE community. Feature rich and production ready.",
+      "category": "Video Editor",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kdenlive-logo.png",
+      "image_ref": "lscr.io/linuxserver/kdenlive",
+      "monthly_pulls": 2650,
+      "stars": 42,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-kdenlive?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "keepassxc",
+      "description": "[KeePassXC] is a free and open-source password manager. It started as a community fork of KeePassX (itself a cross-platform port of KeePass).",
+      "category": "Password Manager",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/keepassxc-logo.png",
+      "image_ref": "lscr.io/linuxserver/keepassxc",
+      "monthly_pulls": 24481,
+      "stars": 40,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-keepassxc?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "kicad",
+      "description": "[KiCad] - A Cross Platform and Open Source Electronics Design Automation Suite.",
+      "category": "3D Modeling",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kicad-logo.png",
+      "image_ref": "lscr.io/linuxserver/kicad",
+      "monthly_pulls": 5202,
+      "stars": 30,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-kicad?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "kimai",
+      "description": "kimai is a professional grade time-tracking application, free and open-source. It handles use-cases of freelancers as well as companies with dozens or hundreds of users. Kimai was build to track your project times and ships with many advanced features, including but not limited to:  JSON API, invoicing, data exports, multi-timer and punch-in punch-out mode, tagging, multi-user - multi-timezones - multi-language ([over 30 translations existing](https://hosted.weblate.org/projects/kimai/)!), authentication via SAML/LDAP/Database, two-factor authentication (2FA) with TOTP, customizable role and team permissions, responsive design, user/customer/project specific rates, advanced search & filtering, money and time budgets, advanced reporting, support for [plugins](https://www.kimai.org/store/) and so much more.",
+      "category": "Finance,Business",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kimai-logo.png",
+      "image_ref": "lscr.io/linuxserver/kimai",
+      "monthly_pulls": 6496,
+      "stars": 28,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-kimai?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "kometa",
+      "description": "kometa is a powerful tool designed to give you complete control over your media libraries. With kometa, you can take your customization to the next level, with granular control over metadata, collections, overlays, and much more.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kometa-banner.png",
+      "image_ref": "lscr.io/linuxserver/kometa",
+      "monthly_pulls": 131569,
+      "stars": 26,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-kometa?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "krita",
+      "description": "[Krita] is a professional FREE and open source painting program. It is made by artists that want to see affordable art tools for everyone.",
+      "category": "Image Editor",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/krita-logo.png",
+      "image_ref": "lscr.io/linuxserver/krita",
+      "monthly_pulls": 3178,
+      "stars": 32,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-krita?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "lazylibrarian",
+      "description": "lazylibrarian is a program to follow authors and grab metadata for all your digital reading needs. It uses a combination of Goodreads Librarything and optionally GoogleBooks as sources for author info and book info.  This container is based on the DobyTang fork.",
+      "category": "Books",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lazylibrarian-icon.png",
+      "image_ref": "lscr.io/linuxserver/lazylibrarian",
+      "monthly_pulls": 357291,
+      "stars": 119,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-lazylibrarian?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "ldap-auth",
+      "description": "ldap-auth software is for authenticating users who request protected resources from servers proxied by nginx. It includes a daemon (ldap-auth) that communicates with an authentication server, and a webserver daemon that generates an authentication cookie based on the user’s credentials. The daemons are written in Python for use with a Lightweight Directory Access Protocol (LDAP) authentication server (OpenLDAP or Microsoft Windows Active Directory 2003 and 2012).",
+      "category": "Administration,Security",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ldap-auth-logo.png",
+      "image_ref": "lscr.io/linuxserver/ldap-auth",
+      "monthly_pulls": 1271,
+      "stars": 75,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ldap-auth?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "libreoffice",
+      "description": "[LibreOffice] is a free and powerful office suite, and a successor to OpenOffice.org (commonly known as OpenOffice). Its clean interface and feature-rich tools help you unleash your creativity and enhance your productivity.",
+      "category": "Documents",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/libreoffice-logo.png",
+      "image_ref": "lscr.io/linuxserver/libreoffice",
+      "monthly_pulls": 35534,
+      "stars": 144,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-libreoffice?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "librespeed",
+      "description": "librespeed is a very lightweight Speedtest implemented in Javascript, using XMLHttpRequest and Web Workers.  No Flash, No Java, No Websocket, No Bullshit.",
+      "category": "Monitoring",
+      "logo_url": "https://raw.githubusercontent.com/librespeed/speedtest/master/.logo/logo3.png",
+      "image_ref": "lscr.io/linuxserver/librespeed",
+      "monthly_pulls": 176339,
+      "stars": 104,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-librespeed?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "librewolf",
+      "description": "[LibreWolf] is a custom and independent version of Firefox, with the primary goals of privacy, security and user freedom. LibreWolf also aims to remove all the telemetry, data collection and annoyances, as well as disabling anti-freedom features like DRM.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/librewolf-logo.png",
+      "image_ref": "lscr.io/linuxserver/librewolf",
+      "monthly_pulls": 17032,
+      "stars": 27,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-librewolf?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "lidarr",
+      "description": "lidarr is a music collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new tracks from your favorite artists and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
+      "category": "Media Management,Music",
+      "logo_url": "https://github.com/lidarr/Lidarr/raw/develop/Logo/400.png",
+      "image_ref": "lscr.io/linuxserver/lidarr",
+      "monthly_pulls": 5252531,
+      "stars": 309,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-lidarr?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "limnoria",
+      "description": "limnoria A robust, full-featured, and user/programmer-friendly Python IRC bot, with many existing plugins. Successor of the well-known Supybot.",
+      "category": "IRC",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/limnoria-icon.png",
+      "image_ref": "lscr.io/linuxserver/limnoria",
+      "monthly_pulls": 1605,
+      "stars": 10,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-limnoria?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "lm-studio",
+      "description": "[LM Studio] can run local AI models like gpt-oss, Llama, Gemma, Qwen, and DeepSeek privately on your computer.",
+      "category": "Remote Desktop,AI",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lmstudio-logo.png",
+      "image_ref": "lscr.io/linuxserver/lm-studio",
+      "monthly_pulls": 1139,
+      "stars": 5,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-lm-studio?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "lollypop",
+      "description": "[Lollypop] is a lightweight modern music player designed to work excellently on the GNOME desktop environment.",
+      "category": "Music",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lollypop-icon.png",
+      "image_ref": "lscr.io/linuxserver/lollypop",
+      "monthly_pulls": 1315,
+      "stars": 5,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-lollypop?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "luanti",
+      "description": "luanti (formerly Minetest) is an open source voxel game-creation platform with easy modding and game creation",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/minetest-icon.png",
+      "image_ref": "lscr.io/linuxserver/luanti",
+      "monthly_pulls": 3874,
+      "stars": 15,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-luanti?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "lychee",
+      "description": "lychee is a free photo-management tool, which runs on your server or web-space. Installing is a matter of seconds. Upload, manage and share photos like from a native application. Lychee comes with everything you need and all your photos are stored securely.",
+      "category": "Photos",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lychee-icon.png",
+      "image_ref": "lscr.io/linuxserver/lychee",
+      "monthly_pulls": 4477,
+      "stars": 51,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-lychee?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "mame",
+      "description": "[MAME] is a free and open-source emulator designed to emulate the hardware of arcade games, video game consoles, old computers and other systems in software on modern personal computers.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mame-logo.png",
+      "image_ref": "lscr.io/linuxserver/mame",
+      "monthly_pulls": 2580,
+      "stars": 6,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mame?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "manyfold",
+      "description": "manyfold  is an open source, self-hosted web application for managing a collection of 3D models, particularly focused on 3D printing.",
+      "category": "3D Printing",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/manyfold-logo.png",
+      "image_ref": "lscr.io/linuxserver/manyfold",
+      "monthly_pulls": 24256,
+      "stars": 10,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-manyfold?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "mariadb",
+      "description": "mariadb is one of the most popular database servers. Made by the original developers of MySQL.",
+      "category": "Databases",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mariadb-git.png",
+      "image_ref": "lscr.io/linuxserver/mariadb",
+      "monthly_pulls": 1733549,
+      "stars": 265,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mariadb?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "mastodon",
+      "description": "mastodon is a free, open-source social network server based on ActivityPub where users can follow friends and discover new ones..",
+      "category": "Social",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mastodon-banner.png",
+      "image_ref": "lscr.io/linuxserver/mastodon",
+      "monthly_pulls": 9501,
+      "stars": 118,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mastodon?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "mediaelch",
+      "description": "[MediaElch] is a MediaManager for Kodi. Information about Movies, TV Shows, Concerts and Music are stored as nfo files. Fanarts are downloaded automatically from fanart.tv. Using the nfo generator, MediaElch can be used with other MediaCenters as well.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mediaelch-logo.png",
+      "image_ref": "lscr.io/linuxserver/mediaelch",
+      "monthly_pulls": 3706,
+      "stars": 12,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mediaelch?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "medusa",
+      "description": "medusa is an automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/medusa-icon.png",
+      "image_ref": "lscr.io/linuxserver/medusa",
+      "monthly_pulls": 14506,
+      "stars": 49,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-medusa?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "melonds",
+      "description": "[melonDS] aims at providing fast and accurate Nintendo DS emulation.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/melonds-logo.png",
+      "image_ref": "lscr.io/linuxserver/melonds",
+      "monthly_pulls": 863,
+      "stars": 2,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-melonds?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "minisatip",
+      "description": "minisatip is a multi-threaded satip server version 1.2 that runs under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2, DVB-C, DVB-C2, ATSC and ISDB-T cards.",
+      "category": "Media Tools",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/minisatip-icon.png",
+      "image_ref": "lscr.io/linuxserver/minisatip",
+      "monthly_pulls": 287,
+      "stars": 19,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-minisatip?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "modmanager",
+      "description": "Modmanager is a centralised tool for downloading and updating docker mods for all your other Linuxserver containers.",
+      "category": "Docker",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver-ls-logo.png",
+      "image_ref": "lscr.io/linuxserver/modmanager",
+      "monthly_pulls": 21735,
+      "stars": 16,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-modmanager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "modrinth",
+      "description": "[Modrinth App] is a unique, open source launcher that allows you to play your favorite mods, and keep them up to date, all in one neat little package.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/modrinth-logo.png",
+      "image_ref": "lscr.io/linuxserver/modrinth",
+      "monthly_pulls": 1010,
+      "stars": 1,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-modrinth?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "msedge",
+      "description": "[Microsoft Edge] is a cross-platform web browser developed by Microsoft and based on Chromium.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/edge-logo.png",
+      "image_ref": "lscr.io/linuxserver/msedge",
+      "monthly_pulls": 12058,
+      "stars": 64,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-msedge?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "mstream",
+      "description": "mstream is a personal music streaming server. You can use mStream to stream your music from your home computer to any device, anywhere.  There are mobile apps available for both Android and iPhone.",
+      "category": "Media Servers,Music",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mstream-icon.png",
+      "image_ref": "lscr.io/linuxserver/mstream",
+      "monthly_pulls": 106773,
+      "stars": 88,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mstream?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "mullvad-browser",
+      "description": "The [Mullvad Browser] is a privacy-focused web browser developed in a collaboration between Mullvad VPN and the Tor Project. It’s designed to minimize tracking and fingerprinting. You could say it’s a Tor Browser to use without the Tor Network. Instead, you can use it with a trustworthy VPN.",
+      "category": "Web Browser,VPN",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mullvad-browser-logo.png",
+      "image_ref": "lscr.io/linuxserver/mullvad-browser",
+      "monthly_pulls": 12377,
+      "stars": 36,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mullvad-browser?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "mylar3",
+      "description": "mylar3 is an automated Comic Book downloader (cbr/cbz) for use with NZB and torrents written in python. It supports SABnzbd, NZBGET, and many torrent clients in addition to DDL.",
+      "category": "Books,Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mylar-icon.png",
+      "image_ref": "lscr.io/linuxserver/mylar3",
+      "monthly_pulls": 429958,
+      "stars": 52,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mylar3?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "mysql-workbench",
+      "description": "[MySQL Workbench] is a unified visual tool for database architects, developers, and DBAs. MySQL Workbench provides data modeling, SQL development, and comprehensive administration tools for server configuration, user administration, backup, and much more.",
+      "category": "Databases",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mysql-workbench-icon.png",
+      "image_ref": "lscr.io/linuxserver/mysql-workbench",
+      "monthly_pulls": 3846,
+      "stars": 44,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-mysql-workbench?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "netbox",
+      "description": "netbox is an IP address management (IPAM) and data center infrastructure management (DCIM) tool. Initially conceived by the network engineering team at DigitalOcean, NetBox was developed specifically to address the needs of network and infrastructure engineers. It is intended to function as a domain-specific source of truth for network operations.",
+      "category": "Administration,Business",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/netbox-logo.png",
+      "image_ref": "lscr.io/linuxserver/netbox",
+      "monthly_pulls": 34166,
+      "stars": 128,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-netbox?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "nextcloud",
+      "description": "nextcloud gives you access to all your files wherever you are.  Where are your photos and documents? With Nextcloud you pick a server of your choice, at home, in a data center or at a provider. And that is where your files will be. Nextcloud runs on that server, protecting your data and giving you access from your desktop or mobile devices. Through Nextcloud you also access, sync and share your existing data on that FTP drive at the office, a Dropbox or a NAS you have at home.",
+      "category": "Cloud,Documents",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/nextcloud-icon.png",
+      "image_ref": "lscr.io/linuxserver/nextcloud",
+      "monthly_pulls": 559437,
+      "stars": 884,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-nextcloud?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "nginx",
+      "description": "nginx is an HTTP web server, reverse proxy, content cache, load balancer, TCP/UDP proxy server, and mail proxy server.",
+      "category": "Reverse Proxy",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/nginx-banner.png",
+      "image_ref": "lscr.io/linuxserver/nginx",
+      "monthly_pulls": 172085,
+      "stars": 167,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-nginx?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "ngircd",
+      "description": "ngircd is a free, portable and lightweight Internet Relay Chat server for small or private networks, developed under the GNU General Public License (GPL). It is easy to configure, can cope with dynamic IP addresses, and supports IPv6, SSL-protected connections as well as PAM for authentication. It is written from scratch and not based on the original IRCd.",
+      "category": "IRC",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ngircd-logo.png",
+      "image_ref": "lscr.io/linuxserver/ngircd",
+      "monthly_pulls": 6025,
+      "stars": 13,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ngircd?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "nzbget",
+      "description": "nzbget is a usenet downloader, written in C++ and designed with performance in mind to achieve maximum download speed by using very little system resources.",
+      "category": "Downloaders",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/nzbget-banner.png",
+      "image_ref": "lscr.io/linuxserver/nzbget",
+      "monthly_pulls": 518168,
+      "stars": 185,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-nzbget?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "nzbhydra2",
+      "description": "nzbhydra2 is a meta search application for NZB indexers, the spiritual successor to NZBmegasearcH, and an evolution of the original application [NZBHydra](https://github.com/theotherp/nzbhydra).  It provides easy access to a number of raw and newznab based indexers.",
+      "category": "Indexers",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hydra-icon.png",
+      "image_ref": "lscr.io/linuxserver/nzbhydra2",
+      "monthly_pulls": 226782,
+      "stars": 86,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-nzbhydra2?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "obsidian",
+      "description": "[Obsidian] is a note-taking app that lets you create, link, and organize your notes on your device, with hundreds of plugins and themes to customize your workflow. You can also publish your notes online, access them offline, and sync them securely with end-to-end encryption.",
+      "category": "Content Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/obsidian-logo.png",
+      "image_ref": "lscr.io/linuxserver/obsidian",
+      "monthly_pulls": 786757,
+      "stars": 866,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-obsidian?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "ombi",
+      "description": "ombi allows you to host your own Plex Request and user management system. If you are sharing your Plex server with other users, allow them to request new content using an easy to manage interface! Manage all your requests for Movies and TV with ease, leave notes for the user and get notification when a user requests something. Allow your users to post issues against their requests so you know there is a problem with the audio etc. Even automatically send them weekly newsletters of new content that has been added to your Plex server!",
+      "category": "Media Requesters",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ombi.png",
+      "image_ref": "lscr.io/linuxserver/ombi",
+      "monthly_pulls": 147974,
+      "stars": 169,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ombi?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "onlyoffice",
+      "description": "[ONLYOFFICE] provides a full range of tools to create, edit and collaborate on text documents, spreadsheets, presentations, PDF forms and regular PDF files on web, desktop and mobile platforms.",
+      "category": "Documents",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/onlyoffice-logo.png",
+      "image_ref": "lscr.io/linuxserver/onlyoffice",
+      "monthly_pulls": 10896,
+      "stars": 18,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-onlyoffice?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "openshot",
+      "description": "[OpenShot] Video Editor is an award-winning free and open-source video editor for Linux, Mac, and Windows, and is dedicated to delivering high quality video editing and animation solutions to the world.",
+      "category": "Video Editor",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/openshot-logo.png",
+      "image_ref": "lscr.io/linuxserver/openshot",
+      "monthly_pulls": 449,
+      "stars": 7,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-openshot?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "openssh-server",
+      "description": "openssh-server is a sandboxed environment that allows ssh access without giving keys to the entire server. Giving ssh access via private key often means giving full access to the server. This container creates a limited and sandboxed environment that others can ssh into. The users only have access to the folders mapped and the processes running inside this container.",
+      "category": "Administration",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/openssh-server-logo.png",
+      "image_ref": "lscr.io/linuxserver/openssh-server",
+      "monthly_pulls": 225000,
+      "stars": 609,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-openssh-server?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "opera",
+      "description": "[Opera] is a multi-platform web browser developed by its namesake company Opera. The browser is based on Chromium, but distinguishes itself from other Chromium-based browsers (Chrome, Edge, etc.) through its user interface and other features.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/opera-icon.png",
+      "image_ref": "lscr.io/linuxserver/opera",
+      "monthly_pulls": 2244,
+      "stars": 5,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-opera?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "orcaslicer",
+      "description": "[Orca Slicer] is an open source slicer for FDM printers. OrcaSlicer is fork of Bambu Studio, it was previously known as BambuStudio-SoftFever, Bambu Studio is forked from PrusaSlicer by Prusa Research, which is from Slic3r by Alessandro Ranellucci and the RepRap community",
+      "category": "3D Printing",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/orcaslicer-logo.png",
+      "image_ref": "lscr.io/linuxserver/orcaslicer",
+      "monthly_pulls": 49321,
+      "stars": 170,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-orcaslicer?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "oscam",
+      "description": "oscam is an Open Source Conditional Access Module software used for descrambling DVB transmissions using smart cards. It's both a server and a client.",
+      "category": "Media Tools",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/oscam-logo.png",
+      "image_ref": "lscr.io/linuxserver/oscam",
+      "monthly_pulls": 15295,
+      "stars": 53,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-oscam?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "pairdrop",
+      "description": "[PairDrop] is a sublime alternative to AirDrop that works on all platforms. Send images, documents or text via peer to peer connection to devices in the same local network/Wi-Fi or to paired devices.",
+      "category": "File Sharing",
+      "logo_url": "https://raw.githubusercontent.com/schlagmichdoch/PairDrop/master/public/images/android-chrome-512x512.png",
+      "image_ref": "lscr.io/linuxserver/pairdrop",
+      "monthly_pulls": 148494,
+      "stars": 113,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-pairdrop?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "pcsx2",
+      "description": "[PCSX2] is an open source PS2 Emulator.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/pcsx2-logo.png",
+      "image_ref": "lscr.io/linuxserver/pcsx2",
+      "monthly_pulls": 3213,
+      "stars": 14,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-pcsx2?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "phpmyadmin",
+      "description": "phpmyadmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.",
+      "category": "Databases",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/phpmyadmin-logo.png",
+      "image_ref": "lscr.io/linuxserver/phpmyadmin",
+      "monthly_pulls": 64724,
+      "stars": 32,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-phpmyadmin?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "pidgin",
+      "description": "[Pidgin] is a chat program which lets you log into accounts on multiple chat networks simultaneously. This means that you can be chatting with friends on XMPP and sitting in an IRC channel at the same time.",
+      "category": "IRC,Chat",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/pidgin-logo.png",
+      "image_ref": "lscr.io/linuxserver/pidgin",
+      "monthly_pulls": 3536,
+      "stars": 13,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-pidgin?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "piper",
+      "description": "piper is a fast, local neural text to speech system that sounds great and is optimized for the Raspberry Pi 4. This container provides a Wyoming protocol server for Piper.",
+      "category": "Machine Learning",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/piper-logo.png",
+      "image_ref": "lscr.io/linuxserver/piper",
+      "monthly_pulls": 100338,
+      "stars": 68,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-piper?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "piwigo",
+      "description": "piwigo is a photo gallery software for the web that comes with powerful features to publish and manage your collection of pictures.",
+      "category": "Photos",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/piwigo-banner.png",
+      "image_ref": "lscr.io/linuxserver/piwigo",
+      "monthly_pulls": 29601,
+      "stars": 149,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-piwigo?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "planka",
+      "description": "planka is an elegant open source project tracking tool.",
+      "category": "Content Management,Business",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/planka-logo.png",
+      "image_ref": "lscr.io/linuxserver/planka",
+      "monthly_pulls": 4639,
+      "stars": 10,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-planka?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "plex",
+      "description": "plex organizes video, music and photos from personal media libraries and streams them to smart TVs, streaming boxes and mobile devices. This container is packaged as a standalone Plex Media Server. Straightforward design and bulk actions mean getting things done faster.",
+      "category": "Media Servers,Music,Audiobooks",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/plex-logo.png",
+      "image_ref": "lscr.io/linuxserver/plex",
+      "monthly_pulls": 2410119,
+      "stars": 1429,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-plex?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "ppsspp",
+      "description": "[PPSSPP] is a free and open-source PSP emulator for Windows, macOS, Linux, iOS, Android, Nintendo Wii U, Nintendo Switch, BlackBerry 10, MeeGo, Pandora, Xbox Series and Symbian with a focus on speed and portability.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ppsspp-logo.png",
+      "image_ref": "lscr.io/linuxserver/ppsspp",
+      "monthly_pulls": 885,
+      "stars": 1,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ppsspp?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "projectsend",
+      "description": "projectsend is a self-hosted application that lets you upload files and assign them to specific clients that you create yourself. Secure, private and easy. No more depending on external services or e-mail to send those files.",
+      "category": "File Sharing",
+      "logo_url": "http://www.projectsend.org/wp-content/themes/projectsend/img/screenshots.png",
+      "image_ref": "lscr.io/linuxserver/projectsend",
+      "monthly_pulls": 20366,
+      "stars": 98,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-projectsend?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "prowlarr",
+      "description": "prowlarr is a indexer manager/proxy built on the popular arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Sonarr, Radarr, Lidarr, and Readarr offering complete management of your indexers with no per app Indexer setup required (we do it all).",
+      "category": "Indexers",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/prowlarr-banner.png",
+      "image_ref": "lscr.io/linuxserver/prowlarr",
+      "monthly_pulls": 12819425,
+      "stars": 530,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-prowlarr?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "pwndrop",
+      "description": "pwndrop is a self-deployable file hosting service for sending out red teaming payloads or securely sharing your private files over HTTP and WebDAV.",
+      "category": "File Sharing,Security",
+      "logo_url": "https://raw.githubusercontent.com/kgretzky/pwndrop/master/media/pwndrop-logo-512.png",
+      "image_ref": "lscr.io/linuxserver/pwndrop",
+      "monthly_pulls": 5469,
+      "stars": 49,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-pwndrop?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "pycharm",
+      "description": "[PyCharm] offers out-of-the-box support for Python, databases, Jupyter, Git, Conda, PyTorch, TensorFlow, Hugging Face, Django, Flask, FastAPI, and more.",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/pycharm-logo.png",
+      "image_ref": "lscr.io/linuxserver/pycharm",
+      "monthly_pulls": 194,
+      "stars": 5,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-pycharm?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "pydio-cells",
+      "description": "pydio-cells is the nextgen file sharing platform for organizations. It is a full rewrite of the Pydio project using the Go language following a micro-service architecture.",
+      "category": "File Sharing",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/pydio-cells-icon.png",
+      "image_ref": "lscr.io/linuxserver/pydio-cells",
+      "monthly_pulls": 1523,
+      "stars": 21,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-pydio-cells?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "pyload-ng",
+      "description": "[pyLoad] is a Free and Open Source download manager written in Python and designed to be extremely lightweight, easily extensible and fully manageable via web.",
+      "category": "Downloaders",
+      "logo_url": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/pyload-logo.png",
+      "image_ref": "lscr.io/linuxserver/pyload-ng",
+      "monthly_pulls": 262385,
+      "stars": 128,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-pyload-ng?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "qbittorrent",
+      "description": "The qbittorrent is a bittorrent client programmed in C++ / Qt that uses libtorrent (sometimes called libtorrent-rasterbar) by Arvid Norberg.",
+      "category": "Downloaders",
+      "logo_url": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/qbittorrent-icon.png",
+      "image_ref": "lscr.io/linuxserver/qbittorrent",
+      "monthly_pulls": 7549412,
+      "stars": 1690,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-qbittorrent?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "qdirstat",
+      "description": "[QDirStat] Qt-based directory statistics: KDirStat without any KDE -- from the author of the original KDirStat.",
+      "category": "Storage",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/qdirstat-logo.png",
+      "image_ref": "lscr.io/linuxserver/qdirstat",
+      "monthly_pulls": 48336,
+      "stars": 34,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-qdirstat?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "qemu-static",
+      "description": "Run multiple architectures of Docker containers on an x86_64 or aarch64 host using QEMU static.",
+      "category": "Docker",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/qemu-logo.png",
+      "image_ref": "lscr.io/linuxserver/qemu-static",
+      "monthly_pulls": 775930,
+      "stars": 13,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-qemu-static",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "radarr",
+      "description": "radarr - A fork of Sonarr to work with movies à la Couchpotato.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/radarr.png",
+      "image_ref": "lscr.io/linuxserver/radarr",
+      "monthly_pulls": 13061680,
+      "stars": 940,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-radarr?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "raneto",
+      "description": "raneto - is an open source Knowledgebase platform that uses static Markdown files to power your Knowledgebase.",
+      "category": "Content Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/raneto-logo.png",
+      "image_ref": "lscr.io/linuxserver/raneto",
+      "monthly_pulls": 430,
+      "stars": 18,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-raneto?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "rawtherapee",
+      "description": "[RawTherapee] is a free, cross-platform raw image processing program!",
+      "category": "Image Editor",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/rawtherapee-logo.png",
+      "image_ref": "lscr.io/linuxserver/rawtherapee",
+      "monthly_pulls": 1480,
+      "stars": 6,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-rawtherapee?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "remmina",
+      "description": "[Remmina] is a remote desktop client written in GTK, aiming to be useful for system administrators and travellers, who need to work with lots of remote computers in front of either large or tiny screens. Remmina supports multiple network protocols, in an integrated and consistent user interface. Currently RDP, VNC, SPICE, SSH and EXEC are supported.",
+      "category": "Remote Desktop",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/remmina-icon.png",
+      "image_ref": "lscr.io/linuxserver/remmina",
+      "monthly_pulls": 14424,
+      "stars": 76,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-remmina?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "resilio-sync",
+      "description": "resilio-sync (formerly BitTorrent Sync) uses the BitTorrent protocol to sync files and folders between all of your devices. There are both free and paid versions, this container supports both. There is an official sync image but we created this one as it supports user mapping to simplify permissions for volumes.",
+      "category": "Backup",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/resilio-sync-logo.png",
+      "image_ref": "lscr.io/linuxserver/resilio-sync",
+      "monthly_pulls": 102783,
+      "stars": 200,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-resilio-sync?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "retroarch",
+      "description": "[RetroArch] is a frontend for emulators, game engines and media players. It enables you to run classic games on a wide range of computers and consoles through its slick graphical interface.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/retroarch-logo.png",
+      "image_ref": "lscr.io/linuxserver/retroarch",
+      "monthly_pulls": 9889,
+      "stars": 19,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-retroarch?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "rpcs3",
+      "description": "[RPCS3] is a multi-platform open-source Sony PlayStation 3 emulator and debugger written in C++ for Windows, Linux, macOS and FreeBSD.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/rpcs3-logo.png",
+      "image_ref": "lscr.io/linuxserver/rpcs3",
+      "monthly_pulls": 752,
+      "stars": 5,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-rpcs3?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "rsnapshot",
+      "description": "rsnapshot is a filesystem snapshot utility based on rsync. rsnapshot makes it easy to make periodic snapshots of local machines, and remote machines over ssh. The code makes extensive use of hard links whenever possible, to greatly reduce the disk space required.",
+      "category": "Backup",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/rsnapshot.png",
+      "image_ref": "lscr.io/linuxserver/rsnapshot",
+      "monthly_pulls": 5296,
+      "stars": 41,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-rsnapshot?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "rustdesk",
+      "description": "[RustDesk] is a full-featured open source remote control alternative for self-hosting and security with minimal configuration.",
+      "category": "Remote Desktop",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/rustdesk-logo.png",
+      "image_ref": "lscr.io/linuxserver/rustdesk",
+      "monthly_pulls": 1904070,
+      "stars": 63,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-rustdesk?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "sabnzbd",
+      "description": "sabnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb. SABnzbd takes over from there, where it will be automatically downloaded, verified, repaired, extracted and filed away with zero human interaction.",
+      "category": "Downloaders",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/sabnzbd-banner.png",
+      "image_ref": "lscr.io/linuxserver/sabnzbd",
+      "monthly_pulls": 3452505,
+      "stars": 356,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-sabnzbd?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "scummvm",
+      "description": "[ScummVM] is a program which allows you to run certain classic graphical adventure and role-playing games, provided you already have their data files. The clever part about this: ScummVM just replaces the executables shipped with the games, allowing you to play them on systems for which they were never designed! ScummVM is a complete rewrite of these games' executables and is not an emulator.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/scummvm-logo.png",
+      "image_ref": "lscr.io/linuxserver/scummvm",
+      "monthly_pulls": 1760,
+      "stars": 11,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-scummvm?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "sealskin",
+      "description": "[Sealskin] is a self-hosted, client-server platform that enables users to run powerful, containerized desktop applications streamed directly to a web browser. It uses a browser extension to intercept user actions—such as clicking a link or downloading a file and redirects them to a secure, isolated application environment running on a remote server.",
+      "category": "Remote Desktop, Business",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/selkies-logo.png",
+      "image_ref": "lscr.io/linuxserver/sealskin",
+      "monthly_pulls": 12501,
+      "stars": 120,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-sealskin?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "shadps4",
+      "description": "[shadPS4] is an early PlayStation 4 emulator for Windows, Linux and macOS written in C++.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/shadps4-logo.png",
+      "image_ref": "lscr.io/linuxserver/shadps4",
+      "monthly_pulls": 68,
+      "stars": 2,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-shadps4?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "shotcut",
+      "description": "shotcut is a free, open source, cross-platform video editor.",
+      "category": "Video Editor",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/shotcut-logo.png",
+      "image_ref": "lscr.io/linuxserver/shotcut",
+      "monthly_pulls": 2801,
+      "stars": 13,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-shotcut?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "sickgear",
+      "description": "[SickGear] provides management of TV shows and/or Anime, it detects new episodes, links downloader apps, and more..  For more information on SickGear visit their website and check it out: https://github.com/SickGear/SickGear",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/wiki/SickGear/SickGear.Wiki/images/SickGearLogo.png",
+      "image_ref": "lscr.io/linuxserver/sickgear",
+      "monthly_pulls": 2057,
+      "stars": 12,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-sickgear?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "signal",
+      "description": "[Signal] is a messaging app with privacy at its core. It is free and easy to use, with strong end-to-end encryption that keeps your communication completely private.",
+      "category": "Chat",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/signal-logo.png",
+      "image_ref": "lscr.io/linuxserver/signal",
+      "monthly_pulls": 1177,
+      "stars": 4,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-signal?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "smokeping",
+      "description": "smokeping keeps track of your network latency. For a full example of what this application is capable of visit [UCDavis](http://smokeping.ucdavis.edu/cgi-bin/smokeping.fcgi).",
+      "category": "Monitoring",
+      "logo_url": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/smokeping-logo.png",
+      "image_ref": "lscr.io/linuxserver/smokeping",
+      "monthly_pulls": 596560,
+      "stars": 430,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-smokeping?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "socket-proxy",
+      "description": "The Socket Proxy is a security-enhanced proxy which allows you to apply access rules to the Docker socket, limiting the attack surface for containers such as watchtower or Traefik that need to use it.",
+      "category": "Docker",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/docker-logo.png",
+      "image_ref": "lscr.io/linuxserver/socket-proxy",
+      "monthly_pulls": 983751,
+      "stars": 299,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-socket-proxy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "sonarr",
+      "description": "sonarr (formerly NZBdrone) is a PVR for usenet and bittorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/sonarr-banner.png",
+      "image_ref": "lscr.io/linuxserver/sonarr",
+      "monthly_pulls": 11374501,
+      "stars": 1104,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-sonarr?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "speedtest-tracker",
+      "description": "speedtest-tracker is a self-hosted internet performance tracking application that runs speedtest checks against Ookla's Speedtest service.",
+      "category": "Monitoring",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/speedtest-tracker-logo.png",
+      "image_ref": "lscr.io/linuxserver/speedtest-tracker",
+      "monthly_pulls": 1577845,
+      "stars": 180,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-speedtest-tracker?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "spotube",
+      "description": "[Spotube] is an open source, cross-platform Spotify client compatible across multiple platforms utilizing Spotify's data API and YouTube, Piped.video or JioSaavn as an audio source, eliminating the need for Spotify Premium",
+      "category": "Music",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/spotube-logo.png",
+      "image_ref": "lscr.io/linuxserver/spotube",
+      "monthly_pulls": 3667,
+      "stars": 38,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-spotube?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "sqlitebrowser",
+      "description": "[DB Browser for SQLite] is a high quality, visual, open source tool to create, design, and edit database files compatible with SQLite.",
+      "category": "Databases",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/sqlitebrowser-banner.png",
+      "image_ref": "lscr.io/linuxserver/sqlitebrowser",
+      "monthly_pulls": 25719,
+      "stars": 38,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-sqlitebrowser?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "steam",
+      "description": "[Steam] is the ultimate destination for playing, discussing, and creating games.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/steam-logo.png",
+      "image_ref": "lscr.io/linuxserver/steam",
+      "monthly_pulls": 15419,
+      "stars": 31,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-steam?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "swag",
+      "description": "SWAG - Secure Web Application Gateway (formerly known as letsencrypt, no relation to Let's Encrypt™) sets up an Nginx webserver and reverse proxy with php support and a built-in certbot client that automates free SSL server certificate generation and renewal processes (Let's Encrypt and ZeroSSL). It also contains fail2ban for intrusion prevention.",
+      "category": "Reverse Proxy",
+      "logo_url": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/swag.gif",
+      "image_ref": "lscr.io/linuxserver/swag",
+      "monthly_pulls": 358001,
+      "stars": 3700,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-swag?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "synclounge",
+      "description": "synclounge is a third party tool that allows you to watch Plex in sync with your friends/family, wherever you are.",
+      "category": "Media Tools",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/synclounge-banner.png",
+      "image_ref": "lscr.io/linuxserver/synclounge",
+      "monthly_pulls": 2011,
+      "stars": 14,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-synclounge?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "syncthing",
+      "description": "syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet.",
+      "category": "Backup",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/syncthing-banner.png",
+      "image_ref": "lscr.io/linuxserver/syncthing",
+      "monthly_pulls": 1146475,
+      "stars": 364,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-syncthing?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "syslog-ng",
+      "description": "[syslog-ng] allows you to flexibly collect, parse, classify, rewrite and correlate logs from across your infrastructure and store or route them to log analysis tools.",
+      "category": "Monitoring",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/syslog-ng-logo.png",
+      "image_ref": "lscr.io/linuxserver/syslog-ng",
+      "monthly_pulls": 76164,
+      "stars": 84,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-syslog-ng?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "tautulli",
+      "description": "tautulli is a python based web application for monitoring, analytics and notifications for Plex Media Server.",
+      "category": "Media Tools",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/tautulli-icon.png",
+      "image_ref": "lscr.io/linuxserver/tautulli",
+      "monthly_pulls": 1294302,
+      "stars": 243,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-tautulli?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "telegram",
+      "description": "[Telegram] is a cloud-based mobile and desktop messaging app.",
+      "category": "Chat",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/telegram-logo.png",
+      "image_ref": "lscr.io/linuxserver/telegram",
+      "monthly_pulls": 19657,
+      "stars": 5,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-telegram?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "thelounge",
+      "description": "thelounge (a fork of shoutIRC) is a web IRC client that you host on your own server.",
+      "category": "IRC,Chat",
+      "logo_url": "https://raw.githubusercontent.com/thelounge/thelounge/master/client/img/logo-vertical-transparent-bg.svg?sanitize=true",
+      "image_ref": "lscr.io/linuxserver/thelounge",
+      "monthly_pulls": 32734,
+      "stars": 36,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-thelounge?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "thunderbird",
+      "description": "[Thunderbird] is a free and open-source personal information manager primarily used as an e-mail client with a calendar and contactbook, as well as an RSS feed reader, chat client, and news client.",
+      "category": "Email",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/thunderbird-logo.png",
+      "image_ref": "lscr.io/linuxserver/thunderbird",
+      "monthly_pulls": 22766,
+      "stars": 11,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-thunderbird?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "transmission",
+      "description": "transmission is designed for easy, powerful use. Transmission has the features you want from a BitTorrent client: encryption, a web interface, peer exchange, magnet links, DHT, µTP, UPnP and NAT-PMP port forwarding, webseed support, watch directories, tracker editing, global and per-torrent speed limits, and more.",
+      "category": "Downloaders",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission.png",
+      "image_ref": "lscr.io/linuxserver/transmission",
+      "monthly_pulls": 1213441,
+      "stars": 733,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-transmission?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "tvheadend",
+      "description": "tvheadend works as a proxy server: is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT>IP and HDHomeRun as input sources. Tvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP streaming. Multiple EPG sources are supported (over-the-air DVB and ATSC including OpenTV DVB extensions, XMLTV, PyXML).",
+      "category": "Media Tools",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/tvheadend-big.png",
+      "image_ref": "lscr.io/linuxserver/tvheadend",
+      "monthly_pulls": 107903,
+      "stars": 214,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-tvheadend?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "ubooquity",
+      "description": "ubooquity is a free, lightweight and easy-to-use home server for your comics and ebooks. Use it to access your files from anywhere, with a tablet, an e-reader, a phone or a computer.",
+      "category": "Books",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ubooquity-banner.png",
+      "image_ref": "lscr.io/linuxserver/ubooquity",
+      "monthly_pulls": 32751,
+      "stars": 115,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ubooquity?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "ungoogled-chromium",
+      "description": "[Ungoogled Chromium] is Google Chromium, sans dependency on Google web services.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ungoogled-chromium-logo.png",
+      "image_ref": "lscr.io/linuxserver/ungoogled-chromium",
+      "monthly_pulls": 12283,
+      "stars": 28,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-ungoogled-chromium?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "unifi-network-application",
+      "description": "The unifi-network-application software is a powerful, enterprise wireless software engine ideal for high-density client deployments requiring low latency and high uptime performance.",
+      "category": "Network",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/unifi-banner.png",
+      "image_ref": "lscr.io/linuxserver/unifi-network-application",
+      "monthly_pulls": 557556,
+      "stars": 1157,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-unifi-network-application?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "vivaldi",
+      "description": "[Vivaldi] is a Norwegian freeware, cross-platform web browser with a built-in email client developed by Vivaldi Technologies.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/vivaldi-logo.png",
+      "image_ref": "lscr.io/linuxserver/vivaldi",
+      "monthly_pulls": 4538,
+      "stars": 8,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-vivaldi?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "vlc",
+      "description": "[VLC Media Player] is a free and open source cross-platform multimedia player and framework that delivers dependable performance across multiple devices.",
+      "category": "Media Management",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/vlc-logo.png",
+      "image_ref": "lscr.io/linuxserver/vlc",
+      "monthly_pulls": 1190,
+      "stars": 4,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-vlc?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "vscode",
+      "description": "[VS Code] is an integrated development environment developed by Microsoft. This container runs the full desktop application, for a web native version see [Code Server](https://github.com/linuxserver/docker-code-server).",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/vscode-logo.png",
+      "image_ref": "lscr.io/linuxserver/vscode",
+      "monthly_pulls": 34706,
+      "stars": 2,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-vscode?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "vscodium",
+      "description": "[VSCodium] is a community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/vscodium-icon.png",
+      "image_ref": "lscr.io/linuxserver/vscodium",
+      "monthly_pulls": 18096,
+      "stars": 77,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-vscodium?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "vscodium-web",
+      "description": "vscodium-web is a community-driven, freely-licensed binary distribution of the remote host web component of Microsoft's editor VS Code.",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/vscodium-icon.png",
+      "image_ref": "lscr.io/linuxserver/vscodium-web",
+      "monthly_pulls": 6240,
+      "stars": 26,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-vscodium-web?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "webcord",
+      "description": "[WebCord] can be summarized as a pack of security and privacy hardenings, Discord features reimplementations, Electron / Chromium / Discord bugs workarounds, stylesheets, internal pages and wrapped https://discord.com page, designed to conform with ToS as much as it is possible (or hide the changes that might violate it from Discord's eyes).",
+      "category": "Chat",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/webcord-icon.png",
+      "image_ref": "lscr.io/linuxserver/webcord",
+      "monthly_pulls": 26469,
+      "stars": 12,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-webcord?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "webgrabplus",
+      "description": "webgrabplus is a multi-site incremental xmltv epg grabber. It collects tv-program guide data from selected tvguide sites for your favourite channels.",
+      "category": "Media Tools",
+      "logo_url": "https://www.webgrabplus.com/sites/default/themes/WgTheme/images/slideshows/EPG_fading.jpg",
+      "image_ref": "lscr.io/linuxserver/webgrabplus",
+      "monthly_pulls": 4945,
+      "stars": 33,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-webgrabplus?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "webstation",
+      "description": "[Webstation] is a web native emulation focused LXQt desktop based on Ubuntu.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/webstation-logo.png",
+      "image_ref": "lscr.io/linuxserver/webstation",
+      "monthly_pulls": 22870,
+      "stars": 4,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-webstation?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "webtop",
+      "description": "webtop - Alpine, Ubuntu, Fedora, and Arch based containers containing full desktop environments in officially supported flavors accessible via any modern web browser.",
+      "category": "Remote Desktop",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/webtop-logo.png",
+      "image_ref": "lscr.io/linuxserver/webtop",
+      "monthly_pulls": 347485,
+      "stars": 4304,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-webtop?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "weixin",
+      "description": "[Weixin] (WeChat) is an instant messaging, social media, and mobile payment app developed by Tencent.",
+      "category": "Chat",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/weixin-logo.png",
+      "image_ref": "lscr.io/linuxserver/weixin",
+      "monthly_pulls": 950,
+      "stars": 59,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-weixin?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "wikijs",
+      "description": "wikijs A modern, lightweight and powerful wiki app built on NodeJS.",
+      "category": "Content Management",
+      "logo_url": "https://static.requarks.io/logo/wikijs-full.svg",
+      "image_ref": "lscr.io/linuxserver/wikijs",
+      "monthly_pulls": 47362,
+      "stars": 99,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-wikijs?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    },
+    {
+      "name": "winegui",
+      "description": "[WineGUI] is a user-interface friendly Wine manager that provides a graphical frontend for creating and managing Wine bottles.",
+      "category": "Games,Business",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/winegui-logo.png",
+      "image_ref": "lscr.io/linuxserver/winegui",
+      "monthly_pulls": 2762,
+      "stars": 3,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-winegui?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "wireguard",
+      "description": "[WireGuard®] is an extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography. It aims to be faster, simpler, leaner, and more useful than IPsec, while avoiding the massive headache. It intends to be considerably more performant than OpenVPN. WireGuard is designed as a general purpose VPN for running on embedded interfaces and super computers alike, fit for many different circumstances. Initially released for the Linux kernel, it is now cross-platform (Windows, macOS, BSD, iOS, Android) and widely deployable. It is currently under heavy development, but already it might be regarded as the most secure, easiest to use, and simplest VPN solution in the industry.",
+      "category": "Network,VPN",
+      "logo_url": "https://www.wireguard.com/img/wireguard.svg",
+      "image_ref": "lscr.io/linuxserver/wireguard",
+      "monthly_pulls": 781099,
+      "stars": 3628,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-wireguard?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "wireshark",
+      "description": "[Wireshark] is the world’s foremost and widely-used network protocol analyzer. It lets you see what’s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions. Wireshark development thrives thanks to the volunteer contributions of networking experts around the globe and is the continuation of a project started by Gerald Combs in 1998.",
+      "category": "Network",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/wireshark-icon.png",
+      "image_ref": "lscr.io/linuxserver/wireshark",
+      "monthly_pulls": 12126,
+      "stars": 164,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-wireshark?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "wps-office",
+      "description": "[WPS Office] is a lightweight, feature-rich comprehensive office suite with high compatibility. As a handy and professional office software, WPS Office allows you to edit files in Writer, Presentation, Spreadsheet, and PDF to improve your work efficiency.",
+      "category": "Documents",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/wps-office-icon.png",
+      "image_ref": "lscr.io/linuxserver/wps-office",
+      "monthly_pulls": 5760,
+      "stars": 185,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-wps-office?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "xbackbone",
+      "description": "xbackbone is a simple, self-hosted, lightweight PHP file manager that support the instant sharing tool ShareX and *NIX systems. It supports uploading and displaying images, GIF, video, code, formatted text, and file downloading and uploading. Also have a web UI with multi user management, past uploads history and search support.",
+      "category": "File Sharing",
+      "logo_url": "https://raw.githubusercontent.com/SergiX44/XBackBone/master/docs/img/xbackbone.png",
+      "image_ref": "lscr.io/linuxserver/xbackbone",
+      "monthly_pulls": 10693,
+      "stars": 35,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-xbackbone?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "xemu",
+      "description": "[xemu] is a free and open-source application that emulates the original Microsoft Xbox game console, enabling people to play their original Xbox games on Windows, macOS, and Linux systems.",
+      "category": "Games",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/xemu-logo.png",
+      "image_ref": "lscr.io/linuxserver/xemu",
+      "monthly_pulls": 2609,
+      "stars": 5,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-xemu?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "yaak",
+      "description": "yaak is a desktop API client for organizing and executing REST, GraphQL, and gRPC requests. It's built using [Tauri](https://tauri.app/), [Rust](https://www.rust-lang.org/), and [ReactJS](https://react.dev/).",
+      "category": "Programming",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/yaak-logo.png",
+      "image_ref": "lscr.io/linuxserver/yaak",
+      "monthly_pulls": 3465,
+      "stars": 11,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-yaak?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "your_spotify",
+      "description": "your_spotify is a self-hosted application that tracks what you listen and offers you a dashboard to explore statistics about it! It's composed of a web server which polls the Spotify API every now and then and a web application on which you can explore your statistics.",
+      "category": "Music",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/your_spotify-logo.png",
+      "image_ref": "lscr.io/linuxserver/your_spotify",
+      "monthly_pulls": 26593,
+      "stars": 51,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-your_spotify?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "zen",
+      "description": "[Zen Browser] is a free and open-source fork of Mozilla Firefox with a focus on privacy, customizability and design.",
+      "category": "Web Browser",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/zen-logo.png",
+      "image_ref": "lscr.io/linuxserver/zen",
+      "monthly_pulls": 2814,
+      "stars": 6,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-zen?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "znc",
+      "description": "znc is an IRC network bouncer or BNC. It can detach the client from the actual IRC server, and also from selected channels. Multiple clients from different locations can connect to a single ZNC account simultaneously and therefore appear under the same nickname on IRC.",
+      "category": "IRC",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/znc-logo.png",
+      "image_ref": "lscr.io/linuxserver/znc",
+      "monthly_pulls": 17191,
+      "stars": 34,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-znc?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": false,
+      "verified": false
+    },
+    {
+      "name": "zotero",
+      "description": "[Zotero] is a free, easy-to-use tool to help you collect, organize, annotate, cite, and share research.",
+      "category": "Documents",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/zotero-icon.png",
+      "image_ref": "lscr.io/linuxserver/zotero",
+      "monthly_pulls": 4454,
+      "stars": 159,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://github.com/linuxserver/docker-zotero?tab=readme-ov-file#application-setup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": false
+    }
+  ]
+}

--- a/docs/reference/catalog-index-schema.md
+++ b/docs/reference/catalog-index-schema.md
@@ -1,0 +1,78 @@
+# Catalog index schema
+
+Provider index files live at `docs/data/catalog/<provider>.json`. They are
+thin, refreshable metadata: the index describes what an upstream provider
+publishes and where to fetch runtime configuration at deploy time. It does
+**not** contain Kubernetes manifests, vendored compose files, or deployment
+logic.
+
+## File format
+
+```json
+{
+  "provider": "linuxserver",
+  "generated_at": "2026-07-24T23:15:00Z",
+  "source_api": "https://api.linuxserver.io/api/v1/images?include_config=true",
+  "apps": [
+    {
+      "name": "adguardhome-sync",
+      "description": "Synchronize AdGuardHome config to replica instances.",
+      "category": "Network,DNS",
+      "logo_url": "https://raw.githubusercontent.com/linuxserver/docker-templates/...",
+      "image_ref": "lscr.io/linuxserver/adguardhome-sync",
+      "monthly_pulls": 100951,
+      "stars": 65,
+      "architectures": ["x86_64", "arm64"],
+      "config_pointer": "https://github.com/linuxserver/docker-adguardhome-sync?tab=readme-ov-file#application-setup",
+      "readonly_supported": true,
+      "nonroot_supported": true,
+      "verified": false
+    }
+  ]
+}
+```
+
+## Fields
+
+Top level:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider` | string | Short provider identifier, matches the file base name. |
+| `generated_at` | string | ISO-8601 UTC timestamp when the index was generated. |
+| `source_api` | string | Upstream API endpoint that produced the index. |
+| `apps` | array | Provider applications, sorted deterministically by `name`. |
+
+Per-app object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Canonical application name. |
+| `description` | string | Short human-readable description. |
+| `category` | string | Provider category label; may be a comma-separated list. |
+| `logo_url` | string or null | URL to a provider-hosted logo or icon. |
+| `image_ref` | string | Canonical OCI image reference, without tag. |
+| `monthly_pulls` | integer or null | Estimated monthly pull count, if published. |
+| `stars` | integer or null | Upstream star/favorite count, if published. |
+| `architectures` | array of strings | Supported CPU architectures. |
+| `config_pointer` | string or null | Upstream URL to fetch configuration from at deploy time. For linuxserver.io this is the `application_setup` README anchor. |
+| `readonly_supported` | boolean | Whether the image supports a read-only rootfs. |
+| `nonroot_supported` | boolean | Whether the image supports running as a non-root user. |
+| `verified` | boolean | Provider verification/trusted badge. Defaults to `false` when the provider does not expose this concept. |
+
+## Provider tiers
+
+The schema is provider-agnostic, but not every provider exposes the same
+richness:
+
+* **linuxserver.io** is the reference rich-API tier. All fields above are
+  populated from `https://api.linuxserver.io/api/v1/images?include_config=true`.
+* Future providers such as NVIDIA NGC, AMD, or DockerHub may leave many fields
+  `null` or `false` and only populate `name`, `description`, `image_ref`, and
+  `config_pointer`.
+
+## Refresh
+
+The `linuxserver.json` index is refreshed weekly by the
+`catalog-lsio-poller` CronWorkflow in `manifests/catalog-lsio-poller.yaml`.
+The poller opens a pull request when the upstream catalog changes.

--- a/manifests/catalog-lsio-poller.yaml
+++ b/manifests/catalog-lsio-poller.yaml
@@ -1,0 +1,85 @@
+# CronWorkflow: refresh the linuxserver.io catalog index weekly.
+# Fetches the upstream images API, regenerates docs/data/catalog/linuxserver.json,
+# and opens a PR when the index changes.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: catalog-lsio-poller
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: catalog-lsio-poller
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  suspend: false
+  schedules:
+    - "0 6 * * 1"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  workflowSpec:
+    serviceAccountName: argo
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterSuccess: 3600
+      secondsAfterFailure: 86400
+    entrypoint: poll-and-pr
+    templates:
+      - name: poll-and-pr
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: bluefin-test-suite
+            bluefin.io/step: catalog-lsio-poller
+        script:
+          image: ghcr.io/projectbluefin/lab-runner:latest
+          command: [bash]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-token
+                  key: token
+          source: |
+            set -euo pipefail
+
+            REPO="projectbluefin/lab"
+            CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+            WORK_DIR="/tmp/lab-catalog"
+            BRANCH="bot/catalog-lsio-$(date -u +%Y%m%d-%H%M%S)"
+            NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+            rm -rf "${WORK_DIR}"
+            git clone --depth 1 "${CLONE_URL}" "${WORK_DIR}"
+            cd "${WORK_DIR}"
+
+            python3 scripts/collect_lsio_catalog.py
+
+            if git diff --quiet -- docs/data/catalog/linuxserver.json; then
+              echo "No catalog changes — skipping PR"
+              exit 0
+            fi
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout -b "${BRANCH}"
+            git add docs/data/catalog/linuxserver.json
+            git commit -m "chore: refresh linuxserver.io catalog index (${NOW})" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+            git push origin "${BRANCH}"
+
+            # gh uses GH_TOKEN when present.
+            gh pr create \
+              --repo "${REPO}" \
+              --title "chore: refresh linuxserver.io catalog index" \
+              --body "Weekly refresh of docs/data/catalog/linuxserver.json from ${NOW}." \
+              --base main \
+              --head "${BRANCH}" \
+              --label "chore"
+
+            echo "Opened PR for ${BRANCH}"

--- a/manifests/catalog-lsio-poller.yaml
+++ b/manifests/catalog-lsio-poller.yaml
@@ -79,7 +79,6 @@ spec:
               --title "chore: refresh linuxserver.io catalog index" \
               --body "Weekly refresh of docs/data/catalog/linuxserver.json from ${NOW}." \
               --base main \
-              --head "${BRANCH}" \
-              --label "chore"
+              --head "${BRANCH}"
 
             echo "Opened PR for ${BRANCH}"

--- a/scripts/collect_lsio_catalog.py
+++ b/scripts/collect_lsio_catalog.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Refresh the linuxserver.io catalog index.
+
+Fetches https://api.linuxserver.io/api/v1/images?include_config=true,
+maps the rich API response to the provider-agnostic catalog index schema
+defined in docs/reference/catalog-index-schema.md, and writes
+docs/data/catalog/linuxserver.json sorted by application name.
+
+Run locally:
+    python3 scripts/collect_lsio_catalog.py
+
+Dry-run (no files written):
+    python3 scripts/collect_lsio_catalog.py --dry-run
+"""
+
+import argparse
+import datetime
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API_URL = "https://api.linuxserver.io/api/v1/images?include_config=true"
+OUT_PATH = Path("docs/data/catalog/linuxserver.json")
+PROVIDER = "linuxserver"
+IMAGE_PREFIX = "lscr.io/linuxserver"
+
+
+def now_iso():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def fetch_json(url):
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def as_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_architectures(image):
+    arches = image.get("architectures") or []
+    names = [a.get("arch") for a in arches if a.get("arch")]
+    # De-duplicate while preserving order.
+    seen = set()
+    result = []
+    for name in names:
+        if name not in seen:
+            seen.add(name)
+            result.append(name)
+    return result
+
+
+def config_pointer(image):
+    """Return the upstream URL consumers should fetch for deploy-time config."""
+    config = image.get("config") or {}
+    pointer = config.get("application_setup")
+    if pointer:
+        return pointer
+    pointer = image.get("project_url")
+    if pointer:
+        return pointer
+    return image.get("github_url")
+
+
+def map_image(image):
+    config = image.get("config") or {}
+    return {
+        "name": image.get("name"),
+        "description": image.get("description"),
+        "category": image.get("category"),
+        "logo_url": image.get("project_logo"),
+        "image_ref": f"{IMAGE_PREFIX}/{image.get('name')}" if image.get("name") else None,
+        "monthly_pulls": as_int(image.get("monthly_pulls")),
+        "stars": as_int(image.get("stars")),
+        "architectures": extract_architectures(image),
+        "config_pointer": config_pointer(image),
+        "readonly_supported": bool(config.get("readonly_supported")),
+        "nonroot_supported": bool(config.get("nonroot_supported")),
+        "verified": False,
+    }
+
+
+def build_index(data):
+    repositories = (data.get("data") or {}).get("repositories") or {}
+    images = repositories.get("linuxserver") or []
+    apps = []
+    for image in images:
+        if not image.get("name"):
+            continue
+        apps.append(map_image(image))
+    apps.sort(key=lambda a: a["name"])
+    return {
+        "provider": PROVIDER,
+        "generated_at": now_iso(),
+        "source_api": API_URL,
+        "apps": apps,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Refresh the linuxserver.io catalog index.")
+    parser.add_argument("--dry-run", action="store_true", help="Print summary but do not write the index file.")
+    args = parser.parse_args()
+
+    try:
+        data = fetch_json(API_URL)
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR: HTTP {exc.code} from {API_URL}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"ERROR: failed to reach {API_URL}: {exc.reason}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON from {API_URL}: {exc}", file=sys.stderr)
+        return 1
+
+    index = build_index(data)
+    apps = index["apps"]
+
+    if args.dry_run:
+        print(f"provider: {index['provider']}")
+        print(f"generated_at: {index['generated_at']}")
+        print(f"source_api: {index['source_api']}")
+        print(f"apps: {len(apps)}")
+        return 0
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(index, indent=2, ensure_ascii=False) + "\n")
+    print(f"catalog-lsio: wrote {len(apps)} apps to {OUT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
First slice of the transparent registry catalog (HIGH PRIORITY follow-on): thin index only — metadata + pointers, no manifests, no vendored compose files (locked anti-goal).

- docs/reference/catalog-index-schema.md: provider-agnostic index schema for docs/data/catalog/<provider>.json; LSIO is the rich-API tier
- scripts/collect_lsio_catalog.py: stdlib-only poller against api.linuxserver.io/api/v1/images?include_config=true, deterministic output, --dry-run
- manifests/catalog-lsio-poller.yaml: weekly CronWorkflow (argo ns, resources per quota, lab-runner image, github-token secret) that regenerates the index and opens a PR on change
- docs/data/catalog/linuxserver.json: live-generated index, 200 apps — schema proven against real data

just lint passes. Deploy-time install workflow (translate-at-install, kompose path) is the next slice.