### PR TITLE
docs: skill write-back from catalog e2e session

### DIFF
--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -54,6 +54,13 @@ The workflow authoring guidance is split by topic:
 - A pipeline with VMs and no `spec.activeDeadlineSeconds` — a stuck VM holds its semaphore slot forever
 - A pipeline with VMs that adds `spec.synchronization.semaphores` — semaphores are removed; k8s scheduler handles concurrency via virt-launcher memory requests
 - A `steps` or `dag` task calling a sub-template without `arguments:`
+- `{{steps.X.outputs...}}` or `{{tasks.X.outputs...}}` used as an input
+  parameter *default inside a leaf template* — that scope only exists at
+  the steps/dag call site, and unresolved literals reach the shell (live
+  failures: catalog-install-lsio-njq2s, -vhbcb). Pass via call-site
+  `arguments:`. Corollary: each step is its own pod — never pass file
+  paths between steps; pass file *content* via an output parameter
+  (`valueFrom.path`, 256KB cap) or an artifact.
 - A pipeline with no `onExit` handler (VM will leak on failure)
 - Any `script:` template without `resources:` limits
 - Templates in `argo/workflow-templates/` applied with `kubectl apply` (not via git)

--- a/docs/skills/gitops-argocd/SKILL.md
+++ b/docs/skills/gitops-argocd/SKILL.md
@@ -120,6 +120,15 @@ names to track resources. Always use a fixed `name:`.
 
 **Exception — intentional runtime-state ConfigMap contract:** If the Git manifest must define an explicit set of runtime keys (for example, to document a lifecycle-state contract with known empty marker keys), scope an `ignoreDifferences` rule to that one ConfigMap and ignore `/data`, then enable `RespectIgnoreDifferences=true` on the Application. This keeps the key contract in git without ArgoCD patching live runtime values back to placeholders.
 
+**Subdirectories and namespaces:** `testing-lab-infra` runs with
+`directory.recurse: true` (live-patched 2026-07-25; the Application object is
+manually applied, not git-tracked) so nested paths like
+`manifests/catalog-apps/<app>/manifest.yaml` sync. It also sets
+`CreateNamespace=false` — any bundle targeting a new namespace must include
+its own `Namespace` object or the sync fails. Symptom of a missing recurse
+flag: files merge to a subdirectory, app reports Synced/Healthy, but the
+resources silently never appear.
+
 ### 6. Sync status and forced sync
 
 ```bash

--- a/docs/skills/registry-catalog/SKILL.md
+++ b/docs/skills/registry-catalog/SKILL.md
@@ -136,6 +136,18 @@ The install WorkflowTemplate takes a `mode` parameter:
   to files instead.
 - LSIO images must use the bare docker.io form in rendered manifests;
   `lscr.io/...` is not in the registry allowlist and fails CI lint.
+- The manifest travels between workflow steps as a base64 output parameter
+  supplied via *call-site* `arguments:` — `{{steps.render.outputs...}}`
+  inside a leaf template's input defaults never resolves (three live
+  failures before the fix; see argo-workflows skill red flags).
+- Deployed bundles land in `manifests/catalog-apps/<app>/`, which requires
+  `directory.recurse: true` on the `testing-lab-infra` Application and a
+  `Namespace` object in the bundle (`CreateNamespace=false`).
+
+Verified end-to-end 2026-07-25: jellyfin gitops install — workflow
+`catalog-install-lsio-bxt72` rendered/validated/opened PR #348; after merge,
+ArgoCD deployed to `catalog-jellyfin` (3 PVCs Bound on local-path, pod Ready,
+web UI HTTP 200 in-cluster).
 
 ## Commands
 


### PR DESCRIPTION
Durable patterns from live failures and fixes: Argo steps output
parameter scope (call-site arguments only, content not paths across
pods), testing-lab-infra recurse+CreateNamespace=false contract for
manifests/catalog-apps/, and the verified jellyfin gitops e2e evidence.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
