### PR TITLE
feat(catalog): add deploy-time install WorkflowTemplate for LSIO apps

### DIFF
--- a/argo/workflow-templates/catalog-install-lsio.yaml
+++ b/argo/workflow-templates/catalog-install-lsio.yaml
@@ -1,0 +1,205 @@
+# WorkflowTemplate: install an app from the linuxserver.io catalog.
+#
+# Fetches the app's upstream config at install time from the LSIO images API,
+# renders Kubernetes manifests via scripts/catalog_install_lsio.py, and either
+# commits them to git and opens a PR (mode=gitops, default) or applies them
+# immediately and captures them in git afterwards (mode=imperative).
+#
+# Lab conventions applied by the translator:
+#   * local-path storage class for PVCs
+#   * PUID/PGID env vars + securityContext
+#   * bare docker.io image names so the zot-docker mirror resolves them
+#   * ClusterIP Service for in-cluster reachability
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: catalog-install-lsio
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: catalog-install-lsio
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  serviceAccountName: argo
+  activeDeadlineSeconds: 1800
+  podGC:
+    strategy: OnWorkflowCompletion
+  ttlStrategy:
+    secondsAfterSuccess: 3600
+    secondsAfterFailure: 86400
+  entrypoint: install
+
+  arguments:
+    parameters:
+      - name: app
+      - name: mode
+        value: "gitops"
+      - name: namespace
+        value: ""
+      - name: image-tag
+        value: "latest"
+      - name: base-branch
+        value: "main"
+
+  templates:
+    - name: install
+      dag:
+        tasks:
+          - name: render-and-apply
+            template: render-and-apply
+          - name: publish-git
+            depends: "render-and-apply.Succeeded"
+            template: publish-git
+
+    - name: render-and-apply
+      inputs:
+        parameters:
+          - name: app
+            value: "{{workflow.parameters.app}}"
+          - name: mode
+            value: "{{workflow.parameters.mode}}"
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: image-tag
+            value: "{{workflow.parameters.image-tag}}"
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: bluefin-test-suite
+          bluefin.io/step: catalog-install-lsio-render
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 100Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+            ephemeral-storage: 1Gi
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+                optional: true
+        source: |
+          set -euo pipefail
+
+          APP="{{inputs.parameters.app}}"
+          MODE="{{inputs.parameters.mode}}"
+          NS_PARAM="{{inputs.parameters.namespace}}"
+          IMAGE_TAG="{{inputs.parameters.image-tag}}"
+          NAMESPACE="${NS_PARAM:-catalog-${APP}}"
+          RENDER_DIR="/tmp/rendered/${APP}"
+
+          rm -rf "${RENDER_DIR}" /tmp/lab-code
+          mkdir -p "${RENDER_DIR}"
+
+          # Fetch the translator from the repo (public clone, token optional).
+          CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git"
+          if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+            CLONE_URL="https://github.com/projectbluefin/lab.git"
+          fi
+          git clone --depth 1 --branch main "${CLONE_URL}" /tmp/lab-code
+
+          echo "Rendering manifests for ${APP} (namespace=${NAMESPACE}, mode=${MODE})" >&2
+          python3 /tmp/lab-code/scripts/catalog_install_lsio.py "${APP}" \
+            --namespace "${NAMESPACE}" \
+            --image-tag "${IMAGE_TAG}" \
+            --output-dir "${RENDER_DIR}"
+
+          echo "Rendered manifests:" >&2
+          cat "${RENDER_DIR}/manifest.yaml" >&2
+
+          if [[ "${MODE}" == "imperative" ]]; then
+            echo "Applying manifests imperatively" >&2
+            kubectl apply -f "${RENDER_DIR}/manifest.yaml"
+            kubectl rollout status "deployment/${APP}" -n "${NAMESPACE}" --timeout=300s >&2 || true
+          fi
+
+          # Pass the render directory forward as an artifact path convention.
+          echo "${RENDER_DIR}" > /tmp/render-dir
+      outputs:
+        parameters:
+          - name: render-dir
+            valueFrom:
+              path: /tmp/render-dir
+
+    - name: publish-git
+      inputs:
+        parameters:
+          - name: app
+            value: "{{workflow.parameters.app}}"
+          - name: mode
+            value: "{{workflow.parameters.mode}}"
+          - name: base-branch
+            value: "{{workflow.parameters.base-branch}}"
+          - name: render-dir
+            value: "{{tasks.render-and-apply.outputs.parameters.render-dir}}"
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: bluefin-test-suite
+          bluefin.io/step: catalog-install-lsio-publish
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 100Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+            ephemeral-storage: 1Gi
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+        source: |
+          set -euo pipefail
+
+          APP="{{inputs.parameters.app}}"
+          MODE="{{inputs.parameters.mode}}"
+          BASE="{{inputs.parameters.base-branch}}"
+          RENDER_DIR="{{inputs.parameters.render-dir}}"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          BRANCH="bot/catalog-install-${APP}-$(date -u +%Y%m%d-%H%M%S)"
+
+          REPO="projectbluefin/lab"
+          CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+          WORK_DIR="/tmp/lab-catalog-install"
+
+          rm -rf "${WORK_DIR}"
+          git clone --depth 1 --branch "${BASE}" "${CLONE_URL}" "${WORK_DIR}"
+          cd "${WORK_DIR}"
+
+          mkdir -p "manifests/catalog-apps/${APP}"
+          cp "${RENDER_DIR}/manifest.yaml" "manifests/catalog-apps/${APP}/manifest.yaml"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add "manifests/catalog-apps/${APP}/manifest.yaml"
+          git commit -m "chore(catalog): install ${APP} (${NOW})" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          git push origin "${BRANCH}"
+
+          if [[ "${MODE}" == "gitops" ]]; then
+            echo "Opening pull request for ${BRANCH}" >&2
+            PR_BODY="Catalog install for ${APP} rendered at ${NOW}."
+            python3 -c "import json; print(json.dumps({'title':'chore(catalog): install ${APP}','body':'${PR_BODY}','head':'${BRANCH}','base':'${BASE}'}))" > /tmp/pr-payload.json
+            PR_RESPONSE=$(curl -sf -X POST \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${REPO}/pulls" \
+              -d @/tmp/pr-payload.json)
+            PR_NUM=$(echo "${PR_RESPONSE}" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("number", "unknown"))')
+            echo "Opened PR #${PR_NUM}"
+          else
+            echo "Imperative mode: pushed capture branch ${BRANCH} (no PR opened)" >&2
+          fi

--- a/scripts/catalog_install_lsio.py
+++ b/scripts/catalog_install_lsio.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Deploy-time translator from linuxserver.io catalog config to Kubernetes manifests.
+
+Reads the app entry from the linuxserver.io images API (or a local catalog
+index), applies lab conventions, and writes rendered manifests to a directory.
+
+Lab conventions applied:
+  * Storage class is local-path; PVCs are created on node data disks.
+  * Image references use the bare docker.io form (linuxserver/<app>:latest)
+    so the cluster's zot-docker mirror resolves them.
+  * PUID/PGID become both env vars and a securityContext (fsGroup/runAsGroup;
+    runAsUser/runAsNonRoot only when the image advertises non-root support).
+  * Optional ports and volumes are included by default; the installer favours
+    a working out-of-the-box config over minimalism.
+  * External ingress is deferred to Gateway API (ADR-0004); a ClusterIP
+    Service is emitted for in-cluster reachability.
+
+Usage:
+    python3 scripts/catalog_install_lsio.py jellyfin
+    python3 scripts/catalog_install_lsio.py jellyfin --mode imperative --namespace media
+    python3 scripts/catalog_install_lsio.py sonarr --catalog-path docs/data/catalog/linuxserver.json
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+API_URL = "https://api.linuxserver.io/api/v1/images?include_config=true"
+DEFAULT_STORAGE_CLASS = "local-path"
+IMAGE_PREFIX = "linuxserver"
+
+# Path-based heuristic for PVC size. These are starting sizes; operators can
+# expand the PVCs after install.
+SIZE_HINTS = [
+    ("/transcode", "50Gi"),
+    ("/config", "5Gi"),
+    ("media", "100Gi"),
+    ("movies", "100Gi"),
+    ("tv", "100Gi"),
+    ("downloads", "100Gi"),
+    ("data", "100Gi"),
+]
+DEFAULT_SIZE = "1Gi"
+
+
+def load_catalog(path=None):
+    """Load catalog JSON from a local file or the LSIO API."""
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    req = urllib.request.Request(API_URL, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def find_app(catalog, name):
+    """Return the catalog entry for ``name`` or raise ValueError.
+
+    Accepts both the upstream API shape (data.repositories.linuxserver)
+    and the normalized index shape (apps).
+    """
+    repositories = (catalog.get("data") or {}).get("repositories") or {}
+    images = repositories.get("linuxserver") or []
+    if not images and "apps" in catalog:
+        images = catalog["apps"]
+    for image in images:
+        if image.get("name") == name:
+            return image
+    raise ValueError(f"app '{name}' not found in linuxserver.io catalog")
+
+
+def pvc_name(app_name, mount_path):
+    """Derive a stable PVC name from the app name and mount path."""
+    suffix = mount_path.strip("/").replace("/", "-")
+    suffix = re.sub(r"[^a-z0-9-]+", "-", suffix.lower()).strip("-")
+    return f"{app_name}-{suffix}" if suffix else app_name
+
+
+def pvc_size(mount_path):
+    """Return a heuristic PVC size for ``mount_path``."""
+    lowered = mount_path.lower()
+    for hint, size in SIZE_HINTS:
+        if hint in lowered:
+            return size
+    return DEFAULT_SIZE
+
+
+def parse_port(port_value):
+    """Parse an LSIO port value like '8096', '8096/tcp', or '7359/udp'."""
+    text = str(port_value)
+    if "/" in text:
+        num, proto = text.split("/", 1)
+    else:
+        num, proto = text, "tcp"
+    try:
+        return int(num), proto.lower()
+    except ValueError:
+        return None, None
+
+
+def env_vars_from_config(config):
+    """Render k8s env list from LSIO config.env_vars."""
+    result = []
+    for ev in config.get("env_vars") or []:
+        name = ev.get("name")
+        if not name:
+            continue
+        entry = {"name": name, "value": str(ev.get("value", ""))}
+        result.append(entry)
+    return result
+
+
+def security_context_from_config(config):
+    """Build a pod-level securityContext from PUID/PGID/flags."""
+    env_map = {ev.get("name"): ev.get("value") for ev in config.get("env_vars") or []}
+    puid = env_map.get("PUID")
+    pgid = env_map.get("PGID")
+    nonroot = config.get("nonroot_supported", False)
+    readonly = config.get("readonly_supported", False)
+
+    ctx = {}
+    if pgid is not None:
+        try:
+            ctx["fsGroup"] = int(pgid)
+        except ValueError:
+            pass
+    if nonroot:
+        if puid is not None:
+            try:
+                ctx["runAsUser"] = int(puid)
+            except ValueError:
+                pass
+        if pgid is not None:
+            try:
+                ctx["runAsGroup"] = int(pgid)
+            except ValueError:
+                pass
+        ctx["runAsNonRoot"] = True
+    if readonly:
+        ctx["readOnlyRootFilesystem"] = True
+    return ctx if ctx else None
+
+
+def render_volumes(app_name, volumes):
+    """Return (pvcs, volume_mounts, volumes) for the Deployment."""
+    pvcs = []
+    mounts = []
+    vols = []
+    seen = set()
+    for vol in volumes or []:
+        path = vol.get("path")
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        name = pvc_name(app_name, path)
+        pvcs.append({
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": name,
+                "labels": {
+                    "app": app_name,
+                    "app.kubernetes.io/part-of": "catalog-apps",
+                    "bluefin.io/catalog-provider": "linuxserver",
+                },
+            },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": DEFAULT_STORAGE_CLASS,
+                "resources": {"requests": {"storage": pvc_size(path)}},
+            },
+        })
+        mounts.append({"name": name, "mountPath": path})
+        vols.append({"name": name, "persistentVolumeClaim": {"claimName": name}})
+    return pvcs, mounts, vols
+
+
+def render_ports(ports):
+    """Return (container_ports, service_ports) from LSIO config.ports."""
+    container_ports = []
+    service_ports = []
+    seen = set()
+    for p in ports or []:
+        internal = p.get("internal") or p.get("external")
+        external = p.get("external") or p.get("internal")
+        port_num, proto = parse_port(internal)
+        ext_num, _ = parse_port(external)
+        if port_num is None:
+            continue
+        key = (port_num, proto)
+        if key in seen:
+            continue
+        seen.add(key)
+        name = f"{proto}-{port_num}"
+        container_ports.append({
+            "name": name,
+            "containerPort": port_num,
+            "protocol": proto.upper(),
+        })
+        service_ports.append({
+            "name": name,
+            "port": ext_num if ext_num is not None else port_num,
+            "targetPort": port_num,
+            "protocol": proto.upper(),
+        })
+    return container_ports, service_ports
+
+
+def render_manifests(app_name, entry, namespace, image_tag="latest"):
+    """Render the full manifest resource list for ``app_name``."""
+    config = entry.get("config") or {}
+    envs = env_vars_from_config(config)
+    pvcs, mounts, vols = render_volumes(app_name, config.get("volumes"))
+    container_ports, service_ports = render_ports(config.get("ports"))
+    sec_ctx = security_context_from_config(config)
+
+    # Use the bare docker.io form so the zot-docker mirror resolves it.
+    image = f"{IMAGE_PREFIX}/{app_name}:{image_tag}"
+
+    namespace_res = {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "name": namespace,
+            "labels": {
+                "app.kubernetes.io/part-of": "catalog-apps",
+                "bluefin.io/catalog-provider": "linuxserver",
+            },
+        },
+    }
+
+    deployment = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": app_name,
+            "namespace": namespace,
+            "labels": {
+                "app": app_name,
+                "app.kubernetes.io/part-of": "catalog-apps",
+                "bluefin.io/catalog-provider": "linuxserver",
+            },
+        },
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": {"app": app_name}},
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "app": app_name,
+                        "app.kubernetes.io/part-of": "catalog-apps",
+                        "bluefin.io/catalog-provider": "linuxserver",
+                    },
+                },
+                "spec": {
+                    "containers": [{
+                        "name": app_name,
+                        "image": image,
+                        "ports": container_ports,
+                        "env": envs,
+                        "volumeMounts": mounts,
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "128Mi",
+                                "ephemeral-storage": "100Mi",
+                            },
+                            "limits": {
+                                "cpu": "1000m",
+                                "memory": "1Gi",
+                                "ephemeral-storage": "1Gi",
+                            },
+                        },
+                    }],
+                    "volumes": vols,
+                },
+            },
+        },
+    }
+    if sec_ctx:
+        deployment["spec"]["template"]["spec"]["securityContext"] = sec_ctx
+
+    service = {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": app_name,
+            "namespace": namespace,
+            "labels": {
+                "app": app_name,
+                "app.kubernetes.io/part-of": "catalog-apps",
+                "bluefin.io/catalog-provider": "linuxserver",
+            },
+        },
+        "spec": {
+            "selector": {"app": app_name},
+            "type": "ClusterIP",
+            "ports": service_ports,
+        },
+    }
+
+    return [namespace_res] + pvcs + [deployment, service]
+
+
+# ── Minimal deterministic YAML emitter (stdlib only) ─────────────────────────
+
+
+def _yaml_scalar(value):
+    """Return a YAML scalar representation of ``value``."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    text = str(value)
+    # Quote strings that look like they could be misinterpreted.
+    if text in ("true", "false", "null", "yes", "no", "on", "off"):
+        return f'"{text}"'
+    if re.match(r"^[-]?\d+(\.\d+)?$", text):
+        return f'"{text}"'
+    if (":" in text or text.startswith("{") or text.startswith("[") or
+            text.startswith("-") or text.startswith("?") or text.startswith("&") or
+            "#" in text or text.strip() != text or "\n" in text or
+            text in ("", "~") or text.lower() in ("null", "~")):
+        return json.dumps(text)
+    return text
+
+
+def _yaml_dump_resource(resource, indent=0):
+    """Dump a single resource dict/list to YAML lines."""
+    lines = []
+    prefix = "  " * indent
+    if isinstance(resource, dict):
+        for key, value in resource.items():
+            if value is None:
+                lines.append(f"{prefix}{key}: null")
+            elif isinstance(value, (dict, list)):
+                if value:
+                    lines.append(f"{prefix}{key}:")
+                    lines.extend(_yaml_dump_resource(value, indent + 1))
+                else:
+                    lines.append(f"{prefix}{key}: []" if isinstance(value, list) else f"{prefix}{key}: {{}}")
+            else:
+                lines.append(f"{prefix}{key}: {_yaml_scalar(value)}")
+    elif isinstance(resource, list):
+        for item in resource:
+            if isinstance(item, dict):
+                if not item:
+                    lines.append(f"{prefix}- {{}}")
+                else:
+                    first = True
+                    for key, value in item.items():
+                        if first:
+                            if isinstance(value, (dict, list)):
+                                lines.append(f"{prefix}- {key}:")
+                                lines.extend(_yaml_dump_resource(value, indent + 2))
+                            else:
+                                lines.append(f"{prefix}- {key}: {_yaml_scalar(value)}")
+                            first = False
+                        else:
+                            if isinstance(value, (dict, list)):
+                                lines.append(f"{prefix}  {key}:")
+                                lines.extend(_yaml_dump_resource(value, indent + 2))
+                            else:
+                                lines.append(f"{prefix}  {key}: {_yaml_scalar(value)}")
+            else:
+                lines.append(f"{prefix}- {_yaml_scalar(item)}")
+    return lines
+
+
+def to_yaml(resources):
+    """Dump a list of resources as a multi-document YAML string."""
+    docs = []
+    for resource in resources:
+        docs.append("---")
+        docs.extend(_yaml_dump_resource(resource))
+    if docs:
+        docs.append("")
+    return "\n".join(docs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render linuxserver.io app manifests for Kubernetes.")
+    parser.add_argument("app", help="Application name from the linuxserver.io catalog")
+    parser.add_argument("--mode", choices=["gitops", "imperative"], default="gitops",
+                        help="Install mode (default: gitops)")
+    parser.add_argument("--namespace", default=None, help="Target namespace (default: catalog-<app>)")
+    parser.add_argument("--output-dir", default=None,
+                        help="Directory to write rendered manifests (default: ./manifests/catalog-apps/<app>)")
+    parser.add_argument("--catalog-path", default=None,
+                        help="Local catalog JSON file (default: fetch from LSIO API)")
+    parser.add_argument("--image-tag", default="latest", help="Image tag (default: latest)")
+    parser.add_argument("--storage-class", default=DEFAULT_STORAGE_CLASS,
+                        help=f"Storage class for PVCs (default: {DEFAULT_STORAGE_CLASS})")
+    args = parser.parse_args()
+
+    namespace = args.namespace or f"catalog-{args.app}"
+    output_dir = Path(args.output_dir or f"manifests/catalog-apps/{args.app}")
+
+    catalog = load_catalog(args.catalog_path)
+    entry = find_app(catalog, args.app)
+
+    resources = render_manifests(args.app, entry, namespace, args.image_tag)
+    yaml_text = to_yaml(resources)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / "manifest.yaml"
+    manifest_path.write_text(yaml_text)
+
+    print(f"Rendered {len(resources)} resources to {manifest_path}")
+    if args.mode == "imperative":
+        print("Imperative apply is handled by the caller (kubectl apply -f)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/fixtures/expected-jellyfin/manifest.yaml
+++ b/tests/unit/fixtures/expected-jellyfin/manifest.yaml
@@ -1,0 +1,162 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: catalog-jellyfin
+  labels:
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-config
+  labels:
+    app: jellyfin
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-data-tvshows
+  labels:
+    app: jellyfin
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-data-movies
+  labels:
+    app: jellyfin
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin
+  namespace: catalog-jellyfin
+  labels:
+    app: jellyfin
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jellyfin
+  template:
+    metadata:
+      labels:
+        app: jellyfin
+        app.kubernetes.io/part-of: catalog-apps
+        bluefin.io/catalog-provider: linuxserver
+    spec:
+      containers:
+        - name: jellyfin
+          image: "linuxserver/jellyfin:latest"
+          ports:
+            - name: tcp-8096
+              containerPort: 8096
+              protocol: TCP
+            - name: tcp-8920
+              containerPort: 8920
+              protocol: TCP
+            - name: udp-7359
+              containerPort: 7359
+              protocol: UDP
+            - name: udp-1900
+              containerPort: 1900
+              protocol: UDP
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: Etc/UTC
+            - name: JELLYFIN_PublishedServerUrl
+              value: "http://192.168.0.5"
+          volumeMounts:
+            - name: jellyfin-config
+              mountPath: /config
+            - name: jellyfin-data-tvshows
+              mountPath: /data/tvshows
+            - name: jellyfin-data-movies
+              mountPath: /data/movies
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+              ephemeral-storage: 1Gi
+      volumes:
+        - name: jellyfin-config
+          persistentVolumeClaim:
+            claimName: jellyfin-config
+        - name: jellyfin-data-tvshows
+          persistentVolumeClaim:
+            claimName: jellyfin-data-tvshows
+        - name: jellyfin-data-movies
+          persistentVolumeClaim:
+            claimName: jellyfin-data-movies
+      securityContext:
+        fsGroup: 1000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin
+  namespace: catalog-jellyfin
+  labels:
+    app: jellyfin
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  selector:
+    app: jellyfin
+  type: ClusterIP
+  ports:
+    - name: tcp-8096
+      port: 8096
+      targetPort: 8096
+      protocol: TCP
+    - name: tcp-8920
+      port: 8920
+      targetPort: 8920
+      protocol: TCP
+    - name: udp-7359
+      port: 7359
+      targetPort: 7359
+      protocol: UDP
+    - name: udp-1900
+      port: 1900
+      targetPort: 1900
+      protocol: UDP

--- a/tests/unit/fixtures/expected-sonarr/manifest.yaml
+++ b/tests/unit/fixtures/expected-sonarr/manifest.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: catalog-sonarr
+  labels:
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr-config
+  labels:
+    app: sonarr
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr-tv
+  labels:
+    app: sonarr
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr-downloads
+  labels:
+    app: sonarr
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sonarr
+  namespace: catalog-sonarr
+  labels:
+    app: sonarr
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarr
+  template:
+    metadata:
+      labels:
+        app: sonarr
+        app.kubernetes.io/part-of: catalog-apps
+        bluefin.io/catalog-provider: linuxserver
+    spec:
+      containers:
+        - name: sonarr
+          image: "linuxserver/sonarr:latest"
+          ports:
+            - name: tcp-8989
+              containerPort: 8989
+              protocol: TCP
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: Etc/UTC
+          volumeMounts:
+            - name: sonarr-config
+              mountPath: /config
+            - name: sonarr-tv
+              mountPath: /tv
+            - name: sonarr-downloads
+              mountPath: /downloads
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+              ephemeral-storage: 1Gi
+      volumes:
+        - name: sonarr-config
+          persistentVolumeClaim:
+            claimName: sonarr-config
+        - name: sonarr-tv
+          persistentVolumeClaim:
+            claimName: sonarr-tv
+        - name: sonarr-downloads
+          persistentVolumeClaim:
+            claimName: sonarr-downloads
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sonarr
+  namespace: catalog-sonarr
+  labels:
+    app: sonarr
+    app.kubernetes.io/part-of: catalog-apps
+    bluefin.io/catalog-provider: linuxserver
+spec:
+  selector:
+    app: sonarr
+  type: ClusterIP
+  ports:
+    - name: tcp-8989
+      port: 8989
+      targetPort: 8989
+      protocol: TCP

--- a/tests/unit/fixtures/linuxserver-catalog.json
+++ b/tests/unit/fixtures/linuxserver-catalog.json
@@ -1,0 +1,72 @@
+{
+  "status": "OK",
+  "last_updated": "2026-07-24 21:44:51+00:00",
+  "data": {
+    "repositories": {
+      "linuxserver": [
+        {
+          "name": "jellyfin",
+          "description": "jellyfin is a Free Software Media System that puts you in control of managing and streaming your media.",
+          "category": "Media Servers,Music,Audiobooks",
+          "project_logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/jellyfin-logo.png",
+          "monthly_pulls": 2955411,
+          "stars": 888,
+          "architectures": [
+            {"arch": "x86_64", "tag": "amd64-latest"},
+            {"arch": "arm64", "tag": "arm64v8-latest"}
+          ],
+          "config": {
+            "application_setup": "https://github.com/linuxserver/docker-jellyfin?tab=readme-ov-file#application-setup",
+            "env_vars": [
+              {"name": "PUID", "value": "1000", "desc": "User ID", "optional": false},
+              {"name": "PGID", "value": "1000", "desc": "Group ID", "optional": false},
+              {"name": "TZ", "value": "Etc/UTC", "desc": "Timezone", "optional": false},
+              {"name": "JELLYFIN_PublishedServerUrl", "value": "http://192.168.0.5", "desc": "Set the autodiscovery response domain or IP address.", "optional": true}
+            ],
+            "volumes": [
+              {"path": "/config", "host_path": "/path/to/jellyfin/library", "desc": "Jellyfin data storage location.", "optional": false},
+              {"path": "/data/tvshows", "host_path": "/path/to/tvseries", "desc": "Media goes here.", "optional": false},
+              {"path": "/data/movies", "host_path": "/path/to/movies", "desc": "Media goes here.", "optional": false}
+            ],
+            "ports": [
+              {"external": "8096", "internal": "8096", "desc": "Http webUI.", "optional": false},
+              {"external": "8920", "internal": "8920", "desc": "Optional - Https webUI.", "optional": true},
+              {"external": "7359", "internal": "7359/udp", "desc": "Optional - Allows clients to discover Jellyfin.", "optional": true},
+              {"external": "1900", "internal": "1900/udp", "desc": "Optional - Service discovery used by DNLA and clients.", "optional": true}
+            ]
+          }
+        },
+        {
+          "name": "sonarr",
+          "description": "Sonarr is a PVR for Usenet and BitTorrent users.",
+          "category": "Media Servers",
+          "project_logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/sonarr-logo.png",
+          "monthly_pulls": 1234567,
+          "stars": 500,
+          "architectures": [
+            {"arch": "x86_64", "tag": "amd64-latest"},
+            {"arch": "arm64", "tag": "arm64v8-latest"}
+          ],
+          "config": {
+            "application_setup": "https://github.com/linuxserver/docker-sonarr?tab=readme-ov-file#application-setup",
+            "readonly_supported": true,
+            "nonroot_supported": true,
+            "env_vars": [
+              {"name": "PUID", "value": "1000", "desc": "User ID", "optional": false},
+              {"name": "PGID", "value": "1000", "desc": "Group ID", "optional": false},
+              {"name": "TZ", "value": "Etc/UTC", "desc": "Timezone", "optional": false}
+            ],
+            "volumes": [
+              {"path": "/config", "host_path": "/path/to/sonarr/data", "desc": "Database and sonarr configs", "optional": false},
+              {"path": "/tv", "host_path": "/path/to/tvseries", "desc": "Location of TV library on disk", "optional": true},
+              {"path": "/downloads", "host_path": "/path/to/downloadclient-downloads", "desc": "Location of download managers output directory", "optional": true}
+            ],
+            "ports": [
+              {"external": "8989", "internal": "8989", "desc": "The port for the Sonarr web interface", "optional": false}
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/unit/test_catalog_install_lsio.py
+++ b/tests/unit/test_catalog_install_lsio.py
@@ -1,0 +1,97 @@
+"""Golden-file tests for the linuxserver.io install translator.
+
+The translator maps LSIO config (env_vars, volumes, ports) to Kubernetes
+manifests with lab conventions. These tests pin the output for representative
+apps so refactors stay deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ is at repo root; import the translator directly.
+repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo_root / "scripts"))
+
+import catalog_install_lsio as translator
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CATALOG_FIXTURE = FIXTURES / "linuxserver-catalog.json"
+
+
+def _load_catalog():
+    with open(CATALOG_FIXTURE) as f:
+        return json.load(f)
+
+
+def _expected_yaml(app_name: str) -> str:
+    return (FIXTURES / f"expected-{app_name}" / "manifest.yaml").read_text()
+
+
+class TestCatalogInstallLsio:
+    """Golden-file assertions for jellyfin and sonarr rendering."""
+
+    @pytest.mark.parametrize("app_name", ["jellyfin", "sonarr"])
+    def test_render_matches_golden(self, app_name, tmp_path):
+        catalog = _load_catalog()
+        entry = translator.find_app(catalog, app_name)
+        resources = translator.render_manifests(app_name, entry, f"catalog-{app_name}")
+        rendered = translator.to_yaml(resources)
+
+        assert rendered == _expected_yaml(app_name)
+
+    def test_jellyfin_resources(self):
+        catalog = _load_catalog()
+        entry = translator.find_app(catalog, "jellyfin")
+        resources = translator.render_manifests("jellyfin", entry, "catalog-jellyfin")
+        kinds = [r["kind"] for r in resources]
+
+        assert kinds == ["Namespace", "PersistentVolumeClaim", "PersistentVolumeClaim", "PersistentVolumeClaim", "Deployment", "Service"]
+
+        deployment = resources[4]
+        container = deployment["spec"]["template"]["spec"]["containers"][0]
+        assert container["image"] == "linuxserver/jellyfin:latest"
+        assert len(container["ports"]) == 4
+        assert {p["protocol"] for p in container["ports"]} == {"TCP", "UDP"}
+        assert len(container["volumeMounts"]) == 3
+        assert any(m["mountPath"] == "/config" for m in container["volumeMounts"])
+
+        pvcs = [r for r in resources if r["kind"] == "PersistentVolumeClaim"]
+        sizes = {r["metadata"]["name"]: r["spec"]["resources"]["requests"]["storage"] for r in pvcs}
+        assert sizes["jellyfin-config"] == "5Gi"
+        assert sizes["jellyfin-data-tvshows"] == "100Gi"
+        assert sizes["jellyfin-data-movies"] == "100Gi"
+
+    def test_sonarr_security_context(self):
+        catalog = _load_catalog()
+        entry = translator.find_app(catalog, "sonarr")
+        resources = translator.render_manifests("sonarr", entry, "catalog-sonarr")
+        deployment = [r for r in resources if r["kind"] == "Deployment"][0]
+        ctx = deployment["spec"]["template"]["spec"].get("securityContext")
+
+        assert ctx is not None
+        assert ctx["runAsUser"] == 1000
+        assert ctx["runAsGroup"] == 1000
+        assert ctx["fsGroup"] == 1000
+        assert ctx["runAsNonRoot"] is True
+        assert ctx["readOnlyRootFilesystem"] is True
+
+    def test_pvc_size_heuristic(self):
+        assert translator.pvc_size("/config") == "5Gi"
+        assert translator.pvc_size("/data/movies") == "100Gi"
+        assert translator.pvc_size("/transcode") == "50Gi"
+        assert translator.pvc_size("/etc/something") == "1Gi"
+
+    def test_parse_port(self):
+        assert translator.parse_port("8096") == (8096, "tcp")
+        assert translator.parse_port("7359/udp") == (7359, "udp")
+        assert translator.parse_port("8096/tcp") == (8096, "tcp")
+        assert translator.parse_port("not-a-port") == (None, None)
+
+    def test_pvc_name_sanitizes_path(self):
+        assert translator.pvc_name("jellyfin", "/config") == "jellyfin-config"
+        assert translator.pvc_name("jellyfin", "/data/tvshows") == "jellyfin-data-tvshows"


