### PR TITLE
feat(missions): add Console guided mission for adding a second PC

### DIFF
--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -93,8 +93,11 @@ the hosting cluster — `kubectl auth can-i get bindingpolicies` on ghost
 correctly answers no. The Console reaches wds1 as a registered cluster.
 - **Missions** (`kc-mission-v1`): step sequences with `yaml` (one-click
   apply) and `command` blocks; custom missions are shareable via built-in
-  PR flow. The "add your second PC" onboarding flow is a custom mission —
-  see `node-lifecycle/SKILL.md`.
+  PR flow. The "add your second PC" onboarding flow is committed as
+  [`missions/add-your-second-pc.json`](../../missions/add-your-second-pc.json).
+  The Console v0.3.34 does not read custom missions from a ConfigMap/CRD yet;
+  import it via **Missions > Local Files > Import**. See
+  `node-lifecycle/SKILL.md` for the agent-executable version.
 
 ## Failure modes
 

--- a/docs/skills/node-lifecycle/SKILL.md
+++ b/docs/skills/node-lifecycle/SKILL.md
@@ -112,7 +112,11 @@ memory/ADR). Cross-WEC grid joins via Tailscale CAS mesh.
 
 ## GUI flow
 
-The Console hosts this as a guided mission ("Add a node") wrapping the
-same steps: token display, agent config, verification queries. Keep the
-mission and this skill in sync — the mission is the GUI counterpart, this
-file is the agent-executable truth.
+The Console hosts this as a guided mission ("Add your second PC") wrapping
+the same steps: token display, agent config, verification queries. The
+mission source lives at
+[`missions/add-your-second-pc.json`](../../missions/add-your-second-pc.json)
+in `kc-mission-v1` format. Because the Console v0.3.34 cannot yet load
+custom missions from an in-cluster ConfigMap or CRD, import it via
+**Missions > Local Files > Import**. Keep the mission and this skill in sync
+— the mission is the GUI counterpart; this file is the agent-executable truth.

--- a/docs/skills/node-lifecycle/SKILL.md
+++ b/docs/skills/node-lifecycle/SKILL.md
@@ -37,13 +37,21 @@ metadata:
 ## Node join (shared cluster)
 
 On the server (ghost): get the join token from the k3s server config
-(never commit it). On the new machine running Bluefin Server:
+(never commit it). On the new machine running Bluefin Server, install k3s
+agent as a persistent systemd service:
 
 ```bash
 # On the new node
-sudo k3s agent --server https://<server-lan-ip>:6443 --token <token>
-# or via config file /etc/rancher/k3s/config.yaml + systemctl enable k3s-agent
+curl -sfL https://get.k3s.io | \
+  K3S_URL="https://<server-lan-ip>:6443" \
+  K3S_TOKEN="<token>" \
+  INSTALL_K3S_BIN_DIR="/var/usrlocal/bin" \
+  sh -s -
 ```
+
+This creates the `k3s-agent` systemd unit; it starts automatically and
+rejoins after reboot. Use `/etc/rancher/k3s/config.yaml` plus
+`systemctl enable --now k3s-agent` if you prefer explicit configuration.
 
 Verify from any kubectl:
 

--- a/missions/README.md
+++ b/missions/README.md
@@ -1,0 +1,25 @@
+# KubeStellar Console missions
+
+This directory contains custom `kc-mission-v1` guided missions for the
+KubeStellar Console.
+
+## Loading mechanism (current gap)
+
+The Console v0.3.34 does **not** read custom missions from an in-cluster
+ConfigMap or CRD. It discovers missions from the public
+`kubestellar/console-kb` GitHub repository (`fixes/index.json`) and supports
+local file import through the Console UI. Therefore the mission files in this
+directory are:
+
+- committed to git as the source of truth for the lab,
+- imported into the Console via **Missions > Local Files > Import**, and
+- candidates for upstream contribution to `kubestellar/console-kb` if they
+  should ship by default.
+
+Do not `kubectl apply` these files; they are JSON payloads, not Kubernetes
+manifests.
+
+## Missions
+
+- [`add-your-second-pc.json`](add-your-second-pc.json) — onboard a second PC
+  as either a k3s agent node in the shared cluster or a new WEC.

