### PR TITLE
feat(catalog): lscr.io mirror and installed-app CVE scans

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,7 +68,7 @@ jobs:
             # skip bare names (no dot or colon = implicit docker.io, handled by zot-docker)
             echo "$registry" | grep -qE '[.:]' || continue
             case "$registry" in
-              ghcr.io|quay.io|registry.fedoraproject.org|registry.k8s.io|cgr.dev|192.168.1.102|192.168.1.102:30500|192.168.1.102:30501|localhost) ;;
+              ghcr.io|quay.io|registry.fedoraproject.org|registry.k8s.io|cgr.dev|lscr.io|192.168.1.102|192.168.1.102:30500|192.168.1.102:30501|localhost) ;;
               *) echo "FAIL: uncached registry '$registry' in $(echo "$line" | cut -d: -f1-2): $imgref"; FAIL=1 ;;
             esac
           done < <(grep -rn 'image:' argo/ manifests/)

--- a/argo/workflow-templates/catalog-cve-scan.yaml
+++ b/argo/workflow-templates/catalog-cve-scan.yaml
@@ -1,0 +1,356 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: catalog-cve-scan
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: catalog-cve-scan
+    app.kubernetes.io/part-of: bluefin-test-suite
+  annotations:
+    bluefin.io/description: |
+      Lab-side grype vulnerability scan of installed catalog apps only.
+      Discovers apps from manifests/catalog-apps/*/manifest.yaml, extracts the
+      container image reference for each, runs grype against that image, and
+      publishes a snapshot to docs/data/catalog/installed-scans.json.
+      Results are display-only and never gate anything.
+spec:
+  serviceAccountName: argo
+  activeDeadlineSeconds: 3600
+  # Keep scans sequential so a single scan owns its memory ceiling; LSIO images
+  # are smaller than bootc images but grype/syft still cache multi-GB layers.
+  parallelism: 1
+  podGC:
+    strategy: OnWorkflowSuccess
+  ttlStrategy:
+    secondsAfterCompletion: 86400
+    secondsAfterFailure: 604800
+  entrypoint: scan-and-publish
+
+  arguments:
+    parameters:
+      - name: branch
+        value: "main"
+
+  templates:
+    - name: scan-and-publish
+      steps:
+        - - name: discover-apps
+            template: discover-apps
+        - - name: scan-app
+            template: scan-app
+            arguments:
+              parameters:
+                - name: app
+                  value: "{{item.app}}"
+                - name: image-ref
+                  value: "{{item.image_ref}}"
+            withParam: "{{steps.discover-apps.outputs.parameters.apps}}"
+        - - name: aggregate-and-publish
+            template: aggregate-and-publish
+            arguments:
+              parameters:
+                - name: summaries
+                  value: "{{steps.scan-app.outputs.parameters.summary}}"
+
+    - name: discover-apps
+      outputs:
+        parameters:
+          - name: apps
+            valueFrom:
+              path: /tmp/apps.json
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: bluefin-test-suite
+          bluefin.io/step: catalog-cve-discover
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash]
+        securityContext:
+          runAsUser: 0
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+                optional: true
+          - name: BRANCH
+            value: "{{workflow.parameters.branch}}"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        source: |
+          set -euo pipefail
+
+          if ! apk add --no-cache python3 py3-yaml jq git >/dev/null 2>&1; then
+            echo "ERROR: failed to install discovery tooling" >&2
+            exit 1
+          fi
+
+          rm -rf /tmp/lab-code
+          CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git"
+          if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+            CLONE_URL="https://github.com/projectbluefin/lab.git"
+          fi
+          git clone --depth 1 --branch "${BRANCH}" "${CLONE_URL}" /tmp/lab-code
+
+          python3 -c '
+          import json
+          import os
+          from pathlib import Path
+          import yaml
+
+          apps = []
+          base = Path("/tmp/lab-code/manifests/catalog-apps")
+          if base.exists():
+              for manifest in sorted(base.glob("*/manifest.yaml")):
+                  app = manifest.parent.name
+                  try:
+                      for doc in yaml.safe_load_all(manifest.read_text()):
+                          if doc.get("kind") == "Deployment":
+                              containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+                              for c in containers:
+                                  image = c.get("image")
+                                  if image:
+                                      apps.append({"app": app, "image_ref": image})
+                                      break
+                              break
+                  except Exception as exc:
+                      print(f"WARN: failed to parse {manifest}: {exc}", file=os.sys.stderr)
+          print(json.dumps(apps))
+          ' > /tmp/apps.json
+
+          echo "Discovered installed apps:" >&2
+          jq '.' /tmp/apps.json >&2
+
+    - name: scan-app
+      inputs:
+        parameters:
+          - name: app
+          - name: image-ref
+      outputs:
+        parameters:
+          - name: summary
+            valueFrom:
+              path: /tmp/summary.json
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: bluefin-test-suite
+          bluefin.io/step: catalog-cve-scan-app
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash]
+        securityContext:
+          runAsUser: 0
+        env:
+          - name: GRYPE_DB_AUTO_UPDATE
+            value: "true"
+          - name: GRYPE_CHECK_FOR_APP_UPDATE
+            value: "false"
+          - name: GOMEMLIMIT
+            value: "7GiB"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+          limits:
+            cpu: "2"
+            memory: 8Gi
+        source: |
+          set -euo pipefail
+          APP="{{inputs.parameters.app}}"
+          IMAGE_REF="{{inputs.parameters.image-ref}}"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          SUMMARY_FILE="/tmp/summary.json"
+          GRYPE_OUT="/tmp/grype.json"
+
+          emit_unavailable() {
+            local reason="$1"
+            printf '{"app":"%s","image_ref":"%s","digest":null,"state":"unavailable","state_reason":"%s","scanner_version":null,"severity_counts":{"critical":0,"high":0,"medium":0,"low":0,"negligible":0,"unknown":0},"fixable":0,"total":0,"top_cves":[],"scan_date":"%s"}\n' \
+              "$APP" "$IMAGE_REF" "$reason" "$NOW" > "$SUMMARY_FILE"
+          }
+
+          echo "Scanning ${IMAGE_REF} for installed app ${APP} at ${NOW}" >&2
+
+          if ! apk add --no-cache grype jq >/dev/null 2>&1; then
+            emit_unavailable "failed to install grype/jq scanner tooling in ephemeral pod"
+            exit 0
+          fi
+
+          SCAN_RC=0
+          grype -o json --file "$GRYPE_OUT" "$IMAGE_REF" >/dev/null 2>&1 || SCAN_RC=$?
+
+          if [[ $SCAN_RC -ne 0 ]]; then
+            emit_unavailable "grype scan failed with exit code ${SCAN_RC}"
+            exit 0
+          fi
+
+          if [[ ! -s "$GRYPE_OUT" ]]; then
+            emit_unavailable "grype produced no output for ${IMAGE_REF}"
+            exit 0
+          fi
+
+          jq -nc \
+            --arg app "$APP" \
+            --arg image_ref "$IMAGE_REF" \
+            --arg now "$NOW" \
+            '
+            input as $grype |
+            ($grype.source.target.manifestDigest // null) as $digest |
+            ($grype.descriptor.version // "unknown") as $scanner_version |
+            ($grype.matches // []) as $matches |
+            {
+              critical: 0, high: 0, medium: 0, low: 0, negligible: 0, unknown: 0
+            } as $init_count |
+            ($matches | reduce .[] as $m ($init_count;
+              (($m.vulnerability.severity // "Unknown") | ascii_downcase) as $sev |
+              .[$sev] += 1
+            )) as $counts |
+            ([$matches[] | select(
+              (.vulnerability.fix.state // "") == "fixed" or
+              ((.vulnerability.fix.versions // []) | length) > 0
+            )] | length) as $fixable |
+            ($matches | length) as $total |
+            ($matches |
+              sort_by([
+                ({"Critical":0,"High":1,"Medium":2,"Low":3,"Negligible":4,"Unknown":5}[.vulnerability.severity // "Unknown"] // 5),
+                -(.vulnerability.risk // 0)
+              ]) |
+              [ .[0:5][] |
+                {
+                  id: (
+                    ((.relatedVulnerabilities // [])[0].id // .vulnerability.id) as $id |
+                    if ($id | startswith("CVE")) then $id else .vulnerability.id end
+                  ),
+                  severity: (.vulnerability.severity // "Unknown"),
+                  package: (.artifact.name // "unknown"),
+                  installed: (.artifact.version // "unknown"),
+                  fixed_in: ((.vulnerability.fix.versions[0]) // null)
+                }
+              ]
+            ) as $top_cves |
+            {
+              app: $app,
+              image_ref: $image_ref,
+              digest: $digest,
+              state: (if $digest then "available" else "unavailable" end),
+              state_reason: (if $digest then null else "grype did not report a manifest digest" end),
+              scanner_version: $scanner_version,
+              severity_counts: $counts,
+              fixable: $fixable,
+              total: $total,
+              top_cves: $top_cves,
+              scan_date: $now
+            }
+            ' "$GRYPE_OUT" > "$SUMMARY_FILE"
+
+    - name: aggregate-and-publish
+      inputs:
+        parameters:
+          - name: summaries
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: bluefin-test-suite
+          bluefin.io/step: catalog-cve-aggregate
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash]
+        securityContext:
+          runAsUser: 0
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+                optional: true
+          - name: BRANCH
+            value: "{{workflow.parameters.branch}}"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        source: |
+          set -euo pipefail
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          WORKFLOW_NAME="{{workflow.name}}"
+          SUMMARIES='{{inputs.parameters.summaries}}'
+
+          echo "Aggregating catalog CVE summaries for ${WORKFLOW_NAME}" >&2
+
+          if ! apk add --no-cache jq git >/dev/null 2>&1; then
+            echo "ERROR: failed to install jq/git in aggregate pod" >&2
+            exit 1
+          fi
+
+          echo "$SUMMARIES" | jq -c --arg now "$NOW" --arg workflow "$WORKFLOW_NAME" '
+            (if (length > 0 and (.[0] | type) == "string") then map(fromjson) else . end) as $summaries |
+            [
+              $summaries[] |
+              {
+                app: .app,
+                image_ref: .image_ref,
+                digest: .digest,
+                scanner: "grype",
+                scanner_version: .scanner_version,
+                severity_counts: .severity_counts,
+                fixable: .fixable,
+                total: .total,
+                top_cves: .top_cves,
+                scan_date: .scan_date,
+                source_url: ("http://192.168.1.102:32746/workflows/argo/" + $workflow),
+                collected_at: $now,
+                derivation: "grype scan of installed catalog app image in ephemeral workflow pod",
+                state: .state,
+                state_reason: .state_reason
+              }
+            ]
+          ' > /tmp/rows.json
+
+          echo "Generated rows:" >&2
+          jq '.' /tmp/rows.json >&2
+
+          if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+            echo "No GITHUB_TOKEN - skipping publication" >&2
+            exit 0
+          fi
+
+          rm -rf /tmp/lab-code
+          git clone --depth 1 --branch "${BRANCH}" "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" /tmp/lab-code
+
+          OUT="/tmp/lab-code/docs/data/catalog/installed-scans.json"
+          mkdir -p "$(dirname "$OUT")"
+          if [[ -f "$OUT" ]]; then
+            jq --argjson rows "$(cat /tmp/rows.json)" --arg now "$NOW" --arg workflow "$WORKFLOW_NAME" '
+              .schema_version = 1 |
+              ._meta.generated_at = $now |
+              ._meta.workflow = $workflow |
+              ._meta.status = "live" |
+              .rows = $rows
+            ' "$OUT" > /tmp/new-scans.json
+          else
+            jq -n --argjson rows "$(cat /tmp/rows.json)" --arg now "$NOW" --arg workflow "$WORKFLOW_NAME" \
+              '{schema_version: 1, _meta: {description: "Lab-side grype scan of installed catalog apps (display-only)", generated_at: $now, workflow: $workflow, status: "live"}, rows: $rows}' \
+              > /tmp/new-scans.json
+          fi
+
+          cp /tmp/new-scans.json "$OUT"
+
+          cd /tmp/lab-code
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/data/catalog/installed-scans.json
+          if git diff --cached --quiet; then
+            echo "No changes to publish" >&2
+            exit 0
+          fi
+          git commit -m "chore(catalog): update installed app CVE scans (${WORKFLOW_NAME})" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          git push origin "HEAD:${BRANCH}"
+          echo "Published catalog CVE scan results" >&2

--- a/argo/workflow-templates/catalog-install-lsio.yaml
+++ b/argo/workflow-templates/catalog-install-lsio.yaml
@@ -8,7 +8,7 @@
 # Lab conventions applied by the translator:
 #   * local-path storage class for PVCs
 #   * PUID/PGID env vars + securityContext
-#   * bare docker.io image names so the zot-docker mirror resolves them
+#   * lscr.io image names so the zot-lscr mirror resolves them
 #   * ClusterIP Service for in-cluster reachability
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate

--- a/docs/data/catalog/installed-scans.json
+++ b/docs/data/catalog/installed-scans.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "_meta": {
+    "description": "Lab-side grype scan of installed catalog apps (display-only)",
+    "generated_at": "2026-07-25T05:31:32Z",
+    "workflow": null,
+    "status": "live"
+  },
+  "rows": [
+    {
+      "app": "jellyfin",
+      "image_ref": "lscr.io/linuxserver/jellyfin:latest",
+      "digest": null,
+      "scanner": "grype",
+      "scanner_version": null,
+      "severity_counts": {
+        "critical": 0,
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "negligible": 0,
+        "unknown": 0
+      },
+      "fixable": 0,
+      "total": 0,
+      "top_cves": [],
+      "scan_date": "2026-07-25T05:31:32Z",
+      "source_url": "",
+      "collected_at": "2026-07-25T05:31:32Z",
+      "derivation": "initial placeholder; first scan pending catalog-cve-scan CronWorkflow run",
+      "state": "unavailable",
+      "state_reason": "awaiting first catalog-cve-scan CronWorkflow run"
+    }
+  ]
+}

--- a/docs/skills/registry-catalog/SKILL.md
+++ b/docs/skills/registry-catalog/SKILL.md
@@ -84,8 +84,9 @@ Lab conventions applied:
 - `storageClassName: local-path` on every PVC.
 - PVC size heuristic based on mount path (`/config` 5Gi, media paths 100Gi,
   `/transcode` 50Gi, default 1Gi).
-- Images emitted as bare `linuxserver/<app>:latest` so the cluster's
-  zot-docker mirror resolves them (avoids the registry allowlist lint).
+- Images emitted as `lscr.io/linuxserver/<app>:latest` so the cluster's
+  zot-lscr mirror resolves them; this matches how other lab workloads
+  reference their upstream mirrored registries.
 - PUID/PGID become env vars and, when the image supports it, a
   `securityContext` with `runAsUser`, `runAsGroup`, `fsGroup`, `runAsNonRoot`,
   and `readOnlyRootFilesystem`.
@@ -134,8 +135,9 @@ The install WorkflowTemplate takes a `mode` parameter:
 - Heredocs (`<<'EOF'`) inside YAML `script:` block scalars break the Argo
   linter. Build JSON payloads with inline `python3 -c` or write helper scripts
   to files instead.
-- LSIO images must use the bare docker.io form in rendered manifests;
-  `lscr.io/...` is not in the registry allowlist and fails CI lint.
+- LSIO images use the upstream `lscr.io/linuxserver/<app>` form in rendered
+  manifests; `lscr.io` is mirrored by the lab zot cache and is in the
+  registry allowlist.
 - The manifest travels between workflow steps as a base64 output parameter
   supplied via *call-site* `arguments:` — `{{steps.render.outputs...}}`
   inside a leaf template's input defaults never resolves (three live

--- a/manifests/catalog-apps/jellyfin/manifest.yaml
+++ b/manifests/catalog-apps/jellyfin/manifest.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
         - name: jellyfin
-          image: "linuxserver/jellyfin:latest"
+          image: "lscr.io/linuxserver/jellyfin:latest"
           ports:
             - name: tcp-8096
               containerPort: 8096

--- a/manifests/catalog-cve-scan-cron.yaml
+++ b/manifests/catalog-cve-scan-cron.yaml
@@ -1,0 +1,36 @@
+# CronWorkflow: nightly CVE scan of installed catalog apps at 04:00 UTC.
+# Runs after the catalog poller and catalog installs have had a chance to
+# land on main. References the catalog-cve-scan WorkflowTemplate so the scan
+# logic lives in one place.
+#
+# Schema note: CronWorkflow fields live at .spec; the Workflow spec is nested
+# under .spec.workflowSpec. workflowTemplateRef is used to invoke the shared
+# catalog-cve-scan template.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: catalog-cve-scan
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  suspend: false
+  schedules:
+    - "0 4 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Replace
+  startingDeadlineSeconds: 300
+  workflowMetadata:
+    labels:
+      app.kubernetes.io/part-of: bluefin-test-suite
+      bluefin.io/trigger: nightly
+      bluefin.io/lane: catalog-cve-scan
+  workflowSpec:
+    serviceAccountName: argo
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterSuccess: 86400
+      secondsAfterFailure: 604800
+    workflowTemplateRef:
+      name: catalog-cve-scan

--- a/manifests/registry-mirror-config.yaml
+++ b/manifests/registry-mirror-config.yaml
@@ -2,7 +2,7 @@
 # Writes containerd hosts.toml to each node's certs.d path.
 # containerd v2.0 (k3s v1.32+) hot-reloads these — no k3s restart needed.
 #
-# All 6 registries mirror through a single zot-cache instance (NodePort 30501).
+# All 8 registries mirror through a single zot-cache instance (NodePort 30501).
 # Zot stores each upstream under a repo prefix via sync destination mapping:
 #   ghcr.io                    → ghcr/<repo>
 #   docker.io                  → docker/<repo>
@@ -10,6 +10,8 @@
 #   registry.fedoraproject.org → fedora/<repo>
 #   registry.k8s.io            → k8s/<repo>
 #   cgr.dev                    → cgr/<repo>
+#   public.ecr.aws             → ecr/<repo>
+#   lscr.io                    → lscr/<repo>
 #
 # containerd should talk to the mirror root and use override_path to point the
 # request at the registry-specific Zot namespace for each upstream.
@@ -67,6 +69,12 @@ data:
     [host."http://192.168.1.102:30501/v2/ecr"]
       capabilities = ["pull", "resolve"]
       override_path = true
+  lscr.io.hosts.toml: |
+    server = "https://lscr.io"
+
+    [host."http://192.168.1.102:30501/v2/lscr"]
+      capabilities = ["pull", "resolve"]
+      override_path = true
   local-zot.hosts.toml: |
     server = "http://192.168.1.102:30500"
 
@@ -106,6 +114,7 @@ spec:
                 /certs.d/registry.k8s.io \
                 /certs.d/cgr.dev \
                 /certs.d/public.ecr.aws \
+                /certs.d/lscr.io \
                 "/certs.d/192.168.1.102:30500"
               cp /config/ghcr.io.hosts.toml                    /certs.d/ghcr.io/hosts.toml
               cp /config/docker.io.hosts.toml                  /certs.d/docker.io/hosts.toml
@@ -114,6 +123,7 @@ spec:
               cp /config/registry.k8s.io.hosts.toml            /certs.d/registry.k8s.io/hosts.toml
               cp /config/cgr.dev.hosts.toml                    /certs.d/cgr.dev/hosts.toml
               cp /config/public.ecr.aws.hosts.toml             /certs.d/public.ecr.aws/hosts.toml
+              cp /config/lscr.io.hosts.toml                    /certs.d/lscr.io/hosts.toml
               cp /config/local-zot.hosts.toml                  "/certs.d/192.168.1.102:30500/hosts.toml"
               echo "Mirror hosts written."
           volumeMounts:

--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -1,4 +1,4 @@
-# Zot pull-through cache — single instance proxying all 7 upstream registries
+# Zot pull-through cache — single instance proxying all 8 upstream registries
 # Zot sync destination prefix mapping stores each registry under a separate subpath:
 #   ghcr.io                    → /ghcr   (pull via http://192.168.1.102:30501/ghcr/...)
 #   docker.io                  → /docker (pull via http://192.168.1.102:30501/docker/...)
@@ -7,6 +7,7 @@
 #   registry.k8s.io            → /k8s    (pull via http://192.168.1.102:30501/k8s/...)
 #   cgr.dev                    → /cgr    (pull via http://192.168.1.102:30501/cgr/...)
 #   public.ecr.aws             → /ecr    (pull via http://192.168.1.102:30501/ecr/...)
+#   lscr.io                    → /lscr   (pull via http://192.168.1.102:30501/lscr/...)
 #
 # Sync content filters are intentionally omitted so Zot mirrors whatever the
 # nodes request; the earlier prefix filtering was preventing on-demand pulls.
@@ -99,6 +100,14 @@ data:
               "maxRetries": 3,
               "retryDelay": "2m",
               "content": [{ "prefix": "**", "destination": "/ecr" }]
+            },
+            {
+              "urls": ["https://lscr.io"],
+              "onDemand": true,
+              "tlsVerify": true,
+              "maxRetries": 3,
+              "retryDelay": "2m",
+              "content": [{ "prefix": "**", "destination": "/lscr" }]
             }
           ]
         }

--- a/scripts/catalog_install_lsio.py
+++ b/scripts/catalog_install_lsio.py
@@ -6,8 +6,9 @@ index), applies lab conventions, and writes rendered manifests to a directory.
 
 Lab conventions applied:
   * Storage class is local-path; PVCs are created on node data disks.
-  * Image references use the bare docker.io form (linuxserver/<app>:latest)
-    so the cluster's zot-docker mirror resolves them.
+  * Image references use the upstream lscr.io form (lscr.io/linuxserver/<app>:latest)
+    so the cluster's zot-lscr mirror resolves them; this matches how other
+    lab workloads reference their upstream mirrored registries.
   * PUID/PGID become both env vars and a securityContext (fsGroup/runAsGroup;
     runAsUser/runAsNonRoot only when the image advertises non-root support).
   * Optional ports and volumes are included by default; the installer favours
@@ -218,8 +219,8 @@ def render_manifests(app_name, entry, namespace, image_tag="latest"):
     container_ports, service_ports = render_ports(config.get("ports"))
     sec_ctx = security_context_from_config(config)
 
-    # Use the bare docker.io form so the zot-docker mirror resolves it.
-    image = f"{IMAGE_PREFIX}/{app_name}:{image_tag}"
+    # Use the upstream lscr.io form so the zot-lscr mirror resolves it.
+    image = f"lscr.io/{IMAGE_PREFIX}/{app_name}:{image_tag}"
 
     namespace_res = {
         "apiVersion": "v1",

--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -20,6 +20,7 @@ ALLOWLISTED_REGISTRIES = {
     "registry.fedoraproject.org",
     "registry.k8s.io",
     "cgr.dev",
+    "lscr.io",
     "192.168.1.102",
     "192.168.1.102:30500",
     "192.168.1.102:30501",

--- a/tests/unit/fixtures/expected-jellyfin/manifest.yaml
+++ b/tests/unit/fixtures/expected-jellyfin/manifest.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
         - name: jellyfin
-          image: "linuxserver/jellyfin:latest"
+          image: "lscr.io/linuxserver/jellyfin:latest"
           ports:
             - name: tcp-8096
               containerPort: 8096

--- a/tests/unit/fixtures/expected-sonarr/manifest.yaml
+++ b/tests/unit/fixtures/expected-sonarr/manifest.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
         - name: sonarr
-          image: "linuxserver/sonarr:latest"
+          image: "lscr.io/linuxserver/sonarr:latest"
           ports:
             - name: tcp-8989
               containerPort: 8989

--- a/tests/unit/test_catalog_install_lsio.py
+++ b/tests/unit/test_catalog_install_lsio.py
@@ -54,7 +54,7 @@ class TestCatalogInstallLsio:
 
         deployment = resources[4]
         container = deployment["spec"]["template"]["spec"]["containers"][0]
-        assert container["image"] == "linuxserver/jellyfin:latest"
+        assert container["image"] == "lscr.io/linuxserver/jellyfin:latest"
         assert len(container["ports"]) == 4
         assert {p["protocol"] for p in container["ports"]} == {"TCP", "UDP"}
         assert len(container["volumeMounts"]) == 3


### PR DESCRIPTION
Implements the catalog supply-chain slice:

- Extends Zot pull-through mirror to lscr.io and wires containerd hosts.toml.
- Adds lscr.io to registry allowlists and switches rendered catalog apps to upstream lscr.io image refs.
- Adds a display-only CVE scan (grype) for installed catalog apps only, writing to docs/data/catalog/installed-scans.json.
- Includes CronWorkflow and updates skill docs / unit fixtures.

Verification: just lint, actionlint, registry allowlist check, and unit tests pass. Live workflow verification happens post-merge via ArgoCD sync.