### PR DESCRIPTION
Deploy-time install WorkflowTemplate for linuxserver.io catalog apps.\n\n## What's included\n- `scripts/catalog_install_lsio.py`: stdlib-only translator from LSIO config to Kubernetes manifests\n- `argo/workflow-templates/catalog-install-lsio.yaml`: WorkflowTemplate with gitops (default) and imperative modes\n- `tests/unit/test_catalog_install_lsio.py`: golden-file tests for jellyfin and sonarr\n\n## Mapping design\n- Fetches upstream config from `api.linuxserver.io/api/v1/images?include_config=true` at install time.\n- Generic LSIO-to-k8s mapping: env_vars, volumes, ports.\n- PVCs use `local-path` storage class with path-based size heuristics.\n- Images emitted as bare `linuxserver/<app>:latest` so the zot-docker mirror resolves them.\n- PUID/PGID become env vars plus a securityContext when the upstream image advertises non-root/readonly support.\n- ClusterIP Service emitted for in-cluster reachability; external ingress deferred to Gateway API (ADR-0004).\n\n## Modes\n- `gitops` (default): renders, commits to `manifests/catalog-apps/<app>/` on `bot/catalog-install-<app>-<ts>`, opens a PR via curl + python3.\n- `imperative`: `kubectl apply` first, then commits the capture branch (no PR opened).\n\n## Validation\n- `just lint` passes.\n- `python3 -m pytest tests/unit/test_catalog_install_lsio.py` passes (7 tests).\n\nDo not enable auto-merge; awaiting review.