--- a/missions/add-your-second-pc.json
+++ b/missions/add-your-second-pc.json
@@ -1,0 +1,87 @@
+{
+  "version": "kc-mission-v1",
+  "name": "add-your-second-pc",
+  "title": "Add your second PC",
+  "description": "Expand your Bluefin Server home cluster by adding a second PC. Choose between joining it as a k3s agent node in the same cluster, or registering a separate cluster as a KubeStellar WEC.",
+  "type": "custom",
+  "tags": [
+    "onboarding",
+    "node",
+    "wec",
+    "k3s",
+    "kubestellar",
+    "buildbarn"
+  ],
+  "category": "Operations",
+  "missionClass": "install",
+  "difficulty": "Beginner",
+  "author": "Project Bluefin lab",
+  "authorGithub": "projectbluefin",
+  "prerequisites": [
+    "Bluefin Server image booted on the new PC",
+    "Network reachability between the new PC and ghost (LAN for shared cluster; reachable hub endpoint for WEC)",
+    "kubectl access to the ghost cluster"
+  ],
+  "steps": [
+    {
+      "title": "Prerequisites",
+      "description": "Boot the new PC from the Bluefin Server image. Make sure it can reach ghost. Decide whether this PC should become part of the same k3s cluster (default, one scheduling domain) or remain a separate cluster that joins as a KubeStellar WEC."
+    },
+    {
+      "title": "Choose join mode",
+      "description": "Shared cluster (default): the PC runs k3s agent and shares the ghost control plane. Live migration is possible and there is no extra control-plane overhead. WEC: the PC is its own cluster, reachable by ghost, and KubeStellar federates workloads to it. Use WEC for remote sites or machines that must stay autonomous."
+    },
+    {
+      "title": "Retrieve the k3s agent token",
+      "description": "On the server node (ghost), read the k3s agent token. The token is sensitive — copy it but never commit it to git.",
+      "command": "sudo cat /var/lib/rancher/k3s/server/node-token"
+    },
+    {
+      "title": "Join the shared cluster",
+      "description": "On the new PC, run the k3s agent. Replace <server-lan-ip> with ghost's LAN IP and <token> with the value from the previous step. For a persistent setup, write the values to /etc/rancher/k3s/config.yaml and enable k3s-agent.",
+      "command": "sudo k3s agent --server https://<server-lan-ip>:6443 --token <token>"
+    },
+    {
+      "title": "Retrieve the hub token (WEC path)",
+      "description": "If you chose WEC mode, get an OCM bootstrap token from the hub cluster (ghost). This token lets the new cluster register itself.",
+      "command": "clusteradm get token --use-bootstrap-token"
+    },
+    {
+      "title": "Join as a WEC",
+      "description": "Run this on the new cluster. Replace <token> with the hub token, <hub-endpoint> with a reachable ghost API address, and <wec-name> with a short name for this cluster. In-LAN clusters can use https://<ghost-lan-ip>:6443; remote clusters need the Gateway API TLSRoute or LoadBalancer endpoint configured per ADR-0004.",
+      "command": "clusteradm join --hub-token <token> --hub-apiserver <hub-endpoint> --cluster-name <wec-name> --singleton --wait"
+    },
+    {
+      "title": "Accept the WEC",
+      "description": "Back on the hub cluster, accept the CSR and label the ManagedCluster so lab BindingPolicies can select it by name.",
+      "command": "clusteradm accept --clusters <wec-name> && kubectl label managedcluster <wec-name> name=<wec-name> --overwrite"
+    },
+    {
+      "title": "Verify the join",
+      "description": "Shared cluster: the new node should appear Ready. WEC: the ManagedCluster should report JOINED and AVAILABLE.",
+      "command": "kubectl get nodes -o wide && kubectl get managedclusters -o wide"
+    },
+    {
+      "title": "Label node capabilities (shared cluster)",
+      "description": "If the new node has a data disk that should host the zot pull-through cache, apply the capability label. Add the node's data-disk path to manifests/local-path-config.yaml via a PR so PVCs land on the data disk, not the root disk. Never hostPath onto root disks.",
+      "command": "kubectl label node <new-node> lab.projectbluefin.io/zot-cache-data=true"
+    },
+    {
+      "title": "Enjoy the elastic BuildStream grid",
+      "description": "More nodes mean BuildBarn workers can spread. Run a build pipeline and confirm workers schedule on the new capacity.",
+      "command": "kubectl get pods -n buildbarn -o wide"
+    }
+  ],
+  "troubleshooting": [
+    {
+      "title": "Node stays NotReady",
+      "description": "Check that the new PC can reach the k3s server on TCP 6443 and that the token is correct. Verify firewall rules allow the agent to reach the server.",
+      "command": "kubectl describe node <new-node>"
+    },
+    {
+      "title": "ManagedCluster stuck JOINED empty",
+      "description": "The CSR may not have been accepted. Re-run accept and ensure the name label is set.",
+      "command": "clusteradm accept --clusters <wec-name> && kubectl label managedcluster <wec-name> name=<wec-name> --overwrite"
+    }
+  ]
+}

