### PR TITLE
fix: catalog poller PR creation via REST API and timestamp-only diff skip

### DIFF
--- a/manifests/catalog-lsio-poller.yaml
+++ b/manifests/catalog-lsio-poller.yaml
@@ -61,7 +61,8 @@ spec:
 
             python3 scripts/collect_lsio_catalog.py
 
-            if git diff --quiet -- docs/data/catalog/linuxserver.json; then
+            # Ignore diffs that only touch the generated_at timestamp.
+            if git diff --quiet -I '"generated_at"' -- docs/data/catalog/linuxserver.json; then
               echo "No catalog changes — skipping PR"
               exit 0
             fi
@@ -73,12 +74,12 @@ spec:
             git commit -m "chore: refresh linuxserver.io catalog index (${NOW})" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
             git push origin "${BRANCH}"
 
-            # gh uses GH_TOKEN when present.
-            gh pr create \
-              --repo "${REPO}" \
-              --title "chore: refresh linuxserver.io catalog index" \
-              --body "Weekly refresh of docs/data/catalog/linuxserver.json from ${NOW}." \
-              --base main \
-              --head "${BRANCH}"
+            # lab-runner has no gh CLI — create the PR via the REST API.
+            PR_URL=$(curl -sf -X POST \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/pulls" \
+              -d "{\"title\":\"chore: refresh linuxserver.io catalog index\",\"body\":\"Weekly refresh of docs/data/catalog/linuxserver.json from ${NOW}.\",\"base\":\"main\",\"head\":\"${BRANCH}\"}" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["html_url"])')
 
-            echo "Opened PR for ${BRANCH}"
+            echo "Opened PR: ${PR_URL}"


### PR DESCRIPTION
Live test-fire (`argo submit --from cronworkflow/catalog-lsio-poller`) exposed two bugs:

1. **gh missing**: lab-runner has no `gh` CLI — the workflow pushed its branch then died with exit 127. PR creation now uses a curl POST to the GitHub REST API.
2. **Timestamp-only diffs**: `generated_at` changes every run, so the poller would open a no-op PR weekly. Diff check now uses `git diff -I '"generated_at"'`.

Stray branch from the failed run (`bot/catalog-lsio-20260725-034215`) has been deleted.

Lab evidence: workflow `catalog-lsio-poller-dbrdf` logs show the 200-app index regenerating correctly before the `gh: command not found` failure.