### PR TITLE
fix(ci): run unit tests when scripts/ changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'tests/**'
+      - 'scripts/**'
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/ci.yml'
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - 'tests/**'
+      - 'scripts/**'
       - 'requirements.txt'
       - 'pyproject.toml'
 


### PR DESCRIPTION
PR #344 merged with unresolved conflict markers in
scripts/catalog_install_lsio.py because the Test Suite Validation
workflow's path filter only watched tests/ — script changes never
triggered the unit tests that import them. Adds scripts/** to both
pull_request and push path filters.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