--- a/missions/add-your-second-pc.json
+++ b/missions/add-your-second-pc.json
@@ -37,9 +37,9 @@
       "command": "sudo cat /var/lib/rancher/k3s/server/node-token"
     },
     {
-      "title": "Join the shared cluster",
-      "description": "On the new PC, run the k3s agent. Replace <server-lan-ip> with ghost's LAN IP and <token> with the value from the previous step. For a persistent setup, write the values to /etc/rancher/k3s/config.yaml and enable k3s-agent.",
-      "command": "sudo k3s agent --server https://<server-lan-ip>:6443 --token <token>"
+      "title": "Install the k3s agent service",
+      "description": "On the new PC, install k3s agent as a persistent systemd unit. On image-based Bluefin Server systems the binary must go under /var/usrlocal/bin. Replace <server-lan-ip> and <token> with the values from the previous step. The service starts automatically on boot; use `sudo systemctl disable k3s-agent` first if you prefer to opt in manually (see docs/reference/agent-cheatsheet.md).",
+      "command": "curl -sfL https://get.k3s.io | K3S_URL=\"https://<server-lan-ip>:6443\" K3S_TOKEN=\"<token>\" INSTALL_K3S_BIN_DIR=\"/var/usrlocal/bin\" sh -s -"
     },
     {
       "title": "Retrieve the hub token (WEC path)",
@@ -62,9 +62,14 @@
       "command": "kubectl get nodes -o wide && kubectl get managedclusters -o wide"
     },
     {
-      "title": "Label node capabilities (shared cluster)",
-      "description": "If the new node has a data disk that should host the zot pull-through cache, apply the capability label. Add the node's data-disk path to manifests/local-path-config.yaml via a PR so PVCs land on the data disk, not the root disk. Never hostPath onto root disks.",
-      "command": "kubectl label node <new-node> lab.projectbluefin.io/zot-cache-data=true"
+      "title": "Prepare storage for the new node (shared cluster)",
+      "description": "The local-path provisioner routes PVCs to node-local data disks via the nodePathMap in manifests/local-path-config.yaml. Before scheduling stateful workloads here, open a PR that adds the new node's data-disk path (e.g. /var/mnt/<node>-data/local-path) to that ConfigMap. Never provision storage on root disks. Do not label the node for zot-cache unless you have manually prepared /var/mnt/<node>-data/zot-cache and intend to host the cache there; the existing zot-cache DaemonSet selects on lab.projectbluefin.io/zot-cache-data=true and will fail if the directory is missing.",
+      "command": "kubectl get configmap local-path-config -n kube-system -o yaml"
+    },
+    {
+      "title": "Verify workloads are scheduling on the new node",
+      "description": "Confirm the scheduler is placing pods on the new capacity. BuildBarn workers and other daemonsets should begin to spread once the node is Ready and any required labels or taints are satisfied.",
+      "command": "kubectl get pods -A -o wide --field-selector spec.nodeName=<new-node>"
     },
     {
       "title": "Enjoy the elastic BuildStream grid",


### PR DESCRIPTION
Add a custom kc-mission-v1 guided mission for onboarding a second PC.

- Covers the default shared-cluster k3s agent join flow.
- Covers the separate-cluster WEC join flow (clusteradm get token / join / accept / label).
- Includes verification (node Ready / ManagedCluster JOINED) and the BuildBarn elastic-build-grid payoff step.
- Documents the Console v0.3.34 loading gap: no in-cluster ConfigMap/CRD loading yet; import via Missions > Local Files > Import.
- Updates node-lifecycle and console-dashboard skills to reference the mission.

Closes gui-node-onboarding mission deliverable for Phase 4 prep.