### PR TITLE
feat: add NVIDIA NGC catalog provider adapter

### DIFF
--- a/manifests/catalog-ngc-poller.yaml
+++ b/manifests/catalog-ngc-poller.yaml
@@ -1,0 +1,85 @@
+# CronWorkflow: refresh the NVIDIA NGC catalog index weekly.
+# Fetches the public NGC catalog API for NVIDIA containers, regenerates
+# docs/data/catalog/ngc.json, and opens a PR when the index changes.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: catalog-ngc-poller
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: catalog-ngc-poller
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  suspend: false
+  schedules:
+    - "0 6 * * 2"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  workflowSpec:
+    serviceAccountName: argo
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterSuccess: 3600
+      secondsAfterFailure: 86400
+    entrypoint: poll-and-pr
+    templates:
+      - name: poll-and-pr
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: bluefin-test-suite
+            bluefin.io/step: catalog-ngc-poller
+        script:
+          image: ghcr.io/projectbluefin/lab-runner:latest
+          command: [bash]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-token
+                  key: token
+          source: |
+            set -euo pipefail
+
+            REPO="projectbluefin/lab"
+            CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+            WORK_DIR="/tmp/lab-catalog-ngc"
+            BRANCH="bot/catalog-ngc-$(date -u +%Y%m%d-%H%M%S)"
+            NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+            rm -rf "${WORK_DIR}"
+            git clone --depth 1 "${CLONE_URL}" "${WORK_DIR}"
+            cd "${WORK_DIR}"
+
+            python3 scripts/collect_ngc_catalog.py
+
+            # Ignore diffs that only touch the generated_at timestamp.
+            if git diff --quiet -I '"generated_at"' -- docs/data/catalog/ngc.json; then
+              echo "No catalog changes — skipping PR"
+              exit 0
+            fi
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout -b "${BRANCH}"
+            git add docs/data/catalog/ngc.json
+            git commit -m "chore: refresh NVIDIA NGC catalog index (${NOW})" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+            git push origin "${BRANCH}"
+
+            # lab-runner has no gh CLI — create the PR via the REST API.
+            PR_URL=$(curl -sf -X POST \
+              -H "Authorization: ******" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/pulls" \
+              -d "{\"title\":\"chore: refresh NVIDIA NGC catalog index\",\"body\":\"Weekly refresh of docs/data/catalog/ngc.json from ${NOW}.\",\"base\":\"main\",\"head\":\"${BRANCH}\"}" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["html_url"])')
+
+            echo "Opened PR: ${PR_URL}"

--- a/scripts/collect_ngc_catalog.py
+++ b/scripts/collect_ngc_catalog.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Refresh the NVIDIA NGC catalog index.
+
+Queries the public NGC catalog API for NVIDIA-published containers and maps
+the response to the provider-agnostic catalog index schema defined in
+docs/reference/catalog-index-schema.md. The resulting thin index is written to
+docs/data/catalog/ngc.json sorted by container name.
+
+NGC catalog listings are public; pulling images from nvcr.io requires auth,
+but this poller only reads metadata.
+
+Run locally:
+    python3 scripts/collect_ngc_catalog.py
+
+Dry-run (no files written):
+    python3 scripts/collect_ngc_catalog.py --dry-run
+"""
+
+import argparse
+import datetime
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# NGC catalog API endpoint for NVIDIA containers.
+# This endpoint requires an NGC API key for authentication; public
+# unauthenticated access is not available for container listings.
+API_URL = "https://api.ngc.nvidia.com/v2/orgs/nvidia/containers"
+OUT_PATH = Path("docs/data/catalog/ngc.json")
+PROVIDER = "ngc"
+IMAGE_PREFIX = "nvcr.io/nvidia"
+PAGE_SIZE = 100
+
+
+class CatalogError(Exception):
+    pass
+
+
+def now_iso():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def fetch_json(url, timeout=60):
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "bluefin-lab-catalog-poller/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_page(page=0, page_size=PAGE_SIZE):
+    url = f"{API_URL}?page={page}&pageSize={page_size}"
+    return fetch_json(url)
+
+
+def fetch_all_containers(max_pages=50):
+    """Fetch all public NVIDIA container listings from the NGC catalog API."""
+    containers = []
+    for page in range(max_pages):
+        data = fetch_page(page=page)
+        page_containers = data.get("containers") or data.get("results") or []
+        if not page_containers:
+            break
+        containers.extend(page_containers)
+        total = data.get("total") or data.get("totalCount") or data.get("total_count")
+        if total is not None and len(containers) >= total:
+            break
+        # If the page is not full, we have reached the end.
+        if len(page_containers) < PAGE_SIZE:
+            break
+    return containers
+
+
+def as_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def get_name(container):
+    """Return the canonical container name from various possible fields."""
+    for key in ("name", "containerName", "displayName", "display_name"):
+        value = container.get(key)
+        if value and isinstance(value, str):
+            return value.strip()
+    return None
+
+
+def get_description(container):
+    for key in ("description", "shortDescription", "short_description", "summary"):
+        value = container.get(key)
+        if value and isinstance(value, str):
+            return value.strip()
+    return None
+
+
+def get_category(container):
+    value = container.get("labels") or container.get("tags") or []
+    if isinstance(value, list):
+        return ", ".join(str(v) for v in value if v) or "AI/ML"
+    if isinstance(value, dict):
+        return ", ".join(str(v) for v in value.values() if v) or "AI/ML"
+    if isinstance(value, str):
+        return value
+    return "AI/ML"
+
+
+def get_logo_url(container):
+    for key in ("logoUrl", "logo_url", "logo", "iconUrl", "icon_url"):
+        value = container.get(key)
+        if value and isinstance(value, str):
+            return value.strip()
+    return None
+
+
+def get_image_ref(container, name):
+    for key in ("imagePath", "image_path", "imageUrl", "image_url", "repository"):
+        value = container.get(key)
+        if value and isinstance(value, str):
+            return value.split(":")[0].strip()
+    if name:
+        return f"{IMAGE_PREFIX}/{name}"
+    return None
+
+
+def get_pulls(container):
+    for key in ("downloads", "pullCount", "pull_count", "monthlyPulls", "monthly_pulls"):
+        value = container.get(key)
+        if value is not None:
+            return as_int(value)
+    return None
+
+
+def get_stars(container):
+    for key in ("likes", "favorites", "stars"):
+        value = container.get(key)
+        if value is not None:
+            return as_int(value)
+    return None
+
+
+def get_architectures(container):
+    arches = container.get("architectures") or container.get("architecture") or []
+    if isinstance(arches, str):
+        arches = [a.strip() for a in arches.split(",")]
+    names = []
+    for a in arches or []:
+        if isinstance(a, dict):
+            name = a.get("arch") or a.get("architecture") or a.get("name")
+        else:
+            name = a
+        if name and isinstance(name, str):
+            names.append(name.strip())
+    # Normalize common forms to the schema's vocabulary.
+    normalized = []
+    mapping = {"amd64": "x86_64", "x64": "x86_64", "arm64": "arm64", "aarch64": "arm64"}
+    seen = set()
+    for name in names:
+        canonical = mapping.get(name.lower(), name)
+        if canonical not in seen:
+            seen.add(canonical)
+            normalized.append(canonical)
+    return normalized
+
+
+def config_pointer(container, name):
+    """Return the upstream URL consumers should fetch for deploy-time config."""
+    for key in ("docsUrl", "docs_url", "documentationUrl", "documentation_url"):
+        value = container.get(key)
+        if value and isinstance(value, str):
+            return value.strip()
+    if name:
+        return f"https://catalog.ngc.nvidia.com/orgs/nvidia/containers/{name}"
+    return None
+
+
+def is_container(container):
+    """Return True if the catalog entry is a container (not a model or chart)."""
+    resource_type = container.get("resourceType") or container.get("resource_type") or ""
+    if resource_type and resource_type.lower() != "container":
+        return False
+    # Accept entries that explicitly carry an image path/repository.
+    if container.get("imagePath") or container.get("image_path") or container.get("repository"):
+        return True
+    # Fallback: accept when no resourceType is present (assume container listing).
+    return True
+
+
+def map_container(container):
+    name = get_name(container)
+    image_ref = get_image_ref(container, name)
+    return {
+        "name": name,
+        "description": get_description(container),
+        "category": get_category(container),
+        "logo_url": get_logo_url(container),
+        "image_ref": image_ref,
+        "monthly_pulls": get_pulls(container),
+        "stars": get_stars(container),
+        "architectures": get_architectures(container),
+        "config_pointer": config_pointer(container, name),
+        "readonly_supported": False,
+        "nonroot_supported": False,
+        "verified": True,
+    }
+
+
+def build_index(containers):
+    apps = []
+    seen = set()
+    for container in containers:
+        if not is_container(container):
+            continue
+        mapped = map_container(container)
+        name = mapped["name"]
+        if not name or not mapped["image_ref"]:
+            continue
+        # Deduplicate by name.
+        if name in seen:
+            continue
+        seen.add(name)
+        apps.append(mapped)
+    apps.sort(key=lambda a: a["name"])
+    return {
+        "provider": PROVIDER,
+        "generated_at": now_iso(),
+        "source_api": API_URL,
+        "apps": apps,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Refresh the NVIDIA NGC catalog index.")
+    parser.add_argument("--dry-run", action="store_true", help="Print summary but do not write the index file.")
+    args = parser.parse_args()
+
+    try:
+        containers = fetch_all_containers()
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR: HTTP {exc.code} from {API_URL}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"ERROR: failed to reach {API_URL}: {exc.reason}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON from {API_URL}: {exc}", file=sys.stderr)
+        return 1
+    except CatalogError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    index = build_index(containers)
+    apps = index["apps"]
+
+    if args.dry_run:
+        print(f"provider: {index['provider']}")
+        print(f"generated_at: {index['generated_at']}")
+        print(f"source_api: {index['source_api']}")
+        print(f"apps: {len(apps)}")
+        return 0
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(index, indent=2, ensure_ascii=False) + "\n")
+    print(f"catalog-ngc: wrote {len(apps)} apps to {OUT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/fixtures/ngc-catalog.json
+++ b/tests/unit/fixtures/ngc-catalog.json
@@ -1,0 +1,46 @@
+{
+  "containers": [
+    {
+      "name": "ollama",
+      "description": "Ollama makes it easy to get started with large language models and run them on NVIDIA GPUs.",
+      "shortDescription": "Run LLMs locally on NVIDIA GPUs",
+      "labels": ["llm", "inference", "generative-ai"],
+      "logoUrl": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ollama/logo.png",
+      "imagePath": "nvcr.io/nvidia/ollama:0.3.0",
+      "downloads": 125000,
+      "architectures": ["amd64", "arm64"]
+    },
+    {
+      "name": "tritonserver",
+      "description": "NVIDIA Triton Inference Server for deploying AI models at scale.",
+      "labels": ["inference", "ai"],
+      "logo_url": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver/logo.png",
+      "image_path": "nvcr.io/nvidia/tritonserver:24.06-py3",
+      "pullCount": 8900000,
+      "architecture": "amd64"
+    },
+    {
+      "name": "pytorch",
+      "description": "NVIDIA optimized PyTorch container.",
+      "tags": ["framework", "training"],
+      "repository": "nvcr.io/nvidia/pytorch:24.05-py3",
+      "downloads": 15000000,
+      "architectures": [{"arch": "amd64", "tag": "24.05-py3"}]
+    },
+    {
+      "name": "tensorrt-llm",
+      "description": "TensorRT-LLM provides users with an easy-to-use Python API to define LLMs.",
+      "labels": ["inference", "llm"],
+      "imagePath": "nvcr.io/nvidia/tensorrt-llm:24.05",
+      "architectures": ["amd64"]
+    },
+    {
+      "name": "nim-llama-3-8b-instruct",
+      "description": "NVIDIA NIM for Meta Llama 3 8B Instruct.",
+      "resourceType": "model",
+      "labels": ["llm", "nim"],
+      "imagePath": "nvcr.io/nim/meta/llama-3-8b-instruct:1.0",
+      "downloads": 42000
+    }
+  ]
+}

--- a/tests/unit/test_collect_ngc_catalog.py
+++ b/tests/unit/test_collect_ngc_catalog.py
@@ -1,0 +1,136 @@
+"""Unit tests for the NVIDIA NGC catalog collector.
+
+Covers mapping of the NGC public catalog response to the shared catalog index
+schema, container filtering, and the deterministic sort order of the output.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo_root / "scripts"))
+
+import collect_ngc_catalog as collector  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CATALOG_FIXTURE = FIXTURES / "ngc-catalog.json"
+
+
+def _load_fixture():
+    with open(CATALOG_FIXTURE) as f:
+        return json.load(f)
+
+
+class TestNgccatalogMapping:
+    """Schema-level mapping tests using the fixture data."""
+
+    def test_build_index_shape(self):
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+
+        assert index["provider"] == "ngc"
+        assert index["source_api"] == collector.API_URL
+        assert "generated_at" in index
+        assert isinstance(index["apps"], list)
+
+    def test_container_filtering(self):
+        """Non-container resources are excluded from the index."""
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+        names = {a["name"] for a in index["apps"]}
+
+        # The model entry should be dropped.
+        assert "nim-llama-3-8b-instruct" not in names
+        # Container entries should be kept.
+        assert "ollama" in names
+        assert "tritonserver" in names
+        assert "pytorch" in names
+        assert "tensorrt-llm" in names
+
+    def test_image_ref_normalized(self):
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+        by_name = {a["name"]: a for a in index["apps"]}
+
+        assert by_name["ollama"]["image_ref"] == "nvcr.io/nvidia/ollama"
+        assert by_name["tritonserver"]["image_ref"] == "nvcr.io/nvidia/tritonserver"
+        assert by_name["pytorch"]["image_ref"] == "nvcr.io/nvidia/pytorch"
+        assert by_name["tensorrt-llm"]["image_ref"] == "nvcr.io/nvidia/tensorrt-llm"
+
+    def test_architecture_normalization(self):
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+        by_name = {a["name"]: a for a in index["apps"]}
+
+        assert "x86_64" in by_name["ollama"]["architectures"]
+        assert "arm64" in by_name["ollama"]["architectures"]
+        assert by_name["tritonserver"]["architectures"] == ["x86_64"]
+        assert by_name["tensorrt-llm"]["architectures"] == ["x86_64"]
+
+    def test_config_pointer_fallback(self):
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+        by_name = {a["name"]: a for a in index["apps"]}
+
+        assert by_name["ollama"]["config_pointer"] == "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ollama"
+
+    def test_sort_order(self):
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+        names = [a["name"] for a in index["apps"]]
+
+        assert names == sorted(names)
+
+    def test_verified_flag(self):
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+
+        for app in index["apps"]:
+            assert app["verified"] is True
+
+    def test_security_flags_default_false(self):
+        data = _load_fixture()
+        index = collector.build_index(data["containers"])
+
+        for app in index["apps"]:
+            assert app["readonly_supported"] is False
+            assert app["nonroot_supported"] is False
+
+
+class TestNgccatalogHelpers:
+    """Low-level helper function tests."""
+
+    def test_get_name_prefers_name(self):
+        assert collector.get_name({"name": "foo", "displayName": "Foo Bar"}) == "foo"
+
+    def test_get_name_falls_back(self):
+        assert collector.get_name({"displayName": "Foo Bar"}) == "Foo Bar"
+
+    def test_get_description_prefers_long(self):
+        assert collector.get_description({"description": "Long", "shortDescription": "Short"}) == "Long"
+
+    def test_get_architectures_string(self):
+        assert collector.get_architectures({"architecture": "amd64, arm64"}) == ["x86_64", "arm64"]
+
+    def test_is_container_rejects_model(self):
+        assert collector.is_container({"resourceType": "model", "imagePath": "x"}) is False
+
+    def test_is_container_accepts_container(self):
+        assert collector.is_container({"imagePath": "nvcr.io/nvidia/foo:1"}) is True
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, None),
+            ("not-a-number", None),
+            ("123", 123),
+            (1234, 1234),
+        ],
+    )
+    def test_as_int(self, raw, expected):
+        assert collector.as_int(raw) == expected


### PR DESCRIPTION
Adds the NGC (NVIDIA GPU Cloud) provider adapter as the second catalog provider.

## Changes
- New collector `scripts/collect_ngc_catalog.py` that queries the NGC container catalog API and maps responses to the shared catalog index schema.
- New CronWorkflow `manifests/catalog-ngc-poller.yaml` with the same PR-based refresh pattern as the LSIO poller.
- Unit tests `tests/unit/test_collect_ngc_catalog.py` plus fixture.

## Blocker
The NGC container catalog API requires authentication (returns 401 for unauthenticated requests). Live generation of `docs/data/catalog/ngc.json` is therefore blocked pending an NGC API key or a public unauthenticated endpoint.

## Verification
- `python3 -m pytest tests/unit/test_collect_ngc_catalog.py -v` passes (18 tests)
- `python3 -m pytest tests/unit/` passes (122 tests)
- `just lint` passes
- `argo lint --offline manifests/catalog-ngc-poller.yaml` passes
