### PR TITLE
feat(console): CRD surface RBAC + install-kubestellar git-ref parameter

### DIFF
--- a/argo/bootstrap/install-kubestellar.yaml
+++ b/argo/bootstrap/install-kubestellar.yaml
@@ -6,8 +6,16 @@ metadata:
 spec:
   entrypoint: install
   serviceAccountName: argo
+  arguments:
+    parameters:
+    - name: git-ref
+      value: main
   templates:
   - name: install
+    inputs:
+      parameters:
+      - name: git-ref
+        value: "{{workflow.parameters.git-ref}}"
     script:
       command:
       - bash
@@ -21,9 +29,10 @@ spec:
           memory: 512Mi
       source: |
         set -euo pipefail
-        echo "-> Installing KubeStellar via ArgoCD Applications (ADR-0003)..."
-        kubectl apply -f https://raw.githubusercontent.com/projectbluefin/lab/main/argocd/kubestellar-postgres-app.yaml
-        kubectl apply -f https://raw.githubusercontent.com/projectbluefin/lab/main/argocd/kubestellar-app.yaml
+        REF="{{inputs.parameters.git-ref}}"
+        echo "-> Installing KubeStellar via ArgoCD Applications (ADR-0003, ref: $REF)..."
+        kubectl apply -f "https://raw.githubusercontent.com/projectbluefin/lab/${REF}/argocd/kubestellar-postgres-app.yaml"
+        kubectl apply -f "https://raw.githubusercontent.com/projectbluefin/lab/${REF}/argocd/kubestellar-app.yaml"
         echo "-> Waiting for ArgoCD to sync the core-chart..."
         kubectl -n argocd wait application/kubestellar \
           --for=jsonpath='{.status.health.status}'=Healthy --timeout=900s

--- a/manifests/kubestellar-console-crd-read.yaml
+++ b/manifests/kubestellar-console-crd-read.yaml
@@ -1,0 +1,63 @@
+# Extends the KubeStellar Console ServiceAccount beyond the chart's core
+# read-only role so the lab's control surfaces render (ADR-0003 dual-mode):
+# - read on Argo, KubeVirt, KubeStellar, and OCM CRDs (status views)
+# - imperative verbs only where the plan grants them: KubeVirt VM
+#   start/stop (patch virtualmachines) and Argo Workflow resubmit
+#   (create workflows). Everything declarative stays GitOps via PRs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubestellar-console-lab-surfaces
+  labels:
+    app.kubernetes.io/part-of: lab
+rules:
+  - apiGroups: [argoproj.io]
+    resources:
+      - applications
+      - applicationsets
+      - workflows
+      - workflowtemplates
+      - cronworkflows
+      - rollouts
+    verbs: [get, list, watch]
+  - apiGroups: [argoproj.io]
+    resources: [workflows]
+    verbs: [create]
+  - apiGroups: [kubevirt.io]
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs: [get, list, watch]
+  - apiGroups: [kubevirt.io]
+    resources: [virtualmachines]
+    verbs: [patch, update]
+  - apiGroups: [subresources.kubevirt.io]
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+    verbs: [update]
+  - apiGroups: [control.kubestellar.io]
+    resources: ["*"]
+    verbs: [get, list, watch]
+  - apiGroups: [cluster.open-cluster-management.io]
+    resources: [managedclusters]
+    verbs: [get, list, watch]
+  - apiGroups: [tenancy.kflex.kubestellar.org]
+    resources: [controlplanes]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubestellar-console-lab-surfaces
+  labels:
+    app.kubernetes.io/part-of: lab
+subjects:
+  - kind: ServiceAccount
+    name: kubestellar-console
+    namespace: kubestellar-console
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubestellar-console-lab-surfaces


### PR DESCRIPTION
- manifests/kubestellar-console-crd-read.yaml: the Console chart's SA
  only reads core resources; this extension role makes the lab's control
  surfaces render — read on Argo/KubeVirt/KubeStellar/OCM CRDs, plus the
  plan's imperative verbs only: VM start/stop/restart (kubevirt patch +
  subresources) and workflow resubmit (workflows create). Declarative
  changes stay GitOps.
- install-kubestellar: git-ref parameter (default main) instead of
  hardcoded main raw URLs — review finding: branch-testable, reproducible
  installs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
