### PR TITLE
feat: add NVIDIA NGC catalog provider adapter

### DIFF
--- a/docs/data/catalog/ngc.json
+++ b/docs/data/catalog/ngc.json
@@ -1,0 +1,12064 @@
+{
+  "provider": "ngc",
+  "generated_at": "2026-07-25T05:53:02Z",
+  "source_api": "https://api.ngc.nvidia.com/v2/search/catalog/resources/CONTAINER",
+  "apps": [
+    {
+      "name": "12.6.11-devel",
+      "description": "CUDA is a parallel computing platform and programming model that enables dramatic increases in computing performance by harnessing the power of the NVIDIA GPUs.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Cuda.png",
+      "image_ref": "nvcr.io/nvidia/12.6.11-devel",
+      "monthly_pulls": 10578,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/12.6.11-devel",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "23.07-0.5.0.0-ubuntu18.04-amd64",
+      "description": "Provision the NVIDIA MOFED driver using containers.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/23.07-0.5.0.0-ubuntu18.04-amd64",
+      "monthly_pulls": 55,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/23.07-0.5.0.0-ubuntu18.04-amd64",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "23.07-0.5.0.0-ubuntu20.04-amd64",
+      "description": "Provision the NVIDIA MOFED driver using containers.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/23.07-0.5.0.0-ubuntu20.04-amd64",
+      "monthly_pulls": 55,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/23.07-0.5.0.0-ubuntu20.04-amd64",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "a2f-authoring",
+      "description": "Early Access version of Audio2Face Authoring Microservice.",
+      "category": "NSPECT-90ZV-A4JL",
+      "logo_url": "https://registry.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fimages.ngc.nvidia.com%2Flogos%2FNvidia-Centric-ACE.png&w=3840&q=80",
+      "image_ref": "nvcr.io/nvidia/ace/a2f-authoring",
+      "monthly_pulls": 329,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/a2f-authoring",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "a2f_controller",
+      "description": "A2F Controller provides bidirectional API for clients to interact with A2F Microservice",
+      "category": "ACE, NSPECT-1LNG-0LXH",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/a2f_controller",
+      "monthly_pulls": 383,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/a2f_controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aa-lcr",
+      "description": "NVIDIA NeMo Evaluator-compatible container with AA-LCR support",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/aa-lcr",
+      "monthly_pulls": 861,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aa-lcr",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "accessrule-controller",
+      "description": "Run:ai accessrule-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/accessrule-controller",
+      "monthly_pulls": 3245,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/accessrule-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ace-agent-ui-client",
+      "description": "ACE Agent UI client is a web allowing users to interact with ACE Agent bots through a browser.",
+      "category": "ACE, NSPECT-26IN-0NIY, Automotive / Transportation",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/ace-agent-ui-client",
+      "monthly_pulls": 2048,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ace-agent-ui-client",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ace-agent-ui-server",
+      "description": "ACE Agent UI server manages text and audio queries between the ACE Agent UI client web app and ACE Agent.",
+      "category": "ACE, NSPECT-26IN-0NIY, Automotive / Transportation",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/ace-agent-ui-server",
+      "monthly_pulls": 445,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ace-agent-ui-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ace-configurator",
+      "description": "ACE Configuration is a kubernetes service that enables live modification of configMap and volumes through a handy REST API.",
+      "category": "NSPECT-HNQ8-SFOF",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fimages.ngc.nvidia.com%2Flogos%2FNvidia-Centric-ACE.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/ace/ace-configurator",
+      "monthly_pulls": 2580,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ace-configurator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "admin-token-issuer-proxy",
+      "description": "Proxies administrative token issuance for NVCF Self-Managed services.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/admin-token-issuer-proxy",
+      "monthly_pulls": 45,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/admin-token-issuer-proxy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "admission-controller",
+      "description": "Run:ai admission-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/admission-controller",
+      "monthly_pulls": 2827,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/admission-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "advice-restart-controller",
+      "description": "Run:ai advice-restart-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/advice-restart-controller",
+      "monthly_pulls": 946,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/advice-restart-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aerial-cuda-accelerated-ran",
+      "description": "An SDK (Software Development Kit) for building commercial-grade, AI-native, 3GPP, and O-RAN compliant 5G/6G gNB software on NVIDIA-accelerated computing platforms.",
+      "category": "NSPECT-RJNI-ZOMD, Cloud Services, AI, High Performance Computing, NSPECT-5C4O-JIA5, Developer Tools, Telecommunications, Application Development, Aerial, Academia / Higher Education, Infrastructure Software",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-accelerated-ran-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aerial-cuda-accelerated-ran",
+      "monthly_pulls": 8987,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aerial-cuda-accelerated-ran",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aerial-framework-base",
+      "description": "A toolchain for generating high-performance, GPU-accelerated 5G/6G pipelines from Python and a modular, real-time runtime for executing the pipelines on NVIDIA Aerial™ RAN Computer platforms.",
+      "category": "AI, Developer Tools, Telecommunications, NSPECT-FH71-2DID, ML, Aerial, Academia / Higher Education",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-accelerated-ran-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aerial-framework-base",
+      "monthly_pulls": 404,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aerial-framework-base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "agent",
+      "description": "OSMO container to process jobs as Kubernetes objects",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/agent",
+      "monthly_pulls": 87930,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/agent",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "agentic_eval",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Agentic Eval support",
+      "category": "Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/agentic_eval",
+      "monthly_pulls": 4036,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/agentic_eval",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "agx-dermatology-reference",
+      "description": "A Dermatology reference application for the Clara AGX platform.",
+      "category": "Healthcare, AI, DL, Dermatology, Clara, Computer Vision, Clara AGX",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Clara.png",
+      "image_ref": "nvcr.io/nvidia/clara/agx-dermatology-reference",
+      "monthly_pulls": 120,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/agx-dermatology-reference",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aicp",
+      "description": "DPU-based Check Point Firewall for Host and Network AI Security",
+      "category": "security, firewall, DOCA, HPC / Supercomputing, Infrastructure Software",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/f/f3/Check_Point_logo_2022.svg",
+      "image_ref": "nvcr.io/nvidia/doca-checkpoint/aicp",
+      "monthly_pulls": 275,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aicp",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aicp_dp",
+      "description": "For use with AI Factory Firewall",
+      "category": "security, firewall, DOCA",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/doca-checkpoint/aicp_dp",
+      "monthly_pulls": 240,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aicp_dp",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aiperf",
+      "description": "AIPerf is a comprehensive benchmarking tool that measures the performance of generative AI models served by your preferred inference solution. It provides detailed metrics using a command line display as well as extensive benchmark performance reports.",
+      "category": "AI, HPC Benchmarks, Developer Tools, Tools and Management, HPC / Supercomputing, Inference, NSPECT-NDBS-O2XD",
+      "logo_url": "https://avatars.githubusercontent.com/u/201626793?s=400&u=58955ac7f08dfc26d7666e71da4f818ea657bfde&v=4",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/aiperf",
+      "monthly_pulls": 3756,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aiperf",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aiperf-nightly",
+      "description": "Nightly (experimental) release channel for AIPerf, a comprehensive benchmarking tool that measures the performance of generative AI models served by your preferred inference solution.",
+      "category": "AI, HPC Benchmarks, Developer Tools, Inference",
+      "logo_url": "https://avatars.githubusercontent.com/u/201626793?s=400&u=58955ac7f08dfc26d7666e71da4f818ea657bfde&v=4",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/aiperf-nightly",
+      "monthly_pulls": 574,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aiperf-nightly",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aiq-agent",
+      "description": "NVIDIA AI-Q Intelligence Agent — an enterprise-grade backend agent built on the NVIDIA NeMo Agent Toolkit, providing quick cited answers and in-depth report-style research with \n  modular multi-agent workflows.",
+      "category": "AI, Natural Language Processing, NeMo, Question Answering, NSPECT-HYTG-KJF1",
+      "logo_url": "https://assets.ngc.nvidia.com/products/api-catalog/images/aiq.jpg",
+      "image_ref": "nvcr.io/nvidia/blueprint/aiq-agent",
+      "monthly_pulls": 655,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aiq-agent",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aiq-frontend",
+      "description": "NVIDIA AI-Q Blueprint frontend — a modern web UI built with Next.js, React, and NVIDIA KUI Foundations, providing an accessible interface for the AI-Q Blueprint backend with\n  optional OAuth authentication.",
+      "category": "AI, Natural Language Processing, NVIDIA AI, NeMo, Question Answering, NSPECT-HYTG-KJF1",
+      "logo_url": "https://assets.ngc.nvidia.com/products/api-catalog/images/aiq.jpg",
+      "image_ref": "nvcr.io/nvidia/blueprint/aiq-frontend",
+      "monthly_pulls": 436,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aiq-frontend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aira-backend",
+      "description": "The NVIDIA AI-Q Research Assistant Blueprint gives developers a foundational starting point for building a deep research assistant that can run on-premise. The backend container provides the RESTful API service.",
+      "category": "AI, Blueprint, NVIDIA AI, Question Answering, NSPECT-HYTG-KJF1",
+      "logo_url": "https://assets.ngc.nvidia.com/products/api-catalog/images/aiq.jpg",
+      "image_ref": "nvcr.io/nvidia/blueprint/aira-backend",
+      "monthly_pulls": 3045,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aira-backend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aira-frontend",
+      "description": "The NVIDIA AI-Q Research Assistant Blueprint gives developers a foundational starting point for building a deep research assistant that can run on-premise. The frontend container provides a demo web UI.",
+      "category": "AI, Blueprint, NVIDIA AI, Question Answering, NSPECT-HYTG-KJF1",
+      "logo_url": "https://assets.ngc.nvidia.com/products/api-catalog/images/aiq.jpg",
+      "image_ref": "nvcr.io/nvidia/blueprint/aira-frontend",
+      "monthly_pulls": 1630,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aira-frontend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aira-load-files",
+      "description": "The NVIDIA AI-Q Research Assistant Blueprint gives developers a foundational starting point for building a deep research assistant that can run on-premise. This container includes a utility to create two default datasets used by the demo web UI.",
+      "category": "AI, Blueprint, NVIDIA AI, Question Answering, NSPECT-HYTG-KJF1",
+      "logo_url": "https://assets.ngc.nvidia.com/products/api-catalog/images/aiq.jpg",
+      "image_ref": "nvcr.io/nvidia/blueprint/aira-load-files",
+      "monthly_pulls": 935,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aira-load-files",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "alert-bridge",
+      "description": "Alert Bridge Container for the VSS event reviewer deployment",
+      "category": "AI, NSPECT-Z2LM-L59M, Vision AI, Video Analytics",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/alert-bridge",
+      "monthly_pulls": 7436,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/alert-bridge",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "anomaly-detection-isolator",
+      "description": "Anomaly Detection Isolator component of AJR.",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/anomaly-detection-isolator",
+      "monthly_pulls": 196,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/anomaly-detection-isolator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "anomaly-remediation-manager",
+      "description": "Anomaly Remediation Manager component of AJR.",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/anomaly-remediation-manager",
+      "monthly_pulls": 319,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/anomaly-remediation-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "anyworkload-controller",
+      "description": "Run:ai anyworkload-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/anyworkload-controller",
+      "monthly_pulls": 2651,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/anyworkload-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aodt-assets",
+      "description": "Containerized sample scenarios for the evaluation of the simulation platform.",
+      "category": "NSPECT-2HA1-RUZO, Telecommunications, Public Sector, Aerial, Academia / Higher Education",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-aerial-digital-twin-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aodt-assets",
+      "monthly_pulls": 567,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aodt-assets",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aodt-gis",
+      "description": "Aerial Omniverse DT GIS image contains the pipelines necessary to take CityGML and OSM geospatial data and create OpenUSD scenes that the DT SIM worker can operate on.",
+      "category": "NSPECT-2HA1-RUZO, Telecommunications, Public Sector, Aerial, Academia / Higher Education",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-aerial-digital-twin-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aodt-gis",
+      "monthly_pulls": 633,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aodt-gis",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aodt-gis-runtime",
+      "description": "Aerial Omniverse DT GIS image contains the pipelines necessary to take CityGML and OSM geospatial data and create OpenUSD scenes that the DT SIM worker can operate on.",
+      "category": "NSPECT-2HA1-RUZO, Telecommunications, Public Sector, Aerial, Academia / Higher Education",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-aerial-digital-twin-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aodt-gis-runtime",
+      "monthly_pulls": 55,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aodt-gis-runtime",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aodt-jupyter",
+      "description": "Jupyter notebook image can be used to access the data produced by the DT SIM worker for analysis and visualization.",
+      "category": "NSPECT-2HA1-RUZO, Aerial",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-aerial-digital-twin-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aodt-jupyter",
+      "monthly_pulls": 504,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aodt-jupyter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aodt-sim",
+      "description": "Aerial Ominverse DT SIM image contains the worker needed by the Aerial Omniverse Digital Twin to perform radio environment and network simulations.",
+      "category": "NSPECT-2HA1-RUZO, Telecommunications, Public Sector, Aerial, Academia / Higher Education",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-aerial-digital-twin-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aodt-sim",
+      "monthly_pulls": 1328,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aodt-sim",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "aodt-sim-runtime",
+      "description": "Aerial Ominverse DT SIM image contains the worker needed by the Aerial Omniverse Digital Twin to perform radio environment and network simulations.",
+      "category": "NSPECT-2HA1-RUZO, Telecommunications, Public Sector, Aerial, Academia / Higher Education",
+      "logo_url": "https://developer.download.nvidia.com/images/aerial/telco-aerial-ngc-catalog-aerial-digital-twin-624x304.jpg",
+      "image_ref": "nvcr.io/nvidia/aerial/aodt-sim-runtime",
+      "monthly_pulls": 68,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/aodt-sim-runtime",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "application-controller",
+      "description": "Run:ai application-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/application-controller",
+      "monthly_pulls": 2411,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/application-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "arbitrator",
+      "description": "Arbitrator Container",
+      "category": "cosmos evaluator, NSPECT-31AR-VU2X",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cosmos/arbitrator",
+      "monthly_pulls": 41,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/arbitrator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "assets-service",
+      "description": "Run:ai assets-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/assets-service",
+      "monthly_pulls": 1513,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/assets-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "assets-sync",
+      "description": "Run:ai assets-sync container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/assets-sync",
+      "monthly_pulls": 2252,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/assets-sync",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "attribute-verification-checker",
+      "description": "Attribute Verification Checker Container",
+      "category": "Cosmos Evaluator",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cosmos/attribute-verification-checker",
+      "monthly_pulls": 135,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/attribute-verification-checker",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "audio2face",
+      "description": "Audio2face converts speech into facial animation in the form of ARKit blendshapes",
+      "category": "ACE, NSPECT-1LNG-0LXH",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/audio2face",
+      "monthly_pulls": 32844,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/audio2face",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "audit-service",
+      "description": "Run:ai audit-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/audit-service",
+      "monthly_pulls": 1798,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/audit-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "auditor",
+      "description": "Auditing models",
+      "category": "NSPECT-L3FU-DSNV, NeMo, Early Access",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/auditor",
+      "monthly_pulls": 1871,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/auditor",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "auditor-tasks",
+      "description": "Job runner for NeMo Auditor",
+      "category": "NSPECT-FLR6-APOD, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-platform/auditor-tasks",
+      "monthly_pulls": 77,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/auditor-tasks",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "authorization",
+      "description": "Run:ai authorization container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/authorization",
+      "monthly_pulls": 1566,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/authorization",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "authorization-migrator",
+      "description": "Run:ai authorization-migrator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/authorization-migrator",
+      "monthly_pulls": 1204,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/authorization-migrator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "authz-sidecar",
+      "description": "OSMO container to evaluate user roles and access",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/authz-sidecar",
+      "monthly_pulls": 5430,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/authz-sidecar",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "auto-magic-calib",
+      "description": "AutoMagicCalib is a tool that estimates both intrinsic and extrinsic camera calibration parameters for single and multi-camera systems",
+      "category": "NSPECT-7TR1-7LVQ, Manufacturing, Retail, Computer Vision",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/auto-magic-calib",
+      "monthly_pulls": 572,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/auto-magic-calib",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "auto-magic-calib-ui",
+      "description": "User Interface for Auto Magic Calib",
+      "category": "DeepStream, NSPECT-7TR1-7LVQ, Manufacturing, Retail, Computer Vision, Metropolis",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/auto-magic-calib-ui",
+      "monthly_pulls": 200,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/auto-magic-calib-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "backend",
+      "description": "Run:ai backend container image",
+      "category": "NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/backend",
+      "monthly_pulls": 1014,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/backend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "backend-listener",
+      "description": "OSMO container to stream node and pod events from the backend compute cluster",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/backend-listener",
+      "monthly_pulls": 44928,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/backend-listener",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "backend-worker",
+      "description": "OSMO container to submit jobs in the backend compute cluster",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/backend-worker",
+      "monthly_pulls": 50083,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/backend-worker",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "base",
+      "description": "The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs.",
+      "category": "RAPIDS, GPU Accelerated Libraries, ML, NSPECT-1RDT-NZVP",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Rapids.png",
+      "image_ref": "nvcr.io/nvidia/rapidsai/base",
+      "monthly_pulls": 74610,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "benchmark",
+      "description": "Autonomous Hardware Recovery (AHR) benchmark container",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/benchmark",
+      "monthly_pulls": 124,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/benchmark",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "bert_workshop",
+      "description": "Jupyter Notebooks for BERT Pre-training, Fine-Tuning and Inference profiling and optimization via TensorFlow, AMP, XLA, DLProf, TF-TRT and Triton.",
+      "category": "SQuAD, Natural Language Processing, NLU, Multi-GPU, Natural Language Understanding, BERT, Triton Inference Server, Conversational AI",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tutorials.png",
+      "image_ref": "nvcr.io/nvidia/bert_workshop",
+      "monthly_pulls": 277,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/bert_workshop",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "bfb-registry",
+      "description": "DOCA Platform Framework enables the management of NVIDIA DPUs and the services that run on them at scale.\n\nDPF BFB Registry contains a webserver that can serve the BFBs when deploying DPUs via the Redfish interface.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/bfb-registry",
+      "monthly_pulls": 2928,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/bfb-registry",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "bfcl",
+      "description": "NVIDIA NeMo Evaluator-compatible container with BFCL support. Based on BFCL available at: https://github.com/ShishirPatil/gorilla",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/bfcl",
+      "monthly_pulls": 4208,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/bfcl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "bff-service",
+      "description": "Run:ai bff-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/bff-service",
+      "monthly_pulls": 1322,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/bff-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "bigcode-evaluation-harness",
+      "description": "NVIDIA NeMo Evaluator-compatible container with BigCode-Evaluation-Harness support. Based on BigCode available at: https://github.com/bigcode-project/bigcode-evaluation-harness",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/bigcode-evaluation-harness",
+      "monthly_pulls": 8215,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/bigcode-evaluation-harness",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "binder",
+      "description": "Run:ai binder container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": "https://i.postimg.cc/vmJLfRNs/image.png",
+      "image_ref": "nvcr.io/nvidia/runai/binder",
+      "monthly_pulls": 999,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/binder",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "bionemo-framework",
+      "description": "BioNeMo Framework for running training and inference on large scale bio-based models.",
+      "category": "Drug Discovery, Healthcare, AI, Life Sciences, Clara, NeMo, NSPECT-K8RW-4YEX",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Clara.png",
+      "image_ref": "nvcr.io/nvidia/clara/bionemo-framework",
+      "monthly_pulls": 17668,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/bionemo-framework",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cached",
+      "description": "CACHED (Context-Aware Chart Element Detection) is a state-of-the-art chart element detection model from University at Buffalo. It was published in Document Analysis and Recognition - ICDAR 2023 conference. The code is based on the MMDetection Framework.",
+      "category": "NSPECT-S96F-FU3F",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/cached",
+      "monthly_pulls": 160,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cached",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "caffe",
+      "description": "NVIDIA Caffe, also known as NVCaffe, is an NVIDIA-maintained fork of Berkeley Vision and Learning Center (BVLC) Caffe tuned for NVIDIA GPUs, particularly in multi-GPU configurations.",
+      "category": "DL",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/NVcaffe.png",
+      "image_ref": "nvcr.io/nvidia/caffe",
+      "monthly_pulls": 3410,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/caffe",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "calibration",
+      "description": "Image for VSS Calibration",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/calibration",
+      "monthly_pulls": 206,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/calibration",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "canonical",
+      "description": "Ubuntu images from Canonical",
+      "category": "DOCA, NSPECT-X1MD-DWQY",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/doca/canonical",
+      "monthly_pulls": 16708,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/canonical",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "catalog-service",
+      "description": "Run:ai catalog-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/catalog-service",
+      "monthly_pulls": 1297,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/catalog-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cc",
+      "description": "C/C++ distroless image.",
+      "category": "Docker, NSPECT-18J8-QKXS, Application Development, Developer Tools, Distroless",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/1/18/ISO_C%2B%2B_Logo.svg",
+      "image_ref": "nvcr.io/nvidia/distroless/cc",
+      "monthly_pulls": 31140,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cc",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ceph_exporter",
+      "description": "Autonomous Hardware Recovery (AHR) ceph_exporter container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/ceph_exporter",
+      "monthly_pulls": 118,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ceph_exporter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cert-manager-cainjector",
+      "description": "Injects certificate authority data into Kubernetes resources for NVCF Self-Managed.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/cert-manager-cainjector",
+      "monthly_pulls": 87,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cert-manager-cainjector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cert-manager-controller",
+      "description": "Manages Kubernetes certificates and issuers for NVCF Self-Managed.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/cert-manager-controller",
+      "monthly_pulls": 81,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cert-manager-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cert-manager-startupapicheck",
+      "description": "Verifies cert-manager APIs are ready during NVCF Self-Managed installation.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/cert-manager-startupapicheck",
+      "monthly_pulls": 88,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cert-manager-startupapicheck",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cert-manager-webhook",
+      "description": "Validates and converts cert-manager resources for NVCF Self-Managed.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/cert-manager-webhook",
+      "monthly_pulls": 78,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cert-manager-webhook",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "chain-server",
+      "description": "An API server that wraps RAG functionality from LangChain and/or LlamaIndex. Supports file upload to a knowledge base, response generation, and document search.",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/aiworkflows/chain-server",
+      "monthly_pulls": 423,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/chain-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "chat-controller",
+      "description": "ACE Agent Chat Controller orchestrates the end-to-end bot pipeline for a speech IO based bot",
+      "category": "ACE, NSPECT-26IN-0NIY, Automotive / Transportation",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/chat-controller",
+      "monthly_pulls": 1189,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/chat-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "chat-engine",
+      "description": "Chat Engine Microservice drives the conversation flow for bots built using ACE Agent",
+      "category": "ACE, NSPECT-26IN-0NIY",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/chat-engine",
+      "monthly_pulls": 1538,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/chat-engine",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cheminformatics_demo",
+      "description": "Real-time interactive search of chemical space is useful in the pursuit of novel chemical entities. This application demonstrates searching, screening, and organizing a large chemical database of compounds.",
+      "category": "Healthcare, Cheminformatics, Chemistry, Clara Discovery, Clara, Drug Discovery",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Clara.png",
+      "image_ref": "nvcr.io/nvidia/clara/cheminformatics_demo",
+      "monthly_pulls": 1723,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cheminformatics_demo",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "chroma",
+      "description": "CHROMA is a Physics application designed for solving the theory of quarks and gluons.",
+      "category": "x86_64, arm64, HPC, Manufacturing, NSPECT-TIWE-2XGO, High Performance Computing, HPC / Supercomputing",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/chroma",
+      "monthly_pulls": 321,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/chroma",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "clara-parabricks",
+      "description": "NVIDIA Parabricks is an accelerated compute framework that supports applications across the genomics industry, primarily supporting analytical workflows for DNA, RNA, and somatic mutation detection applications.",
+      "category": "Drug Discovery, Healthcare, NVIDIA AI Enterprise Supported, Parabricks, Life Sciences, HPC, Genomics, NVIDIA AI, High Performance Computing, Genome Sequencing, NSPECT-YJGV-BUM5, HPC / Supercomputing",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Parabricks.png",
+      "image_ref": "nvcr.io/nvidia/clara/clara-parabricks",
+      "monthly_pulls": 89663,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/clara-parabricks",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "clara-parabricks-deepsap",
+      "description": "DeepSAP is a transformer-based workflow designed to enhance splice junction detection in RNA-seq data.",
+      "category": "NSPECT-CWKM-PN83, Healthcare, Parabricks, NVIDIA AI Enterprise Supported, Genomics, NVIDIA AI, Genome Sequencing",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Parabricks.png",
+      "image_ref": "nvcr.io/nvidia/clara/clara-parabricks-deepsap",
+      "monthly_pulls": 1056,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/clara-parabricks-deepsap",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "clara-parabricks-umi-fgbio",
+      "description": "Parabricks Umi_Fgbio is a pipeline that processes sequencing reads with molecular barcodes, and provides impressive error correction and increased accuracy using a sequencing consensus read level.",
+      "category": "Healthcare, High Performance Computing, Life Sciences, NVIDIA AI Enterprise Supported, HPC, Genomics, NSPECT-0S9C-XAVB, Clara Parabricks",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Parabricks.png",
+      "image_ref": "nvcr.io/nvidia/clara/clara-parabricks-umi-fgbio",
+      "monthly_pulls": 250,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/clara-parabricks-umi-fgbio",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "clara-train-sdk-devel",
+      "description": "Please add description",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/clara-train-sdk-devel",
+      "monthly_pulls": 1672,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/clara-train-sdk-devel",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cli-exposer",
+      "description": "Run:ai cli-exposer container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/cli-exposer",
+      "monthly_pulls": 1786,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cli-exposer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "client",
+      "description": "OSMO container to enable CLIs",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/client",
+      "monthly_pulls": 54184,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/client",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cloudxr-runtime",
+      "description": "CloudXR Runtime container enables streaming virtual reality (VR) and augmented reality (AR) contents over the internet.",
+      "category": "Cloud Services, NSPECT-ZIMA-BGNZ, Application Streaming, Kubernetes Infrastructure, Robotics, Data Collection, Extended Reality, Isaac",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cloudxr-runtime",
+      "monthly_pulls": 2326,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cloudxr-runtime",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cluster-api",
+      "description": "Run:ai cluster-api container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/cluster-api",
+      "monthly_pulls": 8343,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cluster-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cluster-migrator",
+      "description": "Run:ai cluster-migrator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/cluster-migrator",
+      "monthly_pulls": 1158,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cluster-migrator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cluster-service",
+      "description": "Run:ai cluster-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/cluster-service",
+      "monthly_pulls": 1401,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cluster-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cluster-sync",
+      "description": "Run:ai cluster-sync container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/cluster-sync",
+      "monthly_pulls": 15654,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cluster-sync",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cntk",
+      "description": "The Microsoft Cognitive Toolkit, formerly known as CNTK, is a unified deep-learning toolkit that describes neural networks as a series of computational steps via a directed graph.",
+      "category": "DL",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/ISV-OSS-Non-Nvidia-Publishing-Microsoft-Cognitive-Toolkit.png",
+      "image_ref": "nvcr.io/nvidia/cntk",
+      "monthly_pulls": 1012,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cntk",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "compute-eval",
+      "description": "NVIDIA NeMo Evaluator-compatible container with compute-eval support. Based on compute-eval available at: https://github.com/NVIDIA/compute-eval",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/compute-eval",
+      "monthly_pulls": 1186,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/compute-eval",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "container-toolkit",
+      "description": "Build and Run GPU Accelerated Docker Containers.",
+      "category": "NVIDIA AI Enterprise Supported, NSPECT-JIRW-DCW5, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/k8s/container-toolkit",
+      "monthly_pulls": 12465702,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/container-toolkit",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "contamination-detection",
+      "description": "NVIDIA NeMo Evaluator-compatible container with CoDeC support.",
+      "category": "Data Contamination, NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/contamination-detection",
+      "monthly_pulls": 461,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/contamination-detection",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "context-injector",
+      "description": "Tokkio Context Injector responsible for maintaining application context within the tokkio application",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/context-injector",
+      "monthly_pulls": 3514,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/context-injector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "controller-ui",
+      "description": "This container provides a browser-based application that uses NMOS APIs to discover, connect and manage resources within a networked media system. For more information on the Networked Media Open Specifications, see https://www.amwa.tv/nmos-overview.",
+      "category": "Broadcast, NMOS, AMWA, NSPECT-KEM4-ITAL, Media & Entertainment, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/pwk8kpq5rz/web/NVIDIA-Logo-V-ForScreen-ForLightBG.png?color=ffffffff",
+      "image_ref": "nvcr.io/nvidia/holoscan-for-media/controller-ui",
+      "monthly_pulls": 1282,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/controller-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "conundrum-aircraftengine-cuda10-pytorch11",
+      "description": "Conundrum Deep Learning based Predictive Maintenance Demo using NASA-Turbofan Engine Degradation Simulation dataset",
+      "category": "AI, DL, Predictive Maintenance, Simulation, Industrial, PHM08 Dataset, Aircraft Engine, Smart Cities / Spaces",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/ISV-OSS-Non-Nvidia-Publishing-Conundrum.png",
+      "image_ref": "nvcr.io/nvidia/conundrum-aircraftengine-cuda10-pytorch11",
+      "monthly_pulls": 236,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/conundrum-aircraftengine-cuda10-pytorch11",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cosmos-cds-ui",
+      "description": "The NVIDIA Cosmos Dataset Search Blueprint enables Physical AI developers to perform semantic search on large scale visual data. The UI service provides an intuitive way to search and iterate visually.",
+      "category": "AI, Object Detection, Automotive / Transportation, NVIDIA AI Enterprise Supported, Vision AI, NVIDIA AI, Robotics, NSPECT-BTD0-AI1I, Action Recognition, Computer Vision",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/cosmos-cds-ui",
+      "monthly_pulls": 230,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cosmos-cds-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cosmos-curator",
+      "description": "A powerful video curation system that processes, analyzes, and organizes video content using advanced AI models and distributed computing.",
+      "category": "AI, Vision AI, Video Analytics, Computer Vision",
+      "logo_url": "https://assets.ngc.nvidia.com/products/catalog/logos/nvidia.png",
+      "image_ref": "nvcr.io/nvidia/cosmos/cosmos-curator",
+      "monthly_pulls": 73,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cosmos-curator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cosmos-dataset-search",
+      "description": "The NVIDIA Cosmos Dataset Search Blueprint enables Physical AI developers to perform semantic search on large scale visual data. The visual search service orchestrates the overall solution.",
+      "category": "AI, Object Detection, Automotive / Transportation, NVIDIA AI Enterprise Supported, Vision AI, NVIDIA AI, Robotics, NSPECT-BTD0-AI1I, Action Recognition, Computer Vision",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/cosmos-dataset-search",
+      "monthly_pulls": 287,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cosmos-dataset-search",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cosmos-predict2-container",
+      "description": "The container image to run inference and post training on Cosmos-Predict2.",
+      "category": "NSPECT-72FQ-Z3GK",
+      "logo_url": "https://nvdam.widen.net/content/xbsnft8sm2/jpeg/cosmos-thumbnail-274x152.jpeg?position=c&color=ffffffff&quality=100&u=hdilxr&use=c2ccj",
+      "image_ref": "nvcr.io/nvidia/cosmos/cosmos-predict2-container",
+      "monthly_pulls": 2423,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cosmos-predict2-container",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "create-render",
+      "description": "Omniverse Create Render farm job container",
+      "category": "Omniverse, Rendering, Automotive / Transportation, Farm",
+      "logo_url": "https://nvdam.widen.net/content/m6b2kn7mia/jpeg/nvidia-omniverse-farm-lockup-rgb-blk-for-screen.jpg?color=ffffffff&u=iowahy&use=l4e2p&position=c&quality=100",
+      "image_ref": "nvcr.io/nvidia/omniverse/create-render",
+      "monthly_pulls": 254,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/create-render",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuda",
+      "description": "Container registry for CUDA images",
+      "category": "CUDA, NVIDIA AI Enterprise Supported, NSPECT-2IV4-ZWKR",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cuda",
+      "monthly_pulls": 7435586,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuda-dl-base",
+      "description": "CUDA is a parallel computing platform and programming model that enhances computing performance using NVIDIA GPUs. CUDA Deep Learning integrates networking and GPU-accelerated libraries like cuDNN, cuTensor, NCCL, HPC-x, and the CUDA Toolkit.",
+      "category": "CUDA, AI, DL, High Performance Computing, NVIDIA AI Enterprise Supported, NVIDIA AI, DLFW, Application Development, DGX Spark Supported, CUDA Toolkit",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Cuda.png",
+      "image_ref": "nvcr.io/nvidia/cuda-dl-base",
+      "monthly_pulls": 216833,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-dl-base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuda-dl-base-pb25h1",
+      "description": "CUDA Production Branch May 2025 (PB 25h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities. This release is a branch of CUDA DL 25.03.",
+      "category": "CUDA, DL, NVIDIA AI Enterprise Supported, NVIDIA AI, NSPECT-54WV-LXOW",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FCuda.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/cuda-dl-base-pb25h1",
+      "monthly_pulls": 2221,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-dl-base-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuda-dl-base-pb25h2",
+      "description": "CUDA DL Production Branch October 2025 (PB 25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "CUDA, AI, DL, FIPS, NVIDIA AI Enterprise Supported, Production Branch, STIG, NSPECT-54WV-LXOW, gov_ready, Government Ready",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FCuda.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/cuda-dl-base-pb25h2",
+      "monthly_pulls": 3199,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-dl-base-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuda-dl-base-pb6",
+      "description": "CUDA DL Production Branch 6 offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "CUDA, FIPS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, STIG, NSPECT-54WV-LXOW, gov_ready, Government Ready",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FCuda.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/cuda-dl-base-pb6",
+      "monthly_pulls": 234,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-dl-base-pb6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuda-quantum",
+      "description": "Pre-release versions of CUDA Quantum. This container includes features that are currently under development.",
+      "category": "AI/ML",
+      "logo_url": "https://raw.githubusercontent.com/sam-stanwyck/cudaq-logo/main/cudaqlogo.png?token=GHSAT0AAAAAACAJEF2IAYD3D6L37J5MHRP2ZAYOEVQ",
+      "image_ref": "nvcr.io/nvidia/nightly/cuda-quantum",
+      "monthly_pulls": 25797,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cudagl",
+      "description": "CUDA is a parallel computing platform and programming model that enables dramatic increases in computing performance by harnessing the power of the NVIDIA GPUs. These images extend the CUDA images to include OpenGL support through libglvnd.",
+      "category": "DL, HPC, Inference, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Cuda.png",
+      "image_ref": "nvcr.io/nvidia/cudagl",
+      "monthly_pulls": 33046,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cudagl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuopt",
+      "description": "NVIDIA® cuOpt™ is an open-source, GPU-accelerated engine for decision optimization designed to tackle large-scale problems with millions of variables and constraints.",
+      "category": "Automotive / Transportation, Aerospace, Robotics, High Performance Computing, Energy, Smart Cities / Spaces, Restaurant / Quick-Service, cuOpt, NVIDIA AI Enterprise Supported, Retail, GPU Accelerated Libraries, NSPECT-071A-1ZFZ, NSPECT-LZ5P-VOVE",
+      "logo_url": "https://assets.ngc.nvidia.com/products/catalog/images/cuopt.jpg",
+      "image_ref": "nvcr.io/nvidia/cuopt/cuopt",
+      "monthly_pulls": 9426,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuopt",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cuquantum-appliance",
+      "description": "The NVIDIA cuQuantum Appliance is a highly performant multi-GPU multi-node solution for quantum circuit simulation.",
+      "category": "Quantum Computing, Container Toolkit, High Performance Computing, Application Development, GPU Accelerated Libraries, NSPECT-3MF0-KL97, Academia / Higher Education, HPC / Supercomputing",
+      "logo_url": "https://developer.nvidia.com/sites/default/files/akamai/nvidia-cuquantum-icon.svg",
+      "image_ref": "nvcr.io/nvidia/cuquantum-appliance",
+      "monthly_pulls": 19473,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuquantum-appliance",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "customizer",
+      "description": "Model customization for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, Fine Tuning, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/customizer",
+      "monthly_pulls": 3964,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/customizer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "customizer-api",
+      "description": "API service for NeMo Customizer",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/customizer-api",
+      "monthly_pulls": 3562,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/customizer-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "customizer-automodel",
+      "description": "Model customization for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, Fine Tuning, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/customizer-automodel",
+      "monthly_pulls": 174,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/customizer-automodel",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "customizer-gpt-oss",
+      "description": "Model customization for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, Fine Tuning, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/customizer-gpt-oss",
+      "monthly_pulls": 504,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/customizer-gpt-oss",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "customizer-rl",
+      "description": "Model customization for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, Fine Tuning, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/customizer-rl",
+      "monthly_pulls": 190,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/customizer-rl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cybersecurity-dfp-mock-data",
+      "description": "The DFP Pipeline container image contains a compiled Morpheus pipeline that is designed to do DFP analysis on Azure AD logs being streamed in via Kafka.",
+      "category": "AI/ML",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/security-digital-fingerprinting-ai-workflow-no-copy-social-tw-1200x675-2686270.jpg",
+      "image_ref": "nvcr.io/nvidia/cybersecurity-dfp-mock-data",
+      "monthly_pulls": 590,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cybersecurity-dfp-mock-data",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cybersecurity-dfp-pipeline",
+      "description": "The DFP Pipeline container image contains a compiled Morpheus pipeline that is designed to do DFP analysis on Azure AD logs being streamed in via Kafka.",
+      "category": "AI/ML",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/security-digital-fingerprinting-ai-workflow-no-copy-social-tw-1200x675-2686270.jpg",
+      "image_ref": "nvcr.io/nvidia/cybersecurity-dfp-pipeline",
+      "monthly_pulls": 373,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cybersecurity-dfp-pipeline",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "cybersecurity-sp-pipeline",
+      "description": "The Spear Phishing Pipeline container image contains a compiled Morpheus pipeline that is designed to act as a Postfix SMTP e-mail content filter and mock e-mail generator.",
+      "category": "AI/ML",
+      "logo_url": "https://www.nvidia.com/en-us/ai-data-science/ai-workflows/_jcr_content/root/responsivegrid/nv_container_248214577/nv_container/nv_teaser_1315537288.coreimg.100.1070.jpeg/1694534901919/spear-phishing-for-ai-workflow-2560x1440.jpeg",
+      "image_ref": "nvcr.io/nvidia/cybersecurity-sp-pipeline",
+      "monthly_pulls": 321,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cybersecurity-sp-pipeline",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dali-pytorch",
+      "description": "This container contains notebooks to be used alongside an instructor-led NVIDIA DALI workshop and may not contain an up to date DALI version. If you want to use DALI with an NGC container, please check the latest Tensorflow, MxNet, and PyTorch NGC containers - which all contain it, or just download DALI directly.",
+      "category": "DALI, Computer Vision, Data Pipelining",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Dali.png",
+      "image_ref": "nvcr.io/nvidia/dali-pytorch",
+      "monthly_pulls": 343,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dali-pytorch",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dashboard",
+      "description": "AJR UI dashboard",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/dashboard",
+      "monthly_pulls": 198,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dashboard",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "data-designer",
+      "description": "Synthetic data generation",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, Synthetic Data Generation, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/data-designer",
+      "monthly_pulls": 2632,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/data-designer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "data-mover",
+      "description": "The data-mover tool enables users to ingest their datasets into BCP and use them within their assigned ACE.",
+      "category": "NSPECT-I5K2-14OP",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-p@2x.png",
+      "image_ref": "nvcr.io/nvidia/datamover/data-mover",
+      "monthly_pulls": 21179,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/data-mover",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "database",
+      "description": "Database REST API Container",
+      "category": "Cosmos Evaluator",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cosmos/database",
+      "monthly_pulls": 38,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/database",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "database-postgres",
+      "description": "Postgres Database Container",
+      "category": "cosmos evaluator",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cosmos/database-postgres",
+      "monthly_pulls": 43,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/database-postgres",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "datastore",
+      "description": "Data storage for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/datastore",
+      "monthly_pulls": 4735,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/datastore",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "datavolumes-service",
+      "description": "Run:ai datavolumes-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/datavolumes-service",
+      "monthly_pulls": 1439,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/datavolumes-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "db-mechanic",
+      "description": "Run:ai db-mechanic container image",
+      "category": "NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/db-mechanic",
+      "monthly_pulls": 1022,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/db-mechanic",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dcgm",
+      "description": "Manage and Monitor GPUs in Cluster Environments.",
+      "category": "NSPECT-XBPM-A7QQ, Automotive / Transportation, NVIDIA AI Enterprise Supported",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/DCGM.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/dcgm",
+      "monthly_pulls": 5291606,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dcgm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dcgm-exporter",
+      "description": "Monitor GPUs in Kubernetes using NVIDIA DCGM. This is an exporter for a Prometheus monitoring solution in Kubernetes.",
+      "category": "Training, NVIDIA AI Enterprise Supported, K8s, NSPECT-011U-HOBK, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/DCGM.png",
+      "image_ref": "nvcr.io/nvidia/k8s/dcgm-exporter",
+      "monthly_pulls": 315648300,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dcgm-exporter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ddcs-dist-kv",
+      "description": "Container for DDCS",
+      "category": "NSPECT-SRJE-WI5W, NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/ddcs-dist-kv",
+      "monthly_pulls": 1672,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ddcs-dist-kv",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepsearch-renderer",
+      "description": "Omniverse DeepSearch farm job container",
+      "category": "Omniverse, Rendering, Automotive / Transportation, Farm",
+      "logo_url": "https://nvdam.widen.net/content/m6b2kn7mia/jpeg/nvidia-omniverse-farm-lockup-rgb-blk-for-screen.jpg?color=ffffffff&u=iowahy&use=l4e2p&position=c&quality=100",
+      "image_ref": "nvcr.io/nvidia/omniverse/deepsearch-renderer",
+      "monthly_pulls": 339,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepsearch-renderer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepstream",
+      "description": "DeepStream SDK delivers a complete streaming analytics toolkit for AI based video and image understanding and multi-sensor processing. This container is for NVIDIA Enterprise GPUs.",
+      "category": "Optical Inspection, Object Detection, DeepStream, Smart Cities, Inference, Machine Learning, NSPECT-FIKD-PK1E, Retail, AI, Retail Analytics, NVIDIA AI Enterprise Supported, Classification, Toolkit, Computer Vision",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/deepstream",
+      "monthly_pulls": 329811,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepstream-l4t",
+      "description": "DeepStream SDK delivers a complete streaming analytics toolkit for real-time AI based video and image understanding and multi-sensor processing. This container is for NVIDIA Jetson platform.",
+      "category": "Optical Inspection, Object Detection, Inference, Deepstream, Machine Learning, Autonomous Machines, NSPECT-FIKD-PK1E, Retail, Retail Analytics, Jetson, Classification, Toolkit, Embedded, ARM, Computer Vision",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/deepstream-l4t",
+      "monthly_pulls": 61393,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream-l4t",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepstream-pb24h2",
+      "description": "DeepStream SDK delivers a complete streaming analytics toolkit for AI based video and image understanding and multi-sensor processing. This container is for NVIDIA Enterprise GPUs.",
+      "category": "Optical Inspection, Object Detection, Production Branch, Computer Vision, Machine Learning, Smart Cities / Spaces, NSPECT-FIKD-PK1E, Retail Analytics, NVIDIA AI Enterprise Supported, Classification, Retail, Toolkit, ML, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/deepstream-pb24h2",
+      "monthly_pulls": 807,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepstream-pb25h1",
+      "description": "DeepStream May 2025 (PB25h1)",
+      "category": "NSPECT-FIKD-PK1E, DeepStream, NVIDIA AI Enterprise Supported",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/deepstream-pb25h1",
+      "monthly_pulls": 453,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepstream-peopledetection",
+      "description": "DeepStream People Detection Demo container showcasing people detection running on Jetson.",
+      "category": "DeepStream, DL, Object Detection, Computer Vision, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/deepstream-peopledetection",
+      "monthly_pulls": 715,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream-peopledetection",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepstream_360d",
+      "description": "The Smart Parking Detection container includes the DeepStream application and the plugins for an example application of a smart parking solution.",
+      "category": "DeepStream, IVA, SDK, Smart Cities / Spaces",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/deepstream_360d",
+      "monthly_pulls": 553,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream_360d",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deepvariant_train",
+      "description": "This container is used for running the data preprocessing part of DeepVariant Training pipeline including make_examples and shuffle",
+      "category": "Healthcare, Parabricks, NVIDIA AI Enterprise Supported, Genomics, NSPECT-NCUX-AJJM",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Parabricks.png",
+      "image_ref": "nvcr.io/nvidia/clara/deepvariant_train",
+      "monthly_pulls": 808,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepvariant_train",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "delayed-job-monitor",
+      "description": "OSMO container to monitor and clean up all jobs exceeding the timeouts",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/delayed-job-monitor",
+      "monthly_pulls": 58801,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/delayed-job-monitor",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deplot",
+      "description": "NVIDIA NIM for GPU accelerated Deplot inference through OpenAI compatible APIs",
+      "category": "Object Detection, NSPECT-Q0O5-32WR, Automotive / Transportation, Natural Language Understanding",
+      "logo_url": "https://assets.ngc.nvidia.com/products/catalog/images/google-deplot.jpg",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/deplot",
+      "monthly_pulls": 128,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deplot",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deployment-api",
+      "description": "deployment-api is a container that runs as part of the Dynamo cloud platform, a k8s platform for deploying and managing inference services. It runs the Dynamo API store, a service that stores and manages service configurations, metadata and artifacts.",
+      "category": "NSPECT-9EST-K1WZ",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/20237/64e3dc1a3d6332319b2dfd35_NVIDIA-logo-white-16x9/NVIDIA-logo-white-16x9_927581a6-fc31-4fa5-85c6-379680c6aa6c-prv.png",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/deployment-api",
+      "monthly_pulls": 324,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deployment-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "deployment-management",
+      "description": "Deployment management microservice for NeMo models",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/deployment-management",
+      "monthly_pulls": 3593,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deployment-management",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "devel",
+      "description": "TensorRT LLM provides users with an easy-to-use Python API to define Large Language Models (LLMs) and supports state-of-the-art optimizations to perform inference efficiently on NVIDIA GPUs.",
+      "category": "AI, DL, PyTorch, Application Development, TensorRT, LLM Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/tensorrt-llm/devel",
+      "monthly_pulls": 17073,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/devel",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "device-plugin",
+      "description": "Run:ai device-plugin container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/device-plugin",
+      "monthly_pulls": 651,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/device-plugin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dgl",
+      "description": "Deep Graph Library (DGL) is a Python package built for the implementation and training of graph neural networks on top of existing DL frameworks. The DGL NGC Container is built with the latest versions of DGL, PyTorch, and their dependencies.",
+      "category": "DL, Automotive / Transportation, NVIDIA AI Enterprise Supported, DLFW, NSPECT-K7L7-L12G, ML",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2021/10/nvida-and-dgl-acceleration.jpg",
+      "image_ref": "nvcr.io/nvidia/dgl",
+      "monthly_pulls": 9091,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dgl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dgl-pb24h2",
+      "description": "DGL Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "DL, NVIDIA AI Enterprise Supported, Production Branch, NSPECT-K7L7-L12G",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2021/10/nvida-and-dgl-acceleration.jpg",
+      "image_ref": "nvcr.io/nvidia/dgl-pb24h2",
+      "monthly_pulls": 3416,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dgl-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dgxc-admission-controller",
+      "description": "Multi-node training admission controller for DGX Cloud",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, DGX Cloud, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/dgxc-admission-controller",
+      "monthly_pulls": 658,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dgxc-admission-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dgxc-cp-config-fetcher",
+      "description": "This container is part of Runai product",
+      "category": "NSPECT-XKV4-HDZH, INFRASTRUCTURE",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/dgxc-cp-config-fetcher",
+      "monthly_pulls": 195,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dgxc-cp-config-fetcher",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "diagnostics-service",
+      "description": "Run:ai diagnostics-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/diagnostics-service",
+      "monthly_pulls": 1204,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/diagnostics-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "digits",
+      "description": "The NVIDIA Deep Learning GPU Training System (DIGITS) puts the power of deep learning into the hands of engineers and data scientists.",
+      "category": "Segmentation, Classification",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Digits.png",
+      "image_ref": "nvcr.io/nvidia/digits",
+      "monthly_pulls": 41341,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/digits",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dli-cai",
+      "description": "Base environment of the NVIDIA Deep Learning Institute (DLI) course, \"Building Conversational AI Applications\". This container also includes a \"Next Steps\" project.",
+      "category": "Healthcare, AI, DL, Financial Services, Natural Language Processing, Kubernetes Infrastructure, Natural Language Understanding, ML, Conversational AI",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deep-Learning-Institute.png",
+      "image_ref": "nvcr.io/nvidia/dli/dli-cai",
+      "monthly_pulls": 139,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dli-cai",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dli-data-engineering",
+      "description": "Base environment used in the NVIDIA Deep Learning Institute (DLI) Course Accelerating Data Engineering Pipelines, along with other useful libraries for aspiring and professional Data Engineers.",
+      "category": "Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deep-Learning-Institute.png",
+      "image_ref": "nvcr.io/nvidia/dli/dli-data-engineering",
+      "monthly_pulls": 197,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dli-data-engineering",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dli-nano-ai",
+      "description": "Course environment for the Deep Learning Institute (DLI) course, \"Getting Started with AI on Jetson Nano\".",
+      "category": "PyTorch, Facial Landmark Estimation, Vision AI, Manufacturing, Retail, Robotics, Deep Learning Institute, Computer Vision",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deep-Learning-Institute.png",
+      "image_ref": "nvcr.io/nvidia/dli/dli-nano-ai",
+      "monthly_pulls": 6869,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dli-nano-ai",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dli-nano-deepstream",
+      "description": "Course environment for the Deep Learning Institute (DLI) course, \"Building Video AI Applications at the Edge on Jetson Nano\".",
+      "category": "AI, DL, Object Detection, Computer Vision, Smart Cities / Spaces",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deep-Learning-Institute.png",
+      "image_ref": "nvcr.io/nvidia/dli/dli-nano-deepstream",
+      "monthly_pulls": 1009,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dli-nano-deepstream",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dli-nlp-nemo",
+      "description": "Base environment used in the NVIDIA NeMo projects of the NVIDIA Deep Learning Institute (DLI) course, \"Building Transformer-Based Natural Language Processing Applications\".  This container also includes a \"Next Steps\" project.",
+      "category": "AI, DL, BioMegatron, Natural Language Processing, Natural Language Understanding, BERT, Deep Learning Institute",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deep-Learning-Institute.png",
+      "image_ref": "nvcr.io/nvidia/dli/dli-nlp-nemo",
+      "monthly_pulls": 275,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dli-nlp-nemo",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dli-recommender-systems",
+      "description": "Base environment used in the NVIDIA Deep Learning Institute (DLI) Course Building Intelligent Recommender Systems, along with Next Steps project.",
+      "category": "Recommendation, Data Frames, Jupyter, CuPy, Deep Learning Institute, TensorFlow, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deep-Learning-Institute.png",
+      "image_ref": "nvcr.io/nvidia/dli-recommender-systems",
+      "monthly_pulls": 320,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dli-recommender-systems",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dns-logger",
+      "description": "NVCF DNS Logger",
+      "category": "NSPECT-OW8S-JYHG",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/dns-logger",
+      "monthly_pulls": 105,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dns-logger",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca",
+      "description": "DOCA enables the development of applications that deliver breakthrough networking, security, and storage performance by harnessing the power of the NVIDIA DPUs.",
+      "category": "DOCA, DPU, NSPECT-X1MD-DWQY, Hardware / Semiconductor",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca",
+      "monthly_pulls": 65835,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca-driver",
+      "description": "NVIDIA DOCA-OFED Driver for NVIDIA Network Adapters\nThe NVIDIA DOCA-OFED driver container offers an alternative to the traditional DOCA-Host package-based installation by simply deploying a containerized driver image on the host.",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported, DOCA, Network Operator",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/mellanox/doca-driver",
+      "monthly_pulls": 104239,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca-driver",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca-driver-stig-fips",
+      "description": "Provision the NVIDIA DOCA-OFED driver using containers.",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported, DOCA, Network Operator, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/doca-driver-stig-fips",
+      "monthly_pulls": 1145,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca-driver-stig-fips",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_argus",
+      "description": "DOCA Argus utilizes Bluefield DPU for real-time, hardware-level memory forensics, ensuring robust, integrated security for AI workloads and microservices without impacting performance or requiring host agents.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-X1MD-DWQY",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_argus",
+      "monthly_pulls": 392,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_argus",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_blueman_conv",
+      "description": "The DOCA BlueMan Converter service converts DOCA BlueMan-Frontend requests from http to gRPC.",
+      "category": "DOCA Service, DOCA, DPU, Tools and Management, NSPECT-3QPM-YIPX",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_blueman_conv",
+      "monthly_pulls": 1418,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_blueman_conv",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_blueman_fe",
+      "description": "The DOCA BlueMan service is a simple and user-friendly standalone web dashboard that runs completely on NVIDIA's DPU, transparent to the host. The service consolidates all the information an admin needs to know and serves as a one stop shop.",
+      "category": "DOCA Service, DOCA, DPU, Tools and Management, NSPECT-3QPM-YIPX",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_blueman_fe",
+      "monthly_pulls": 1625,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_blueman_fe",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_firefly",
+      "description": "The DOCA Firefly service provides time synchronization services leveraging the hardware acceleration of the NVIDIA DPUs.",
+      "category": "NSPECT-X1MD-DWQY",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_firefly",
+      "monthly_pulls": 17733,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_firefly",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_flow_inspector",
+      "description": "The DOCA Flow Inspector service allows monitoring real-time data and the extraction of telemetry components which can be utilized by various services for security, big data and many more telemetry-based services.",
+      "category": "DOCA Service, DOCA, DPU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_flow_inspector",
+      "monthly_pulls": 786,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_flow_inspector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_hbn",
+      "description": "Host based networking (HBN) is a DOCA Service that runs on NVIDIA's DPU. It orchestrates network connectivity of dynamically created VMs/Containers on cloud servers. HBN service is a BGP router that supports EVPN extension to enable multi-tenant cloud.",
+      "category": "Cloud Services, DOCA Service, NVIDIA AI Enterprise Supported, DOCA, DPU, NSPECT-EW28-0EMC, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_hbn",
+      "monthly_pulls": 123467,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_hbn",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_nvmf_target_offload",
+      "description": "NVIDIA® BlueField® enables hardware acceleration for the NVMe-oF (Non-Volatile Memory Express over Fabrics) target application. NVMe-oF RoCE/RDMA packets are processed by BlueField® hardware and passed directly from the network to the storage disk drives.",
+      "category": "DOCA, NSPECT-77LK-Y6E4",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_nvmf_target_offload",
+      "monthly_pulls": 375,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_nvmf_target_offload",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_snap",
+      "description": "NVMe/virtio-blk Storage-defined Network Accelerated Processing (SNAP) Service is based on NVIDIA's DPU and enables hardware-accelerated virtualization of local storage. Resulting in enhanced storage and networking efficiency and performance.",
+      "category": "DOCA Service, NSPECT-U3UQ-LRFO, NVIDIA AI Enterprise Supported, DOCA, DPU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_snap",
+      "monthly_pulls": 2821,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_snap",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_telemetry",
+      "description": "DOCA Telemetry Service (DTS) is a DOCA Service for collecting and exporting telemetry data. Both predefined and user-defined telemetry counters are available and the export is made by Prometheus, Fluent Bit, Open Telemetry and netflow.",
+      "category": "NSPECT-SYCV-CCZS, DOCA Service, NVIDIA AI Enterprise Supported, DOCA, DPU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_telemetry",
+      "monthly_pulls": 178368,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_telemetry",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_urom",
+      "description": "DOCA UROM Service is an instance of the service framework for offloading High-Performance Computing computations directly from the host and to the DPU. Running on the DPU and responsible for discovering resources, managing the workers, etc.",
+      "category": "HPC, DOCA, DOCA Services, DPU, HPC / Supercomputing",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_urom",
+      "monthly_pulls": 188,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_urom",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "doca_vfs",
+      "description": "NVIDIA® BlueField® DOCA SNAP Virtio-fs technology enables hardware-accelerated virtualization of local file system.",
+      "category": "DOCA Service, NVIDIA AI Enterprise Supported, DOCA, DPU, NSPECT-7UX2-DMPY",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/doca_vfs",
+      "monthly_pulls": 915,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/doca_vfs",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dpf-cni-installer",
+      "description": "CNI installer container for DPF",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/doca/dpf-cni-installer",
+      "monthly_pulls": 1040,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dpf-cni-installer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dpf-keepalived",
+      "description": "DOCA Platform Framework enables the management of NVIDIA DPUs and the services that run on them at scale.\n\nDPF keepalived is a component used in DPF to provide a highly available virtual IP for DPUCluster control-plane endpoints.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/dpf-keepalived",
+      "monthly_pulls": 231,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dpf-keepalived",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dpf-system",
+      "description": "DOCA Platform Framework enables the management of NVIDIA DPUs and the services that run on them at scale.\n\nDPF System contains the main system components for DPF.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/dpf-system",
+      "monthly_pulls": 66574,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dpf-system",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dpf_containers",
+      "description": "DOCA Base Distroless Image for DPF",
+      "category": "DOCA, NSPECT-H0M6-TQAU",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/dpf_containers",
+      "monthly_pulls": 47748,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dpf_containers",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dpl_dev",
+      "description": "DPL Development is an NVIDIA® container image that bundles several tools for compiling, controlling and debugging DPL applications.",
+      "category": "DPL, Cloud Services, DOCA Service, NSPECT-8VVD-N93I, NSPECT-0HWF-ERPG, P4, Developer Tools, DOCA, DPU",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/dpl_dev",
+      "monthly_pulls": 891,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dpl_dev",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dpl_rt_service",
+      "description": "The DOCA Pipeline Language Runtime Service (DPL RT Service) is an NVIDIA® BlueField® service that implements the backend functionality to manage and program the DPU datapath.",
+      "category": "DPL, Cloud Services, NSPECT-1BKK-GWW2, DOCA Service, Networking, P4, DOCA, DPU",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/dpl_rt_service",
+      "monthly_pulls": 996,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dpl_rt_service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dps-bmc-simulator",
+      "description": "DPS-BMC-Simulator",
+      "category": "HPC, Tools and Management, NSPECT-3KNY-RHQB, High Performance Computing, HPC / Supercomputing",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dps-bmc-simulator",
+      "monthly_pulls": 2894,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dps-bmc-simulator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dps-docs",
+      "description": "The Domain Power Service (DPS) is a project by NVIDIA that aims to make power use and performance better in large datacenters.",
+      "category": "HPC, Tools and Management, NSPECT-3KNY-RHQB, High Performance Computing, HPC / Supercomputing",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dps-docs",
+      "monthly_pulls": 268,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dps-docs",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dps-server",
+      "description": "The Domain Power Service (DPS) is a project by NVIDIA that aims to make power use and performance better in large datacenters.",
+      "category": "DPS, HPC, Tools and Management, NSPECT-3KNY-RHQB, High Performance Computing, HPC / Supercomputing",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dps-server",
+      "monthly_pulls": 3294,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dps-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dps-ui",
+      "description": "The Domain Power Service (DPS) is a project by NVIDIA that aims to make power use and performance better in large datacenters.",
+      "category": "HPC, Tools and Management, NSPECT-3KNY-RHQB, High Performance Computing, HPC / Supercomputing",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dps-ui",
+      "monthly_pulls": 2825,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dps-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dpsctl",
+      "description": "NVIDIA Domain Power Service (DPS) CLI",
+      "category": "High Performance Computing, DPS, HPC, Tools and Management, NSPECT-3KNY-RHQB, DCGM, Energy",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dpsctl",
+      "monthly_pulls": 480,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dpsctl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dra-driver-nvidia-gpu",
+      "description": "DRA Driver for NVIDIA GPUs",
+      "category": "NSPECT-N13T-XM50, Kubernetes Infrastructure, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dra-driver-nvidia-gpu",
+      "monthly_pulls": 472,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dra-driver-nvidia-gpu",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "driver",
+      "description": "Provision NVIDIA GPU Driver as a Container",
+      "category": "Automotive / Transportation, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-TTR3-FBEO, Infrastructure Software, Multi-Arch",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/driver",
+      "monthly_pulls": 8659452,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ds_deployment_demo",
+      "description": "How to deploy pre-trained models from NGC into an intelligent video analytics (IVA) pipeline in DeepStream",
+      "category": "DeepStream, intelligent video analytics, iva, npn",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/ds_deployment_demo",
+      "monthly_pulls": 508,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ds_deployment_demo",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dynamo-frontend",
+      "description": "The Dynamo frontend image is a framework-less image which contains core Dynamo components along with Endpoint Picker (EPP) for Gateway API Inference Extension (GAIE).",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/20237/64e3dc1a3d6332319b2dfd35_NVIDIA-logo-white-16x9/NVIDIA-logo-white-16x9_927581a6-fc31-4fa5-85c6-379680c6aa6c-prv.png",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/dynamo-frontend",
+      "monthly_pulls": 6660,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dynamo-frontend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "dynamo-planner",
+      "description": "The Dynamo Planner image is a containerized build of Planner which serves as the runtime environment for SLA-driven autoscaling of prefill and decode workers in Dynamo's distributed inference framework.",
+      "category": "AI, DL, High Performance Computing, NVIDIA AI, NSPECT-9EST-K1WZ, ML, Inference, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/dynamo-planner",
+      "monthly_pulls": 1248,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/dynamo-planner",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eclair-beta",
+      "description": "ECLAIR is a general purpose text-extraction model, specifically designed to handle documents. Given an image, ECLAIR is able to extract formatted-text, with bounding-boxes and the corresponding semantic class.",
+      "category": "AI, NSPECT-03PN-TNKX, Computer Vision",
+      "logo_url": "https://assets.ngc.nvidia.com/products/api-catalog/images/nemoretriever-parse.jpg",
+      "image_ref": "nvcr.io/nvidia/eclair/eclair-beta",
+      "monthly_pulls": 509,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eclair-beta",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eclipse-mosquitto",
+      "description": "NVIDIA mirror of the Eclipse Mosquitto container",
+      "category": "Robotics",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/omniverse/eclipse-mosquitto",
+      "monthly_pulls": 23226,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eclipse-mosquitto",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "email-service",
+      "description": "Run:ai email-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/email-service",
+      "monthly_pulls": 800,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/email-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "emdx-analytics",
+      "description": "Generate time-series insights for the physical spaces based on perception metadata.",
+      "category": "DeepStream, Vision AI, Robotics, Video Analytics, Metropolis Microservices, Computer Vision, JPS, Metropolis, Smart Cities / Spaces, NSPECT-Q29M-RRKV, Restaurant / Quick-Service, AI, Jetson, Retail",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FJetson.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/jps/emdx-analytics",
+      "monthly_pulls": 1209,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/emdx-analytics",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "emdx-analytics-web-api",
+      "description": "Container for AI Analytics API service",
+      "category": "DeepStream, Vision AI, Robotics, Video Analytics, Metropolis Microservices, Computer Vision, JPS, Metropolis, Smart Cities / Spaces, NSPECT-Q29M-RRKV, Restaurant / Quick-Service, AI, Jetson, Retail",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FJetson.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/jps/emdx-analytics-web-api",
+      "monthly_pulls": 836,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/emdx-analytics-web-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "emdx-analytics_amd64",
+      "description": "Container for Occupancy Alerts service",
+      "category": "NSPECT-Q29M-RRKV, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/emdx-analytics_amd64",
+      "monthly_pulls": 543,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/emdx-analytics_amd64",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "emdx-web-api_amd64",
+      "description": "Container for Occupancy Alerts API service",
+      "category": "NSPECT-Q29M-RRKV, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/emdx-web-api_amd64",
+      "monthly_pulls": 646,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/emdx-web-api_amd64",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "engine-admission",
+      "description": "Run:ai engine-admission container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/engine-admission",
+      "monthly_pulls": 995,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/engine-admission",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "engine-operator",
+      "description": "Run:ai engine-operator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/engine-operator",
+      "monthly_pulls": 13487,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/engine-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "entity-store",
+      "description": "Entity management for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/entity-store",
+      "monthly_pulls": 4295,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/entity-store",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "envoy",
+      "description": "Tokkio Envoy is the proxy service used in the Tokkio Application",
+      "category": "NSPECT-RDWK-7253, ACE, NSPECT-B61D-LIZ2",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/envoy",
+      "monthly_pulls": 4118,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/envoy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "envoy-auth-ext",
+      "description": "Please add description",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/envoy-auth-ext",
+      "monthly_pulls": 144,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/envoy-auth-ext",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "envoy-proxy",
+      "description": "Envoy Proxy -SDR",
+      "category": "Vision AI, NSPECT-B61D-LIZ2",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/envoy-proxy",
+      "monthly_pulls": 2935,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/envoy-proxy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ess-agent",
+      "description": "Provides encrypted application secret injection for NVCF Self-Managed workloads.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/ess-agent",
+      "monthly_pulls": 37,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ess-agent",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ess-api",
+      "description": "Encrypted Secrets Service - Used for application secret injection",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/ess-api",
+      "monthly_pulls": 34,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ess-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-factory-benchmark-agentic-eval",
+      "description": "Evaluation benchmark for agentic systems",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-factory-benchmark-agentic-eval",
+      "monthly_pulls": 278,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-factory-benchmark-agentic-eval",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-factory-benchmark-bfcl",
+      "description": "Evaluation benchmark for BFCL targets.",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-factory-benchmark-bfcl",
+      "monthly_pulls": 273,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-factory-benchmark-bfcl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-tool-benchmark-bigcode",
+      "description": "Evaluation benchmark for code generation models",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-tool-benchmark-bigcode",
+      "monthly_pulls": 571,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-tool-benchmark-bigcode",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-tool-benchmark-custom-eval",
+      "description": "Framework for custom evaluation benchmarks",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-tool-benchmark-custom-eval",
+      "monthly_pulls": 541,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-tool-benchmark-custom-eval",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-tool-benchmark-llm-as-a-judge",
+      "description": "Evaluation benchmark using LLMs as judges",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-tool-benchmark-llm-as-a-judge",
+      "monthly_pulls": 517,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-tool-benchmark-llm-as-a-judge",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-tool-benchmark-lm-eval-harness",
+      "description": "Evaluation benchmark using LM Eval Harness",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-tool-benchmark-lm-eval-harness",
+      "monthly_pulls": 545,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-tool-benchmark-lm-eval-harness",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-tool-benchmark-rag",
+      "description": "Evaluation benchmark for Retrieval Augmented Generation",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-tool-benchmark-rag",
+      "monthly_pulls": 548,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-tool-benchmark-rag",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "eval-tool-benchmark-retriever",
+      "description": "Evaluation benchmark for retrieval systems",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/eval-tool-benchmark-retriever",
+      "monthly_pulls": 695,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/eval-tool-benchmark-retriever",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "evaluator",
+      "description": "Model evaluation service for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/evaluator",
+      "monthly_pulls": 4978,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/evaluator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "event-aggregation-service",
+      "description": "RabbitMQ implementation of a Notification Aggregation Adapter conforming to OV Storage APIs.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-36VS-TCJ8, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/event-aggregation-service",
+      "monthly_pulls": 330,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/event-aggregation-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "event-consumer-service",
+      "description": "RabbitMQ implementation of a Notification Consumer Adapter conforming to OV Storage APIs.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-36VS-TCJ8, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/event-consumer-service",
+      "monthly_pulls": 355,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/event-consumer-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "external-workload-integrator",
+      "description": "Run:ai external-workload-integrator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/external-workload-integrator",
+      "monthly_pulls": 3404,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/external-workload-integrator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "fact-service",
+      "description": "Fact attribution service (AJR).",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/fact-service",
+      "monthly_pulls": 159,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/fact-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "foundational-flywheel-server",
+      "description": "Turn workload evaluation and optimization requests into a fully automated, end-to-end workflow across many specialized micro-services with the Flywheel orchestrator control-plane service.",
+      "category": "AI, NSPECT-HBS9-YQFW, Natural Language Processing, NVIDIA AI, Synthetic Data Generation, NeMo, Conversational AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/foundational-flywheel-server",
+      "monthly_pulls": 7365,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/foundational-flywheel-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "frontend",
+      "description": "Run:ai frontend container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/frontend",
+      "monthly_pulls": 1911,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/frontend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "garak",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Garak support. Based on garak available at: https://github.com/NVIDIA/garak",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/garak",
+      "monthly_pulls": 3084,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/garak",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "gdrdrv",
+      "description": "GDRCopy kernel mode driver",
+      "category": "GPU Operator, High Performance Computing, NSPECT-SQHH-C582, NVIDIA AI Enterprise Supported, HPC / Supercomputing",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/gdrdrv",
+      "monthly_pulls": 108133,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gdrdrv",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "genai-llm-playground",
+      "description": "Web application with a front end for the GenAI workflow. Supports querying the LLM and streaming responses, uploading files to a knowledge base, and chatting with the knowledge base.",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/aiworkflows/genai-llm-playground",
+      "monthly_pulls": 371,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/genai-llm-playground",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "genai-model-server",
+      "description": "Please add description",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/aiworkflows/genai-model-server",
+      "monthly_pulls": 345,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/genai-model-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "genai-notebook-server",
+      "description": "JupyterLab notebook server with dependencies for the GenAI workflow notebooks installed.",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/aiworkflows/genai-notebook-server",
+      "monthly_pulls": 380,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/genai-notebook-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "genai-perf",
+      "description": "NVIDIA NeMo Evaluator-compatible container with GenAI-Perf support. See https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/perf_analyzer/genai-perf/README.html",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/genai-perf",
+      "monthly_pulls": 1349,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/genai-perf",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "go",
+      "description": "Go/Base Distroless Image",
+      "category": "NSPECT-18J8-QKXS, Application Development, Developer Tools",
+      "logo_url": "https://go.dev/blog/go-brand/Go-Logo/PNG/Go-Logo_Aqua.png",
+      "image_ref": "nvcr.io/nvidia/distroless/go",
+      "monthly_pulls": 154100,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/go",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "go-operator",
+      "description": "Run:ai go-operator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/go-operator",
+      "monthly_pulls": 2855,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/go-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "gpu-driver-stig-fips",
+      "description": "NVIDIA GPU Driver with Enterprise Support",
+      "category": "GPU Operator, GPU Driver, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-TTR3-FBEO, gov_ready, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/gpu-driver-stig-fips",
+      "monthly_pulls": 6266,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gpu-driver-stig-fips",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "gpu-feature-discovery",
+      "description": "Plugin for the Kubernetes Node Feature Discovery for adding GPU node labels.",
+      "category": "Automotive / Transportation, NSPECT-3HP2-SUDS, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, Infrastructure Software, Multi-Arch",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/gpu-feature-discovery",
+      "monthly_pulls": 7607097,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gpu-feature-discovery",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "gpu-operator",
+      "description": "Deploy and Manage NVIDIA GPU resources in Kubernetes.",
+      "category": "NVIDIA AI Enterprise Supported, Infrastructure, NSPECT-ZPNK-IK0N, gov_ready, Kubernetes",
+      "logo_url": "http://cms.ipressroom.com.s3.amazonaws.com/219/files/20149/NVLogo_B%26W.jpg",
+      "image_ref": "nvcr.io/nvidia/gpu-operator",
+      "monthly_pulls": 7734318,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gpu-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "gpu-operator-validator",
+      "description": "Validates NVIDIA GPU Operator components",
+      "category": "Automotive / Transportation, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-ZPNK-IK0N, Infrastructure Software, Multi-Arch",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/gpu-operator-validator",
+      "monthly_pulls": 22209864,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gpu-operator-validator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "gpud",
+      "description": "GPUd is designed to ensure GPU efficiency and reliability by actively monitoring GPUs and effectively managing AI/ML workloads.\n\nLicense: Apache License 2.0",
+      "category": "GPU Enablement with Kubernetes, Tools and Management, NSPECT-3CAP-9WC2",
+      "logo_url": "https://raw.githubusercontent.com/leptonai/gpud/refs/heads/main/assets/gpud.svg",
+      "image_ref": "nvcr.io/nvidia/dgx-cloud-lepton/gpud",
+      "monthly_pulls": 1020,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gpud",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "grafana",
+      "description": "Run:ai grafana container image",
+      "category": "NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/grafana",
+      "monthly_pulls": 1405,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/grafana",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "grafana-proxy",
+      "description": "Run:ai grafana-proxy container image",
+      "category": "NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/grafana-proxy",
+      "monthly_pulls": 1165,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/grafana-proxy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "gromacs",
+      "description": "GROMACS is a popular molecular dynamics application used to simulate proteins and lipids.",
+      "category": "NSPECT-ELYR-9VU8, High Performance Computing, HPC, HPC / Supercomputing",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FISV-OSS-Non-Nvidia-Publishing-Gromacs.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/gromacs",
+      "monthly_pulls": 3639,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gromacs",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "guardrails",
+      "description": "Safety checks and moderation for LLM applications",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, AI, Conversational AI, Safety, NeMo, Languages and APIs",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/guardrails",
+      "monthly_pulls": 14884,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/guardrails",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "guardrails-callout",
+      "description": "Guardrails sidecar for GKE Gateway Traffic Extensions",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, AI, Conversational AI, Safety, NeMo, Languages and APIs",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/guardrails-callout",
+      "monthly_pulls": 682,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/guardrails-callout",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "h4m-verification-tool-internals",
+      "description": "This container is used by the Holoscan for Media Verification Tool.",
+      "category": "Broadcast, NSPECT-KEM4-ITAL, Media & Entertainment",
+      "logo_url": "https://nvdam.widen.net/content/pwk8kpq5rz/web/NVIDIA-Logo-V-ForScreen-ForLightBG.png?color=ffffffff",
+      "image_ref": "nvcr.io/nvidia/holoscan-for-media/h4m-verification-tool-internals",
+      "monthly_pulls": 396,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/h4m-verification-tool-internals",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "hallucination-checker",
+      "description": "Hallucination Checker Container",
+      "category": "Cosmos Evaluator",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cosmos/hallucination-checker",
+      "monthly_pulls": 133,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/hallucination-checker",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "harbor-reef-operator",
+      "description": "Minimal Kubernetes operator that extends functionality of Harbor Image Cache",
+      "category": "Kubernetes Infrastructure, NSPECT-G1VF-CFQD",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/202512/692f50553d6332b453bbc5c2_nvidia-logo-vert-blk/nvidia-logo-vert-blk_6390c37f-960b-42bd-a176-b51cfa6d7ba4-prv.png",
+      "image_ref": "nvcr.io/nvidia/harbor-reef-operator",
+      "monthly_pulls": 440,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/harbor-reef-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "helm",
+      "description": "NVIDIA NeMo Evaluator-compatible container with CRFM Helm support. Based on the Stanford CRFM HELM available at: https://github.com/stanford-crfm/helm",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/helm",
+      "monthly_pulls": 1767,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/helm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "helm-dashboard",
+      "description": "Helm Dashboard provides a GUI-driven way to install and manage Helm charts on a Holoscan for Media cluster.",
+      "category": "Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/pwk8kpq5rz/web/NVIDIA-Logo-V-ForScreen-ForLightBG.png?color=ffffffff",
+      "image_ref": "nvcr.io/nvidia/holoscan-for-media/helm-dashboard",
+      "monthly_pulls": 2122,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/helm-dashboard",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "hle",
+      "description": "NVIDIA NeMo Evaluator-compatible container with hle support. Based on the HLE available at: https://github.com/centerforaisafety/hle",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/hle",
+      "monthly_pulls": 2838,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/hle",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan",
+      "description": "The Holoscan container includes the Holoscan libraries, GXF extensions, headers, example source code, and sample datasets. It is the recommended way to run the Holoscan examples or build your own applications.",
+      "category": "NSPECT-30ST-1A4V, NVIDIA AI Enterprise Supported, Holoscan",
+      "logo_url": "https://avatars.githubusercontent.com/u/119712212",
+      "image_ref": "nvcr.io/nvidia/clara-holoscan/holoscan",
+      "monthly_pulls": 54778,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan-ltsb2",
+      "description": "Holoscan LTSB2, part of NVIDIA AI Enterprise, the AI sensor processing platform.",
+      "category": "NSPECT-30ST-1A4V, Healthcare, AI, NVIDIA AI Enterprise Supported, Holoscan, NVIDIA AI",
+      "logo_url": "https://catalog.ngc.nvidia.com/nvidia_centric_nvaie.png",
+      "image_ref": "nvcr.io/nvidia/holoscan-ltsb2",
+      "monthly_pulls": 1491,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan-ltsb2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan-oe-builder",
+      "description": "OpenEmbedded/Yocto Build Container for NVIDIA Holoscan",
+      "category": "NSPECT-30ST-1A4V, NSPECT-NGB1-EJND",
+      "logo_url": "https://avatars.githubusercontent.com/u/119712212",
+      "image_ref": "nvcr.io/nvidia/clara-holoscan/holoscan-oe-builder",
+      "monthly_pulls": 1655,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan-oe-builder",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan-oe-builder-ltsb2",
+      "description": "OpenEmbedded/Yocto Build Container for NVIDIA Holoscan LTSB2",
+      "category": "NSPECT-30ST-1A4V, Healthcare, NVIDIA AI Enterprise Supported, Holoscan",
+      "logo_url": "https://catalog.ngc.nvidia.com/nvidia_centric_nvaie.png",
+      "image_ref": "nvcr.io/nvidia/holoscan-oe-builder-ltsb2",
+      "monthly_pulls": 626,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan-oe-builder-ltsb2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan-pb24h2",
+      "description": "Holoscan Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "NSPECT-30ST-1A4V, NVIDIA AI Enterprise Supported, Production Branch, Holoscan",
+      "logo_url": "https://catalog.ngc.nvidia.com/nvidia_centric_nvaie.png",
+      "image_ref": "nvcr.io/nvidia/holoscan-pb24h2",
+      "monthly_pulls": 442,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan-pb25h1",
+      "description": "Holoscan Production Branch May 2025 (PB 25h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "NSPECT-30ST-1A4V, NVIDIA AI Enterprise Supported, Production Branch, Holoscan",
+      "logo_url": "https://catalog.ngc.nvidia.com/nvidia_centric_nvaie.png",
+      "image_ref": "nvcr.io/nvidia/holoscan-pb25h1",
+      "monthly_pulls": 629,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan-pb25h2",
+      "description": "Holoscan Production Branch October 2025 (PB 25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "NSPECT-30ST-1A4V, NVIDIA AI Enterprise Supported, Production Branch, Holoscan",
+      "logo_url": "https://catalog.ngc.nvidia.com/nvidia_centric_nvaie.png",
+      "image_ref": "nvcr.io/nvidia/holoscan-pb25h2",
+      "monthly_pulls": 793,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "holoscan-pb6",
+      "description": "Holoscan Production Branch May 2026 (PB6) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "NSPECT-30ST-1A4V, NVIDIA AI Enterprise Supported, Production Branch, Holoscan, gov_ready",
+      "logo_url": "https://catalog.ngc.nvidia.com/nvidia_centric_nvaie.png",
+      "image_ref": "nvcr.io/nvidia/holoscan-pb6",
+      "monthly_pulls": 327,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/holoscan-pb6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "hostdriver",
+      "description": "DOCA Platform Framework enables the management of NVIDIA DPUs and the services that run on them at scale.\n\nDPF Host Driver image contains the components for managing the DPU across a PCI bridge.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/hostdriver",
+      "monthly_pulls": 1885,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/hostdriver",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "hpc-benchmarks",
+      "description": "The NVIDIA HPC-Benchmarks collection provides four accelerated HPC benchmarks: HPL-NVIDIA, HPL-MxP-NVIDIA, HPCG-NVIDIA, and STREAM.",
+      "category": "Supercomputing, Linpack, NSPECT-L86B-WMQF, High Performance Computing, Benchmark, HPC, High Performance Conjugate Gradient",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/HPC.png",
+      "image_ref": "nvcr.io/nvidia/hpc-benchmarks",
+      "monthly_pulls": 234318,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/hpc-benchmarks",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "hub_workstation_cache",
+      "description": "Container of Hub Workstation Cache allows for file content and derived data caching for use with Kit-based applications on a single machine.",
+      "category": "NSPECT-A23X-PJ7A, Omniverse, NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/hub_workstation_cache",
+      "monthly_pulls": 516,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/hub_workstation_cache",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ia-animation-graph-microservice",
+      "description": "Powerful and flexible node-based system designed to facilitate the creation of animation state machines and blend trees.",
+      "category": "ACE, NSPECT-G5X8-NJHG",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/ia-animation-graph-microservice",
+      "monthly_pulls": 3908,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ia-animation-graph-microservice",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ia-unreal-renderer-microservice",
+      "description": "Unreal Renderer Runtime Image",
+      "category": "ACE, NSPECT-3FW6-K0LU",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fimages.ngc.nvidia.com%2Flogos%2FNvidia-Centric-ACE.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/ace/ia-unreal-renderer-microservice",
+      "monthly_pulls": 2974,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ia-unreal-renderer-microservice",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "identity-manager",
+      "description": "Run:ai identity-manager container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/identity-manager",
+      "monthly_pulls": 1879,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/identity-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ifbench",
+      "description": "NVIDIA NeMo Evaluator-compatible container with IFBench support. Based on the IFBench available at: https://github.com/allenai/IFBench",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/ifbench",
+      "monthly_pulls": 2185,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ifbench",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "inference-workload-controller",
+      "description": "Run:ai inference-workload-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/inference-workload-controller",
+      "monthly_pulls": 4975,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/inference-workload-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ingestor-server",
+      "description": "This is the Ingestor server container used as part of the NVIDIA RAG Blueprint and used to orchestrate the end to end Ingestion.",
+      "category": "AI, RAG, NSPECT-UV6I-R3V9",
+      "logo_url": "https://nvdam.widen.net/content/qhl26oo9hq/jpeg/ai-platform-social-ai-chatbots-with-rag-24-1200x628.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/ingestor-server",
+      "monthly_pulls": 32378,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ingestor-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ingress",
+      "description": "Container for Tokkio ingress",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/ingress",
+      "monthly_pulls": 2169,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ingress",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ingress-mgr",
+      "description": "Tokkio Ingress Manager provides traffic routing and stream allocation to the Tokkio application",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/ingress-mgr",
+      "monthly_pulls": 1379,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ingress-mgr",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ingress-tunnel-client",
+      "description": "Lepton Ingress Tunnel client.",
+      "category": "Cloud Services, GPU Enablement with Kubernetes, Kubernetes Infrastructure, NSPECT-3CAP-9WC2, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dgx-cloud-lepton/ingress-tunnel-client",
+      "monthly_pulls": 280,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ingress-tunnel-client",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "init-ca-base",
+      "description": "Run:ai init-ca-base container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/init-ca-base",
+      "monthly_pulls": 2747,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/init-ca-base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "init-container",
+      "description": "OSMO container to initialize the controller",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/init-container",
+      "monthly_pulls": 54368,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/init-container",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "integration-tests",
+      "description": "Storage APIs service stack integration test suite",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/integration-tests",
+      "monthly_pulls": 240,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/integration-tests",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "iperf3-mpi",
+      "description": "Please add description",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/iperf3-mpi",
+      "monthly_pulls": 82,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/iperf3-mpi",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ipoib-cni",
+      "description": "IP Over Infiniband (IPoIB) CNI plugin with allows user to create IPoIB child link and move it to the pod.",
+      "category": "Automotive / Transportation, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/ipoib-cni",
+      "monthly_pulls": 10220,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ipoib-cni",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "isaac-lab",
+      "description": "Isaac Lab is a unified and modular framework for robot learning that aims to simplify common workflows in robotics research (such as reinforcement learning, learning from demonstrations, and motion planning).",
+      "category": "NSPECT-4OH8-F62F, Omniverse, Reinforcement Learning, Isaac, Simulation and Modeling",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/gtcf20/omniverse/refresh-open-beta/nvidia-omniverse-isaac-sim-icon-128.png",
+      "image_ref": "nvcr.io/nvidia/isaac-lab",
+      "monthly_pulls": 35860,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/isaac-lab",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "isaac-ml-3dpose",
+      "description": "Isaac SIM ML Training Workflow - Object 3D pose estimation - this is a Docker container to help Robotics ML engineers to use Isaac Sim to train object 3D pose estimation (included with Isaac SDK) using simulation data and test it in simulation as well as real world. It is targeted at Robotics App Developer and ML Engineer. Required HW is NVIDIA DGX Station i.e. V100 is preferred; but any CUDA capable GPU will do.Please add description",
+      "category": "AI, DL, Training in Simulation, Perception, Robotics, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Isaac.png",
+      "image_ref": "nvcr.io/nvidia/isaac-ml-3dpose",
+      "monthly_pulls": 294,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/isaac-ml-3dpose",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "isaac-sim",
+      "description": "NVIDIA Isaac Sim™ is a robotics and AI simulation application framework built on NVIDIA Omniverse™. Isaac Sim has essential features for building virtual robotic worlds and experiments.",
+      "category": "Reinforcement Learning, sdg, robotics, omniverse, Synthetic Data Generation, NSPECT-8CX1-LP1G, Simulation and Modeling",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/gtcf20/omniverse/refresh-open-beta/nvidia-omniverse-isaac-sim-icon-128.png",
+      "image_ref": "nvcr.io/nvidia/isaac-sim",
+      "monthly_pulls": 110816,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/isaac-sim",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "isaac-sim-comp-check",
+      "description": "Isaac Sim Compatibility Checker is a lightweight application that programmatically checks the system requirements and indicates which of them are valid, or not, for running Isaac Sim on the machine.",
+      "category": "NSPECT-1AOT-9NF4",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/gtcf20/omniverse/refresh-open-beta/nvidia-omniverse-isaac-sim-icon-128.png",
+      "image_ref": "nvcr.io/nvidia/isaac-sim-comp-check",
+      "monthly_pulls": 1473,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/isaac-sim-comp-check",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "java",
+      "description": "Java JDK and JRE Distroless images",
+      "category": "NSPECT-18J8-QKXS, Application Development, Developer Tools",
+      "logo_url": "https://1000logos.net/wp-content/uploads/2020/09/Java-Logo.png",
+      "image_ref": "nvcr.io/nvidia/distroless/java",
+      "monthly_pulls": 40691,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/java",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "jax",
+      "description": "JAX is a framework for high-performance numerical computing and machine learning research. It includes Numpy-like APIs, automatic differentiation, XLA acceleration and simple primitives for scaling across GPUs and supports an ecosystem of libraries.",
+      "category": "AI, DL, NSPECT-Q9WX-5SWR, DLFW, JAX",
+      "logo_url": "https://developer.nvidia.com/sites/default/files/akamai/OSS-Nvidia-Partnership-JAX.png",
+      "image_ref": "nvcr.io/nvidia/jax",
+      "monthly_pulls": 34896,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jax",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "jetpack-linux-aarch64-crosscompile-x86",
+      "description": "JetPack cross compilation container can be used to  cross compile various JetPack components on a x86 host machine. This container simplifies cross compilation and includes the needed cross compilation tools and build environment already setup within it.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/jetpack-linux-aarch64-crosscompile-x86",
+      "monthly_pulls": 7302,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jetpack-linux-aarch64-crosscompile-x86",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "jetson-gaze",
+      "description": "Gaze Demo container showcasing gaze detection running on Jetson.",
+      "category": "DL, Object Detection, Computer Vision, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/jetson-gaze",
+      "monthly_pulls": 425,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jetson-gaze",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "jetson-linux-flash-x86",
+      "description": "Jetson Linux Flash continer provides an lightweight environment to allow users to flash Jetson Linux without installing any prerequisites on your host.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/jetson-linux-flash-x86",
+      "monthly_pulls": 12235,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jetson-linux-flash-x86",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "jetson-pose",
+      "description": "Pose Demo container showcasing pose detection running on Jetson.",
+      "category": "DL, Object Detection, Computer Vision, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/jetson-pose",
+      "monthly_pulls": 465,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jetson-pose",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "jetson-voice",
+      "description": "ASR + BERT QA interactive chatbot demo for Jetson",
+      "category": "DL, Automatic Speech Recognition, BERT",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/jetson-voice",
+      "monthly_pulls": 479,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jetson-voice",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "job-manager",
+      "description": "Job-manager component of AJR",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/job-manager",
+      "monthly_pulls": 5833,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/job-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "jps-gdino",
+      "description": "Grounding Dino enables open vocabulary object detection supporting limitless category of objects",
+      "category": "AI, NSPECT-HP40-TL07, JPS, Metropolis",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FJetson.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/jps/jps-gdino",
+      "monthly_pulls": 1386,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jps-gdino",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-cc-manager",
+      "description": "Manages Confidential Computing Modes on NVIDIA GPUs in a Kubernetes cluster.",
+      "category": "GPU Operator, GPU Enablement with Kubernetes, NVIDIA AI",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/GPUoperator.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/k8s-cc-manager",
+      "monthly_pulls": 22338,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-cc-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-device-plugin",
+      "description": "The NVIDIA Kubernetes Device Plugin registers GPUs as compute resources in the Kubernetes cluster.",
+      "category": "NSPECT-AZTI-KLKH, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/k8s-device-plugin",
+      "monthly_pulls": 212884210,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-device-plugin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-dra-driver-gpu",
+      "description": "NVIDIA DRA Driver for GPUs",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/k8s-dra-driver-gpu",
+      "monthly_pulls": 246828,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-dra-driver-gpu",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-driver-manager",
+      "description": "Manages NVIDIA Driver upgrades in Kubernetes cluster.",
+      "category": "NSPECT-V1IZ-VFX2, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/GPUoperator.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/k8s-driver-manager",
+      "monthly_pulls": 9253918,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-driver-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-kata-manager",
+      "description": "Manage Kata Containers configuration on GPU nodes in Kubernetes.",
+      "category": "GPU Operator, GPU Enablement with Kubernetes, NVIDIA AI",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/GPUoperator.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/k8s-kata-manager",
+      "monthly_pulls": 9810,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-kata-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-launch-kit",
+      "description": "K8s Launch Kit (l8k) is a CLI tool for deploying and managing NVIDIA cloud-native solutions on Kubernetes. The tool helps provide flexible deployment workflows for optimal network performance with SR-IOV, RDMA, and other networking technologies.",
+      "category": "NSPECT-3Z9B-C2EX, DOCA, Network Operator",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cloud-native/k8s-launch-kit",
+      "monthly_pulls": 693,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-launch-kit",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-mig-manager",
+      "description": "Manage MIG partitions in Kubernetes with a simple label change to a node.",
+      "category": "NSPECT-9OCC-OY69, GPU Operator, MIG, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/k8s-mig-manager",
+      "monthly_pulls": 2059772,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-mig-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-nim-operator",
+      "description": "An Operator for deployment and maintenance of NVIDIA NIMs and NeMo microservices in a Kubernetes environment",
+      "category": "AI, NIM, NSPECT-U4XT-R3UP, NVIDIA AI Enterprise Supported, NVIDIA AI, NeMo, DGX Spark Supported, gov_ready, Inference",
+      "logo_url": "https://assets.ngc.nvidia.com/products/catalog/logos/NIMOperator.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/k8s-nim-operator",
+      "monthly_pulls": 265295,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-nim-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-objects-tracker",
+      "description": "Run:ai k8s-objects-tracker container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/k8s-objects-tracker",
+      "monthly_pulls": 1512,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-objects-tracker",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "k8s-rdma-shared-dev-plugin",
+      "description": "This is simple RDMA Device Plugin that support IB and RoCE HCA.",
+      "category": "Cloud Services, NSPECT-0LNP-57C6, High Performance Computing, Automotive / Transportation, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/k8s-rdma-shared-dev-plugin",
+      "monthly_pulls": 28542,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-rdma-shared-dev-plugin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kaldi",
+      "description": "Kaldi is an open-source software framework for speech processing.",
+      "category": "DL, Automatic Speech Recognition, Natural Language Processing, NLU, Retail, Natural Language Understanding, ML, Conversational AI, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Kaldi.png",
+      "image_ref": "nvcr.io/nvidia/kaldi",
+      "monthly_pulls": 12097,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kaldi",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "karta-migrate",
+      "description": "Please add description",
+      "category": "NVIDIA AI Enterprise Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/karta-migrate",
+      "monthly_pulls": 38,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/karta-migrate",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kata-gpu-artifacts",
+      "description": "Please add description",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cloud-native/kata-gpu-artifacts",
+      "monthly_pulls": 13670,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kata-gpu-artifacts",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "keycloak",
+      "description": "Run:ai keycloak container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/keycloak",
+      "monthly_pulls": 2433,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/keycloak",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "keydb",
+      "description": "This container is part of Runai product",
+      "category": "NSPECT-XKV4-HDZH, INFRASTRUCTURE",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/keydb",
+      "monthly_pulls": 189,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/keydb",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kit",
+      "description": "Omniverse Kit is a toolkit for building native Omniverse applications and microservices. It leverages a framework that provides a wide variety of functionality through a set of light-weight extensions.",
+      "category": "Omniverse, Automotive / Transportation, NVIDIA AI Enterprise Supported, Application Development, kit, NVIDIA Omniverse Enterprise Supported",
+      "logo_url": "https://nvdam.widen.net/content/fu3h7ysk0v/jpeg/nvidia-omniverse-enterprise-lockup-rgb-blk-for-screen-final.jpg?color=ffffffff&u=iowahy&use=l4e2p&position=c&quality=100",
+      "image_ref": "nvcr.io/nvidia/omniverse/kit",
+      "monthly_pulls": 21846,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kit",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kit-appstreaming-applications",
+      "description": "Omniverse Kit App Streaming - Applications and Profiles Service",
+      "category": "NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported, NSPECT-Y6OR-XSQN",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/kit-appstreaming-applications",
+      "monthly_pulls": 13774,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kit-appstreaming-applications",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kit-appstreaming-aws-nlb",
+      "description": "Service to manage and maintain targetgroups and listeners for AWS network load balancers",
+      "category": "NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported, NSPECT-Y6OR-XSQN",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/kit-appstreaming-aws-nlb",
+      "monthly_pulls": 2316,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kit-appstreaming-aws-nlb",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kit-appstreaming-manager",
+      "description": "Create and manage streaming sessions",
+      "category": "NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported, NSPECT-Y6OR-XSQN",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/kit-appstreaming-manager",
+      "monthly_pulls": 8945,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kit-appstreaming-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kit-appstreaming-rmcp",
+      "description": "Service for managing sessions and resources through Kubernetes and Helm",
+      "category": "NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported, NSPECT-Y6OR-XSQN",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/kit-appstreaming-rmcp",
+      "monthly_pulls": 8587,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kit-appstreaming-rmcp",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kpis-service",
+      "description": "KPIs service (AJR)",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/kpis-service",
+      "monthly_pulls": 1431,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kpis-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kubernetes-operator",
+      "description": "kubernetes-operator is a container that runs as part of the Dynamo cloud platform. Dynamo cloud is a kubernetes platform for deploying and managing inference services. This container manages the lifecycle of Dynamo inference deployments in kubernetes.",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/20237/64e3dc1a3d6332319b2dfd35_NVIDIA-logo-white-16x9/NVIDIA-logo-white-16x9_927581a6-fc31-4fa5-85c6-379680c6aa6c-prv.png",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/kubernetes-operator",
+      "monthly_pulls": 18096,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kubernetes-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "kubevirt-gpu-device-plugin",
+      "description": "Kubernetes Device Plugin built to be used for Kubevirt. Kubevirt is a Kubernetes based technology that provides a unified development platform where users can build, modify, and deploy applications residing in both Application Containers as well as VMs.",
+      "category": "Kubevirt, NVIDIA AI Enterprise Supported, K8s, NSPECT-78NH-ZJ1Y, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/kubevirt-gpu-device-plugin",
+      "monthly_pulls": 96405,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kubevirt-gpu-device-plugin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-base",
+      "description": "NVIDIA L4T is a Linux based software distribution for the NVIDIA Jetson embedded computing platform.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/l4t-base",
+      "monthly_pulls": 215831,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-compute-assist",
+      "description": "This container allows running compute-only applications using CUDA and TensorRT on the integrated GPU of Holoscan devkits (Clara AGX DevKit, IGX Orin DevKit) while other applications can run on dGPU, natively or in another container.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/clara-holoscan/l4t-compute-assist",
+      "monthly_pulls": 632,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-compute-assist",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-cuda",
+      "description": "CUDA is a parallel computing platform and programming model that enables dramatic increases in computing performance by harnessing the power of the NVIDIA GPUs.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Cuda.png",
+      "image_ref": "nvcr.io/nvidia/l4t-cuda",
+      "monthly_pulls": 57821,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-cuda",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-jetpack",
+      "description": "NVIDIA JetPack SDK is the most comprehensive solution for building end-to-end accelerated AI applications. This container contains all JetPack SDK components like CUDA, cuDNN, Tensorrt, VPI, Jetson Multimedia and so on.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/l4t-jetpack",
+      "monthly_pulls": 104870,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-jetpack",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-ml",
+      "description": "Get started on your AI journey quickly on Jetson. The Machine learning container contains TensorFlow, PyTorch, JupyterLab, and other popular ML and data science frameworks such as scikit-learn, scipy, and Pandas pre-installed in a Python environment.",
+      "category": "scipy, PyTorch, PyCUDA, scikit-learn, Pandas, Jupyter, ONNX, TensorFlow",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Jetson.png",
+      "image_ref": "nvcr.io/nvidia/l4t-ml",
+      "monthly_pulls": 33886,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-ml",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-pytorch",
+      "description": "PyTorch is a GPU accelerated tensor computational framework with a Python front end. This container contains PyTorch and torchvision pre-installed in a Python 3 environment to get up & running quickly with PyTorch on Jetson.",
+      "category": "PyTorch",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png",
+      "image_ref": "nvcr.io/nvidia/l4t-pytorch",
+      "monthly_pulls": 40840,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-pytorch",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-tensorflow",
+      "description": "TensorFlow is an open-source software library for numerical computation using data flow graphs. This container contains TensorFlow pre-installed in a Python 3 environment to get up & running quickly with TensorFlow on Jetson.",
+      "category": "TensorFlow",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Tensorflow.png",
+      "image_ref": "nvcr.io/nvidia/l4t-tensorflow",
+      "monthly_pulls": 10397,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-tensorflow",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "l4t-tensorrt",
+      "description": "NVIDIA TensorRT is a C++ library that facilitates high-performance inference on NVIDIA graphics processing units (GPUs). TensorRT takes a trained network and produces a highly optimized runtime engine that performs inference for that network.",
+      "category": "Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/l4t-tensorrt",
+      "monthly_pulls": 46128,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-tensorrt",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "lammps",
+      "description": "Large-scale Atomic/Molecular Massively Parallel Simulator (LAMMPS) is a software application designed for molecular dynamics simulations.",
+      "category": "NSPECT-ONM1-EWXY, x86_64, arm64, HPC / Supercomputing",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/ISV-OSS-Non-Nvidia-Publishing-Lammps.png",
+      "image_ref": "nvcr.io/nvidia/lammps",
+      "monthly_pulls": 2639,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/lammps",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "lepton-kueue",
+      "description": "Lepton kueue implementation.",
+      "category": "Kubernetes Infrastructure, NSPECT-3CAP-9WC2, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dgx-cloud-lepton/lepton-kueue",
+      "monthly_pulls": 209,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/lepton-kueue",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "lepton-node-validation-cpu",
+      "description": "Lepton node validation for CPU nodes.",
+      "category": "Kubernetes Infrastructure, NSPECT-3CAP-9WC2, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dgx-cloud-lepton/lepton-node-validation-cpu",
+      "monthly_pulls": 210,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/lepton-node-validation-cpu",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "lepton-node-validation-gpu",
+      "description": "Lepton node validation for GPU nodes.",
+      "category": "Kubernetes Infrastructure, NSPECT-3CAP-9WC2, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dgx-cloud-lepton/lepton-node-validation-gpu",
+      "monthly_pulls": 225,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/lepton-node-validation-gpu",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "lepton-scheduler",
+      "description": "Lepton Kubernetes scheduler.",
+      "category": "Kubernetes Infrastructure, NSPECT-3CAP-9WC2, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/dgx-cloud-lepton/lepton-scheduler",
+      "monthly_pulls": 206,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/lepton-scheduler",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "lifecycle-mgr",
+      "description": "Tokkio lifecycle manager for system health monitoring for Tokkio application.",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/lifecycle-mgr",
+      "monthly_pulls": 5385,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/lifecycle-mgr",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "livecodebench",
+      "description": "NVIDIA NeMo Evaluator-compatible container with LiveCodeBench support. Based on the LiveCodeBench available at: https://github.com/LiveCodeBench/LiveCodeBench",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/livecodebench",
+      "monthly_pulls": 2141,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/livecodebench",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "llama-3.2-nemoretriever-1b-vlm-embed-v1",
+      "description": "World-class multimodal question-answering retrieval.",
+      "category": "NSPECT-A2V9-7M6B, NVIDIA NIM",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/llama-3.2-nemoretriever-1b-vlm-embed-v1",
+      "monthly_pulls": 3577,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/llama-3.2-nemoretriever-1b-vlm-embed-v1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "llama-3.2-nv-embedqa-1b-v2",
+      "description": "The NVIDIA Retrieval QA Llama3.2 1b Embedding NIM is an embedding NIM optimized for multilingual and crosslingual text question-answering retrieval.",
+      "category": "NVIDIA NIM, NVIDIA AI Enterprise Supported, NSPECT-A2V9-7M6B",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/llama-3.2-nv-embedqa-1b-v2",
+      "monthly_pulls": 1534,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/llama-3.2-nv-embedqa-1b-v2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "llm-nim-pb25h2",
+      "description": "Multi-LLM NIM Production Branch October 2025 (PB25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments",
+      "category": "FIPS, NVIDIA AI Enterprise Supported, Production Branch, STIG, NSPECT-XWFD-L6PL, NVIDIA NIM, gov_ready",
+      "logo_url": "https://assets.ngc.nvidia.com/products/catalog/images/llm-nim-ga.png",
+      "image_ref": "nvcr.io/nvidia/llm-nim-pb25h2",
+      "monthly_pulls": 6691,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/llm-nim-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "lm-evaluation-harness",
+      "description": "NVIDIA NeMo Evaluator-compatible container with LM-Evaluation-Harness support. Based on lm-evaluation-harness available at: https://github.com/EleutherAI/lm-evaluation-harness",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/lm-evaluation-harness",
+      "monthly_pulls": 20131,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/lm-evaluation-harness",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "local-path-provisioner",
+      "description": "Autonomous Hardware Recovery (AHR) local-path-provisioner container",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/local-path-provisioner",
+      "monthly_pulls": 306,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/local-path-provisioner",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "logger",
+      "description": "OSMO container to stream logs from workflow in real-time",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/logger",
+      "monthly_pulls": 89244,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/logger",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "long-context-eval",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Long Context Eval support",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/long-context-eval",
+      "monthly_pulls": 1201,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/long-context-eval",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "magnum-io",
+      "description": "NVIDIA Magnum IO is the I/O technologies from NVIDIA and Mellanox that enable applications at scale. The Magnum IO Developer Environment container allows developers to begin scaling their applications on a laptop, desktop, workstation, or in the cloud.",
+      "category": "DL, High Performance Computing, Multi-Node, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-MAGNUM-IO.png",
+      "image_ref": "nvcr.io/nvidia/magnum-io/magnum-io",
+      "monthly_pulls": 69456,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/magnum-io",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "manual-resource-downloader",
+      "description": "The Manual Resource Downloader Init Container allows you to download the resource files (e.g an avatar USD scene) onto the persistent volume of the microservice pod. It waits until the resources have been manually uploaded to the persistent volume.",
+      "category": "ACE, NSPECT-F8D2-8418, Automotive / Transportation, NVIDIA AI Enterprise Supported",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/manual-resource-downloader",
+      "monthly_pulls": 1047,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/manual-resource-downloader",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "megamolbart",
+      "description": "A gRPC service to generate SMILES using MegaMolBART model.",
+      "category": "Healthcare, Cheminformatics, Chemistry, Clara Discovery, Clara, Drug Discovery",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Clara.png",
+      "image_ref": "nvcr.io/nvidia/clara/megamolbart",
+      "monthly_pulls": 566,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/megamolbart",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "megamolbart_base",
+      "description": "Base container with prerequisites for MegaMolBART",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Clara.png",
+      "image_ref": "nvcr.io/nvidia/clara/megamolbart_base",
+      "monthly_pulls": 276,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/megamolbart_base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "megamolbart_v0.2",
+      "description": "Inference container for MegaMolBART model.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Clara.png",
+      "image_ref": "nvcr.io/nvidia/clara/megamolbart_v0.2",
+      "monthly_pulls": 563,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/megamolbart_v0.2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "memo_test_pushimage",
+      "description": "Please add description",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/ngc-apps/memo_test_pushimage",
+      "monthly_pulls": 15,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/memo_test_pushimage",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-hugectr",
+      "description": "The Merlin HugeCTR container enables you to perform data preprocessing, feature engineering, train models with HugeCTR, and then serve the trained model with Triton Inference Server.",
+      "category": "DL, Recommendation, Merlin, HugeCTR, Preprocessing, Automotive / Transportation, NVIDIA AI, NVTabular, ML, ETL, Triton Inference Server, Inference",
+      "logo_url": "https://dz112fgwz7ogh.cloudfront.net/logos/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-hugectr",
+      "monthly_pulls": 3231,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-hugectr",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-inference",
+      "description": "This container allows users to deploy NVTabular workflows and HugeCTR or TensorFlow models to Triton Inference server for production.",
+      "category": "AI/ML",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-inference",
+      "monthly_pulls": 2583,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-inference",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-pytorch",
+      "description": "The Merlin PyTorch container allows users to do preprocessing and feature engineering with NVTabular, and then train a deep-learning based recommender system model with PyTorch, and serve the trained model on Triton Inference Server.",
+      "category": "DL, Recommendation, Merlin, Preprocessing, Automotive / Transportation, PyTorch, NVIDIA AI, NVTabular, ML, ETL, Triton Inference Server, Inference",
+      "logo_url": "https://dz112fgwz7ogh.cloudfront.net/logos/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-pytorch",
+      "monthly_pulls": 10667,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-pytorch",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-pytorch-inference",
+      "description": "This container allows users to deploy NVTabular workflows and PyTorch models to Triton Inference server for production.",
+      "category": "Infernece, Recommendation, Merlin, PyTorch, Triton Inference Server",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-pytorch-inference",
+      "monthly_pulls": 1601,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-pytorch-inference",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-pytorch-training",
+      "description": "This container allows users to do preprocessing and feature engineering with NVTabular, and then train a deep-learning based recommender system model with PyTorch.",
+      "category": "DL, Recommendation, Merlin, Preprocessing, PyTorch, Quick Deploy, Feature Engineering, NVTabular, ETL",
+      "logo_url": "https://dz112fgwz7ogh.cloudfront.net/logos/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-pytorch-training",
+      "monthly_pulls": 3900,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-pytorch-training",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-tensorflow",
+      "description": "The Merlin TensorFlow container allows users to do preprocessing and feature engineering with NVTabular, and then train a deep-learning based recommender system model with TensorFlow, and serve the trained model on Triton Inference Server.",
+      "category": "DL, Merlin, HugeCTR, Preprocessing, Automotive / Transportation, NVIDIA AI, NVTabular, TensorFlow, ETL, Triton Inference Server, Recommender Systems, Inference",
+      "logo_url": "https://dz112fgwz7ogh.cloudfront.net/logos/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-tensorflow",
+      "monthly_pulls": 6181,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-tensorflow",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-tensorflow-inference",
+      "description": "This container allows users to deploy NVTabular workflows and TensorFlow models to Triton Inference server for production.",
+      "category": "Recommendation, Merlin, TensorFlow, Triton Inference Server, Inference",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-tensorflow-inference",
+      "monthly_pulls": 450,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-tensorflow-inference",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-tensorflow-training",
+      "description": "This container allows users to do preprocessing and feature engineering with NVTabular, and then train a deep-learning based recommender system model with TensorFlow.",
+      "category": "DL, Recommendation, Merlin, HugeCTR, Preprocessing, NVTabular, TensorFlow",
+      "logo_url": "https://dz112fgwz7ogh.cloudfront.net/logos/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-tensorflow-training",
+      "monthly_pulls": 9168,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-tensorflow-training",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "merlin-training",
+      "description": "This container allows users to do preprocessing and feature engineering with NVTabular, and then train a deep-learning based recommender system model with HugeCTR.",
+      "category": "Recommendation, Merlin, HugeCTR, Preprocessing, Quick Deploy, NVTabular",
+      "logo_url": "https://dz112fgwz7ogh.cloudfront.net/logos/Nvidia-Centric-Merlin.png",
+      "image_ref": "nvcr.io/nvidia/merlin/merlin-training",
+      "monthly_pulls": 1997,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/merlin-training",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "metric-stores-migrator",
+      "description": "Run:ai metric-stores-migrator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/metric-stores-migrator",
+      "monthly_pulls": 878,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/metric-stores-migrator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "metrics-exporter",
+      "description": "Run:ai metrics-exporter container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/metrics-exporter",
+      "monthly_pulls": 2037,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/metrics-exporter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "metrics-service",
+      "description": "Run:ai metrics-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/metrics-service",
+      "monthly_pulls": 1895,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/metrics-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mission-control",
+      "description": "Mission Control is a lightweight fleet manager that coordinates Isaac Cloud microservices.  It demonstrates how you can integrate cuOpt, VDA5050, and Isaac.",
+      "category": "NSPECT-OCRJ-2E8O, VDA5050, Tools and Management, Robotics, Isaac",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/icons/m48-robot-256px-grn.png",
+      "image_ref": "nvcr.io/nvidia/isaac/mission-control",
+      "monthly_pulls": 21500,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mission-control",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mission-database",
+      "description": "Mission Database container helps to demonstrate a development environment configured to build/run/test Isaac Mission Dispatch and Control functionality.",
+      "category": "NSPECT-6HQC-D5BP, VDA5050, Tools and Management, Robotics, Isaac",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/icons/m48-robot-256px-grn.png",
+      "image_ref": "nvcr.io/nvidia/isaac/mission-database",
+      "monthly_pulls": 7476,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mission-database",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mission-dispatch",
+      "description": "Mission Dispatch container demonstrates a development environment configured to build/run/test Isaac Mission Dispatch and Client functionality.",
+      "category": "NSPECT-6HQC-D5BP, VDA5050, Tools and Management, Robotics, Isaac",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/icons/m48-robot-256px-grn.png",
+      "image_ref": "nvcr.io/nvidia/isaac/mission-dispatch",
+      "monthly_pulls": 6698,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mission-dispatch",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mission-simulator",
+      "description": "Mission Simulator container helps to demonstrate a development environment if you are not testing with the real navstack and would like simple, simulated robots that implement the vda5050 client.",
+      "category": "NSPECT-6HQC-D5BP, VDA5050, Tools and Management, Robotics, Isaac",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/icons/m48-robot-256px-grn.png",
+      "image_ref": "nvcr.io/nvidia/isaac/mission-simulator",
+      "monthly_pulls": 1012,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mission-simulator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mlflow-triton-plugin",
+      "description": "The MLflow Triton plugin is for deploying your models from MLflow to Triton Inference Server.",
+      "category": "Cloud Services, AI, DL, Morpheus, Data Analytics, Kubernetes Infrastructure, NVIDIA AI, Application Development, ML, Public Sector, Academia / Higher Education, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Triton-Inference-Server.png",
+      "image_ref": "nvcr.io/nvidia/morpheus/mlflow-triton-plugin",
+      "monthly_pulls": 5231,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mlflow-triton-plugin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mlperf-inference",
+      "description": "MLPerf Inference containers are base containers for people interested in NVIDIA's MLPerf Inference submission results",
+      "category": "Benchmarking, NSPECT-4IID-YXTU, MLPerf Inference",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-p@2x.png",
+      "image_ref": "nvcr.io/nvidia/mlperf/mlperf-inference",
+      "monthly_pulls": 21539,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mlperf-inference",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mlpinf-v4.0-cuda12.2-cudnn8.9-aarch64-ubuntu22.04-public",
+      "description": "MLPerf Inference containers are base containers for people interested in NVIDIA's MLPerf Inference submission results",
+      "category": "Benchmarking, MLPerf Inference",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-p@2x.png",
+      "image_ref": "nvcr.io/nvidia/mlperf/mlpinf-v4.0-cuda12.2-cudnn8.9-aarch64-ubuntu22.04-public",
+      "monthly_pulls": 263,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mlpinf-v4.0-cuda12.2-cudnn8.9-aarch64-ubuntu22.04-public",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mmath",
+      "description": "NVIDIA NeMo Evaluator-compatible container with MMATH support. Based on the MMATH available at: https://github.com/RUCAIBox/MMATH",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/mmath",
+      "monthly_pulls": 2053,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mmath",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "model-utils",
+      "description": "ACE Agent Model Utils Container",
+      "category": "ACE, NSPECT-26IN-0NIY",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/model-utils",
+      "monthly_pulls": 2163,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/model-utils",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "modelexpress-server",
+      "description": "Model Express is a Rust-based model cache management service designed to be deployed as a sidecar alongside existing inference solutions such as NVIDIA Dynamo.",
+      "category": "NSPECT-64TW-KXVB, AI, GPU Enablement with Kubernetes, Kubernetes Infrastructure, Tools and Management, High Performance Computing, Inference, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/ai-dynamo/modelexpress/main/ModelExpressTrainLogo.jpeg",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/modelexpress-server",
+      "monthly_pulls": 1289,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/modelexpress-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mofed",
+      "description": "Provision the NVIDIA MOFED driver using containers.",
+      "category": "AI/ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/mofed",
+      "monthly_pulls": 36704,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mofed",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mofed-5.6-1.0.3.3",
+      "description": "Provision the NVIDIA MOFED driver using containers.",
+      "category": "Kubernetes Infrastructure, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/mofed-5.6-1.0.3.3",
+      "monthly_pulls": 356,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mofed-5.6-1.0.3.3",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "monai-toolkit",
+      "description": "MONAI Toolkit is a one-stop, development sandbox environment for researchers, data scientists, developers, and clinical teams.",
+      "category": "Healthcare, AI, DL, NSPECT-H66I-92SZ, NVIDIA AI Enterprise Supported, NVIDIA AI, Clara, High Performance Computing, ML, Monai",
+      "logo_url": "https://developer.download.nvidia.com/assets/Clara/Images/monai_toolkit_logo.png",
+      "image_ref": "nvcr.io/nvidia/clara/monai-toolkit",
+      "monthly_pulls": 5841,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/monai-toolkit",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "morpheus",
+      "description": "NVIDIA Morpheus is an open AI application framework for cybersecurity developers.",
+      "category": "Cloud Services, Financial Services, Natural Language Processing, Data Analytics, Developer Tools, NVIDIA AI, Public Sector, NSPECT-V1TL-NPZI, AI, DL, Morpheus, Languages and APIs, GPU Accelerated Libraries, ML, Academia / Higher Education, Inference",
+      "logo_url": "https://d29g4g2dyqv443.cloudfront.net/sites/default/files/nvidia-morpheus-kv-630x354.jpg",
+      "image_ref": "nvcr.io/nvidia/morpheus/morpheus",
+      "monthly_pulls": 8458,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/morpheus",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "morpheus-pb24h1",
+      "description": "NVIDIA Morpheus Production Branch May 2024 (PB 24h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "Cloud Services, Financial Services, Natural Language Processing, Automotive / Transportation, Data Analytics, Developer Tools, Production Branch, NVIDIA AI, Public Sector, AI, DL, Morpheus, Languages and APIs, NVIDIA AI Enterprise Supported, GPU Accelerated Libraries, ML, Academia / Higher Education, Inference",
+      "logo_url": "https://d29g4g2dyqv443.cloudfront.net/sites/default/files/nvidia-morpheus-kv-630x354.jpg",
+      "image_ref": "nvcr.io/nvidia/morpheus-pb24h1",
+      "monthly_pulls": 3517,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/morpheus-pb24h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "morpheus-pb24h2",
+      "description": "NVIDIA Morpheus Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "Cloud Services, Financial Services, Natural Language Processing, Data Analytics, Developer Tools, Production Branch, NVIDIA AI, Public Sector, NSPECT-V1TL-NPZI, AI, DL, Morpheus, Languages and APIs, NVIDIA AI Enterprise Supported, GPU Accelerated Libraries, ML, Academia / Higher Education, Inference",
+      "logo_url": "https://d29g4g2dyqv443.cloudfront.net/sites/default/files/nvidia-morpheus-kv-630x354.jpg",
+      "image_ref": "nvcr.io/nvidia/morpheus-pb24h2",
+      "monthly_pulls": 752,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/morpheus-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "morpheus-pb25h1",
+      "description": "NVIDIA Morpheus Production Branch May 2025 (PB 25h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "Cloud Services, Financial Services, Natural Language Processing, Data Analytics, Developer Tools, Production Branch, NVIDIA AI, Public Sector, NSPECT-V1TL-NPZI, AI, DL, Morpheus, Languages and APIs, NVIDIA AI Enterprise Supported, GPU Accelerated Libraries, ML, Academia / Higher Education, Inference",
+      "logo_url": "https://d29g4g2dyqv443.cloudfront.net/sites/default/files/nvidia-morpheus-kv-630x354.jpg",
+      "image_ref": "nvcr.io/nvidia/morpheus-pb25h1",
+      "monthly_pulls": 1502,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/morpheus-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "morpheus-tritonserver-models",
+      "description": "The Morpheus Triton Server Models Container builds upon the NVIDIA Triton Inference Server container by adding the Morpheus pre-trained models.",
+      "category": "Cloud Services, Financial Services, Natural Language Processing, Data Analytics, Developer Tools, NVIDIA AI, Public Sector, AI, DL, Morpheus, Languages and APIs, NSPECT-94O8-XDVJ, GPU Accelerated Libraries, ML, Academia / Higher Education, Inference",
+      "logo_url": "https://d29g4g2dyqv443.cloudfront.net/sites/default/files/nvidia-morpheus-kv-630x354.jpg",
+      "image_ref": "nvcr.io/nvidia/morpheus/morpheus-tritonserver-models",
+      "monthly_pulls": 1834,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/morpheus-tritonserver-models",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "morpheus-vuln-analysis",
+      "description": "The Vulnerability Analysis for Container Security is a NIM Agent Blueprint that dramatically accelerates vulnerability detection and mitigation with generative AI and the Morpheus cybersecurity SDK.",
+      "category": "AI, DL, Financial Services, Natural Language Processing, Morpheus, Data Analytics, NVIDIA AI, NSPECT-9J8B-56TF, GPU Accelerated Libraries, ML, Inference",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/get-started-in-ai/AI_Workflow_1Panel_Layout1_v0061.png",
+      "image_ref": "nvcr.io/nvidia/morpheus/morpheus-vuln-analysis",
+      "monthly_pulls": 604,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/morpheus-vuln-analysis",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mtbench",
+      "description": "NVIDIA NeMo Evaluator-compatible container with MTBench support. Based on FastChat available at: https://github.com/lm-sys/FastChat",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/mtbench",
+      "monthly_pulls": 3149,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mtbench",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mteb",
+      "description": "NVIDIA NeMo Evaluator-compatible container with MTEB support. Based on Massive Text Embedding Benchmark available at: https://github.com/embeddings-benchmark/mteb",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/mteb",
+      "monthly_pulls": 590,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mteb",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "munge",
+      "description": "Munge Authentication service for Workflow-controller to work with BCM Slurm",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/munge",
+      "monthly_pulls": 965,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/munge",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "mxnet",
+      "description": "NVIDIA Optimized Deep Learning Framework, powered by Apache MXNet is a deep learning framework that allows you to mix the flavors of symbolic programming and imperative programming to maximize efficiency and productivity.",
+      "category": "DL, NSPECT-128F-3QQP, DGX Cloud Supported, Automotive / Transportation, NVIDIA AI",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Mxnet.png",
+      "image_ref": "nvcr.io/nvidia/mxnet",
+      "monthly_pulls": 199477,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/mxnet",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "namd",
+      "description": "NAMD is a parallel molecular dynamics code designed for high-performance simulation of large biomolecular systems.",
+      "category": "Drug Discovery, Healthcare, High Performance Computing, NSPECT-YXMX-79HX, HPC, Academia / Higher Education, HPC / Supercomputing",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/namd",
+      "monthly_pulls": 424,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/namd",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nats",
+      "description": "Run:ai nats container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/nats",
+      "monthly_pulls": 1786,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nats",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nats-box",
+      "description": "Provides NATS administrative and diagnostic tools for NVCF Self-Managed deployments.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nats-box",
+      "monthly_pulls": 63,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nats-box",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nats-server",
+      "description": "Pub Sub Messages, used for Function Invocation and Deployment",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nats-server",
+      "monthly_pulls": 154,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nats-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nds-v2-huggingface-cli",
+      "description": "CLI tool for NeMo Datastore V2 with Hugging Face integration",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, Hugging Face, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nds-v2-huggingface-cli",
+      "monthly_pulls": 5965,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nds-v2-huggingface-cli",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo",
+      "description": "NVIDIA NeMo™ framework Megatron backend supports pre-training, post-training, and reinforcement learning of LLMs and multi-modal generative AI models with state-of-the-art data processing, model training techniques, and flexible deployment options.",
+      "category": "Natural Language Processing, NVIDIA AI Enterprise Supported, NSPECT-IAFK-3RP3, NVIDIA AI, Natural Language Understanding, NeMo, NeMo Framework, Conversational AI",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FNemo.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/nemo",
+      "monthly_pulls": 685082,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo-automodel",
+      "description": "NVIDIA NeMo™ AutoModel accelerates LLM and VLM training and fine‑tuning with PyTorch DTensor‑native SPMD, day‑0 Hugging Face support, and optimized parallelism from single‑ to multi‑node scale.",
+      "category": "Deep Learning Examples, NSPECT-VURV-H2II, AI, PyTorch, Language Modeling, NVIDIA AI, NeMo",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nemo-automodel",
+      "monthly_pulls": 7107,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo-curator",
+      "description": "NVIDIA NeMo™ Curator accelerates generative AI model development with GPU-powered data curation, offering comprehensive text, image, video, and audio processing for enterprise-scale deployments.",
+      "category": "NVIDIA AI Enterprise Supported, NSPECT-5LHI-MDN0",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FNemo.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/nemo-curator",
+      "monthly_pulls": 4548,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-curator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo-gym",
+      "description": "NVIDIA NeMo Evaluator-compatible container with NeMo Gym support. Based on NeMo Gym available at: https://github.com/NVIDIA-NeMo/Gym",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/nemo-gym",
+      "monthly_pulls": 914,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-gym",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo-operator",
+      "description": "Kubernetes operator for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nemo-operator",
+      "monthly_pulls": 4534,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo-rl",
+      "description": "NVIDIA NeMo™ RL accelerates reinforcement learning post-training with high-performance GPU backends, offering scalable GRPO, DPO, SFT, and distillation for multimodal models from single-node experiments to enterprise-scale clusters.",
+      "category": "Deep Learning Examples, Reinforcement Learning, AI, Language Modeling, NVIDIA AI, NeMo, NSPECT-Q42R-YJOR",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nemo-rl",
+      "monthly_pulls": 15611,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo-skills",
+      "description": "NVIDIA NeMo Evaluator-compatible container with NeMo Skills support: https://github.com/NVIDIA/NeMo-Skills",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/nemo-skills",
+      "monthly_pulls": 40216,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-skills",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo-studio-ui",
+      "description": "Web interface for NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nemo-studio-ui",
+      "monthly_pulls": 465,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-studio-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo_asr_app_img",
+      "description": "The Domain Specific - NeMo Automatic Speech Recognition (ASR) Application facilitates training, evaluation and performance comparison of ASR models. This NeMo application enables you to train or fine-tune pre-trained ASR models with your own data.",
+      "category": "Automatic Speech Recognition, PyTorch with NeMo, NeMo",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/nemo_asr_app_img",
+      "monthly_pulls": 1023,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo_asr_app_img",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo_bert_text_classification",
+      "description": "Text Classification with BERT and NeMo. This NeMo application trains text classification models using single-GPU or multi-GPU. We log performance metrics and visualize them with TensorBoard. We show how to do inference with NeMo, and we visualize BERT embeddings before and after fine-tuning.",
+      "category": "Natural Language Processing, PyTorch, NLU, Multi-GPU, Text-Classification, BERT, NeMo",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/nemo_bert_text_classification",
+      "monthly_pulls": 481,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo_bert_text_classification",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemo_skills",
+      "description": "NVIDIA NeMo Evaluator-compatible container with NeMo Skills support: https://github.com/NVIDIA/NeMo-Skills",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/nemo_skills",
+      "monthly_pulls": 1197,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo_skills",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemoretriever-ocr-v1",
+      "description": "NVIDIA NeMo™ Retriever NIM for Image OCR v1 is an optical character recognition (OCR) microservice that extracts text from images",
+      "category": "NSPECT-VO27-1BOR, NVIDIA AI Enterprise Supported",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nemoretriever-ocr-v1",
+      "monthly_pulls": 4226,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemoretriever-ocr-v1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemotron-voice-agent",
+      "description": "Python app for the Nemotron Voice Agent: end-to-end voice agent blueprint using NVIDIA Nemotron Speech and LLM NIMs for acceleration and scaling.",
+      "category": "Conversational AI, NSPECT-EN4P-2958",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/nemotron-voice-agent",
+      "monthly_pulls": 247,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemotron-voice-agent",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nemotron-voice-agent-ui",
+      "description": "Web frontend for the Nemotron Voice Agent blueprint. Serves the real-time voice conversation UI over WebRTC.",
+      "category": "Conversational AI, NSPECT-EN4P-2958",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/nemotron-voice-agent-ui",
+      "monthly_pulls": 227,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemotron-voice-agent-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "network-operator",
+      "description": "Deploy and manage NVIDIA networking resources in Kubernetes.",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported, Infrastructure, gov_ready, Government Ready, Kubernetes",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-Network-Operator.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/network-operator",
+      "monthly_pulls": 152549,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/network-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ngc-resource-downloader",
+      "description": "The NGC Resource Downloader Init Container allows you to download the resource files (e.g an avatar USD scene) onto the persistent volume of the microservice pod. It downloads resources from NGC.",
+      "category": "ACE, NSPECT-JQQC-77EG",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fimages.ngc.nvidia.com%2Flogos%2FNvidia-Centric-ACE.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/ace/ngc-resource-downloader",
+      "monthly_pulls": 7905,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ngc-resource-downloader",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nginx",
+      "description": "nginx used by AHR backend helm chart",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/nginx",
+      "monthly_pulls": 52,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nginx",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nic-configuration-operator",
+      "description": "NVIDIA NIC Configuration Operator provides Kubernetes API(Custom Resource Definition) to allow FW configuration on Nvidia NICs",
+      "category": "NVIDIA AI Enterprise Supported, NSPECT-3Z9B-C2EX, Kubernetes Infrastructure, Network Operator, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/nic-configuration-operator",
+      "monthly_pulls": 7203,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nic-configuration-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nic-configuration-operator-daemon",
+      "description": "NVIDIA NIC Configuration Operator provides Kubernetes API(Custom Resource Definition) to allow FW configuration on Nvidia NICs in a coordinated manner.",
+      "category": "NVIDIA AI Enterprise Supported, NSPECT-3Z9B-C2EX, Kubernetes Infrastructure, Network Operator, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/nic-configuration-operator-daemon",
+      "monthly_pulls": 7442,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nic-configuration-operator-daemon",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nic-configuration-operator-daemon-stig-fips",
+      "description": "NVIDIA NIC Configuration Operator provides Kubernetes API(Custom Resource Definition) to allow FW configuration on Nvidia NICs in a coordinated manner.",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported, Network Operator, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/nic-configuration-operator-daemon-stig-fips",
+      "monthly_pulls": 585,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nic-configuration-operator-daemon-stig-fips",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nic-configuration-operator-stig-fips",
+      "description": "NVIDIA NIC Configuration Operator provides Kubernetes API(Custom Resource Definition) to allow FW configuration on Nvidia NICs",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported, Network Operator, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/nic-configuration-operator-stig-fips",
+      "monthly_pulls": 540,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nic-configuration-operator-stig-fips",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nim-proxy",
+      "description": "Proxy service for NIM microservices",
+      "category": "NSPECT-L3FU-DSNV, NIM, NVIDIA AI Enterprise Supported, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nim-proxy",
+      "monthly_pulls": 3403,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nim-proxy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nlp-server",
+      "description": "NLP server integrate various NLP models in bots built using ACE Agent",
+      "category": "ACE, NSPECT-26IN-0NIY",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/nlp-server",
+      "monthly_pulls": 586,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nlp-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nmc-airgap",
+      "description": "The NMC Airgap Tool downloads Helm charts, container images, and files required for air-gapped deployment of NVIDIA Mission Control.",
+      "category": "NVIDIA Mission Control, NVIDIA Mission Control Supported, NSPECT-7Z0U-6GZW, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/nmc-airgap",
+      "monthly_pulls": 136,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nmc-airgap",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nmc-launchpad",
+      "description": "NMC Launchpad container provides an intuitive web interface to access NMC components",
+      "category": "NVIDIA Mission Control, NVIDIA Mission Control Supported, NSPECT-7Z0U-6GZW, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/nmc-launchpad",
+      "monthly_pulls": 394,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nmc-launchpad",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nmos-cpp",
+      "description": "Container implementation of the AMWA Networked Media Open Specifications (NMOS) providing a complete NMOS Registry, a JavaScript-based NMOS Client/Controller and an embedded NMOS Virtual Node. For more information please refer to http://amwa.tv/.",
+      "category": "Broadcast, NMOS, AMWA, Infrastructure Software, Media & Entertainment",
+      "logo_url": "https://nvdam.widen.net/content/pwk8kpq5rz/web/NVIDIA-Logo-V-ForScreen-ForLightBG.png?color=ffffffff",
+      "image_ref": "nvcr.io/nvidia/holoscan-for-media/nmos-cpp",
+      "monthly_pulls": 1857,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nmos-cpp",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nmp-automodel-tasks",
+      "description": "Job runner for NeMo Automodel workflows in NeMo Platform",
+      "category": "Fine Tuning, NSPECT-FLR6-APOD, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-platform/nmp-automodel-tasks",
+      "monthly_pulls": 85,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nmp-automodel-tasks",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nmp-automodel-training",
+      "description": "Model training runtime for NeMo Automodel in NeMo Platform",
+      "category": "Fine Tuning, NSPECT-FLR6-APOD, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-platform/nmp-automodel-training",
+      "monthly_pulls": 104,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nmp-automodel-training",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nmp-core",
+      "description": "Shared components of the NeMo microservices",
+      "category": "NSPECT-L3FU-DSNV, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nmp-core",
+      "monthly_pulls": 2521,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nmp-core",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nmp-unsloth-training",
+      "description": "Unsloth-based model training runtime for NeMo Platform",
+      "category": "Fine Tuning, NSPECT-FLR6-APOD, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-platform/nmp-unsloth-training",
+      "monthly_pulls": 108,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nmp-unsloth-training",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "node",
+      "description": "Node.js Distroless Images",
+      "category": "NSPECT-18J8-QKXS, Application Development, Developer Tools",
+      "logo_url": "https://cdn.pixabay.com/photo/2015/04/23/17/41/node-js-736399_1280.png",
+      "image_ref": "nvcr.io/nvidia/distroless/node",
+      "monthly_pulls": 38870,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/node",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "node-scale-adjuster",
+      "description": "Run:ai node-scale-adjuster container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/node-scale-adjuster",
+      "monthly_pulls": 625,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/node-scale-adjuster",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nodepool-controller",
+      "description": "Run:ai nodepool-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/nodepool-controller",
+      "monthly_pulls": 2026,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nodepool-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "notary-service",
+      "description": "Provides signing and assertion services for NVIDIA Cloud Functions.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/notary-service",
+      "monthly_pulls": 29,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/notary-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "notebooks",
+      "description": "The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs.",
+      "category": "RAPIDS, GPU Accelerated Libraries, ML, NSPECT-1RDT-NZVP",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Rapids.png",
+      "image_ref": "nvcr.io/nvidia/rapidsai/notebooks",
+      "monthly_pulls": 804387,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/notebooks",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "notifications",
+      "description": "Notification service (AJR)",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/notifications",
+      "monthly_pulls": 232,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/notifications",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "notifications-proxy",
+      "description": "Run:ai notifications-proxy container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/notifications-proxy",
+      "monthly_pulls": 1396,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/notifications-proxy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "notifications-service",
+      "description": "Run:ai notifications-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/notifications-service",
+      "monthly_pulls": 4626,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/notifications-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nova-carter-amr-bridge",
+      "description": "Please add description",
+      "category": "NSPECT-66WO-QL5Q, Robotics",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/omniverse/nova-carter-amr-bridge",
+      "monthly_pulls": 8382,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nova-carter-amr-bridge",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nova_carter_bringup",
+      "description": "This image contains pre-built binaries to run different Isaac ROS applications on the Nova Carter robot.",
+      "category": "Vision AI, Robotics, Computer Vision, Isaac, NSPECT-81Y4-JSCU",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/nova_carter/Nova_Carter_Isaac_ThreeQuarterView_Smooth_540_crop.jpg",
+      "image_ref": "nvcr.io/nvidia/isaac/nova_carter_bringup",
+      "monthly_pulls": 634,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nova_carter_bringup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nova_carter_sil",
+      "description": "This image contains pre-built binaries to run different Isaac ROS applications on the Nova Carter robot in a simulator on x86_64 platform.",
+      "category": "NSPECT-81Y4-JSCU",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/nova_carter/Nova_Carter_Isaac_ThreeQuarterView_Smooth_540_crop.jpg",
+      "image_ref": "nvcr.io/nvidia/isaac/nova_carter_sil",
+      "monthly_pulls": 2451,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nova_carter_sil",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nova_developer_kit_bringup",
+      "description": "This image contains pre-built binaries to run different Isaac ROS applications on the Nova Orin Developer Kit.",
+      "category": "AI, Vision AI, NVIDIA AI, Robotics, Computer Vision, Isaac, NSPECT-81Y4-JSCU",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/nova_developer_kit/nova_orin_devkit_sm.png",
+      "image_ref": "nvcr.io/nvidia/isaac/nova_developer_kit_bringup",
+      "monthly_pulls": 711,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nova_developer_kit_bringup",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nova_extrinsics_sensor_calibration_tool",
+      "description": "The Extrinsics Sensor Calibration Tool for Nova is an interactive tool that uses checkerboards to estimate the relative position of sensors on a Nova Carter robot.",
+      "category": "Robotics, Calibration, Computer Vision, Isaac, NSPECT-81Y4-JSCU, NSPECT-QL57-4OVM",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/calibration/calibration_illustration.jpg",
+      "image_ref": "nvcr.io/nvidia/isaac/nova_extrinsics_sensor_calibration_tool",
+      "monthly_pulls": 805,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nova_extrinsics_sensor_calibration_tool",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nre-ga",
+      "description": "NVIDIA Neural Reconstruction (NuRec) is a technology that converts recorded camera and lidar data into 3D scenes.",
+      "category": "AI, Rendering, PyTorch, Automotive / Transportation, Robotics, Computer Vision, Simulation and Modeling",
+      "logo_url": "https://assets.ngc.nvidia.com/products/catalog/images/stable-video-diffusion.jpg",
+      "image_ref": "nvcr.io/nvidia/nre/nre-ga",
+      "monthly_pulls": 2811,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nre-ga",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nre-tools-ga",
+      "description": "NVIDIA Neural Reconstruction Tools Container containing Aux Data Generation.",
+      "category": "Rendering, PyTorch, Automotive / Transportation, Robotics, ML, Computer Vision, Simulation and Modeling",
+      "logo_url": "https://assets.ngc.nvidia.com/products/catalog/images/stable-video-diffusion.jpg",
+      "image_ref": "nvcr.io/nvidia/nre/nre-tools-ga",
+      "monthly_pulls": 1126,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nre-tools-ga",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nrl-service",
+      "description": "NeMo Retriever Library is a scalable, performance-oriented document content and metadata extraction microservice.",
+      "category": "AI, NSPECT-DFYJ-JJ49, NeMo, Conversational AI, Question Answering",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nrl-service",
+      "monthly_pulls": 234,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nrl-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-analysis",
+      "description": "Runs NVIDIA Nsight Systems analysis recipes on performance profiles and exposes results through a REST API.",
+      "category": "Developer Tools, NSPECT-FH82-4QJV",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-analysis",
+      "monthly_pulls": 815,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-analysis",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-coordinator",
+      "description": "Orchestrates distributed profiling sessions for NVIDIA DevTools (Nsight Systems) in Kubernetes, managing session coordination and centralized report storage.",
+      "category": "Developer Tools, NSPECT-FH82-4QJV",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-coordinator",
+      "monthly_pulls": 1686,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-coordinator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-copilot",
+      "description": "NVIDIA Nsight Copilot backend for offline self-hosted deployment on DGX Spark",
+      "category": "NSPECT-MO14-U63R, AI, Developer Tools",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/nsight-copilot",
+      "monthly_pulls": 91,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-copilot",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-copilot-rag",
+      "description": "CUDA RAG backend for NVIDIA Nsight Copilot offline deployment on DGX Spark",
+      "category": "NSPECT-MO14-U63R, AI, Developer Tools",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/nsight-copilot-rag",
+      "monthly_pulls": 107,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-copilot-rag",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-injector",
+      "description": "Injects NVIDIA DevTools into Kubernetes pods",
+      "category": "Developer Tools, NSPECT-FH82-4QJV",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-injector",
+      "monthly_pulls": 4623,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-injector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-operator",
+      "description": "Containerized Nsight Operator that automates NVIDIA profiling deployment and management on Kubernetes clusters.",
+      "category": "Developer Tools, NSPECT-FH82-4QJV",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-operator",
+      "monthly_pulls": 5503,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-streamer-ncu",
+      "description": "A self-hosted NVIDIA Nsight Tools GUI (for Nsight Compute) running in a Docker container allows for remote access via a web browser.",
+      "category": "NSPECT-HCNB-YOJN",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-compute-icon-gbp-shaded-128.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-streamer-ncu",
+      "monthly_pulls": 2329,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-streamer-ncu",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-streamer-ndld",
+      "description": "A self-hosted NVIDIA Nsight Tools GUI (for Nsight Deep Learning Designer) running in a Docker container allows for remote access via a web browser.",
+      "category": "NSPECT-HCNB-YOJN",
+      "logo_url": "https://developer.download.nvidia.com/images/nsight/nvidia-nsight-dl-designer-icon.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-streamer-ndld",
+      "monthly_pulls": 1141,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-streamer-ndld",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-streamer-ngfx",
+      "description": "A self-hosted NVIDIA Nsight Tools GUI (for Nsight Graphics) running in a Docker container allows for remote access via a web browser.",
+      "category": "NSPECT-HCNB-YOJN",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-graphics-icon-gbp-shaded-128.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-streamer-ngfx",
+      "monthly_pulls": 961,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-streamer-ngfx",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-streamer-nsys",
+      "description": "A self-hosted NVIDIA Nsight Tools GUI (for Nsight Systems) running in a Docker container allows for remote access via a web browser.",
+      "category": "NSPECT-HCNB-YOJN",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-streamer-nsys",
+      "monthly_pulls": 5381,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-streamer-nsys",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nsight-systems-cli",
+      "description": "Containerized NVIDIA Nsight Systems CLI (a system-wide performance analysis tool)",
+      "category": "Developer Tools, NSPECT-FH82-4QJV",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nsight-systems-cli",
+      "monthly_pulls": 8050,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nsight-systems-cli",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "numa-placement-exporter",
+      "description": "Please add description",
+      "category": "NVIDIA AI Enterprise Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/numa-placement-exporter",
+      "monthly_pulls": 16,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/numa-placement-exporter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nv-cv-event-detector",
+      "description": "Nvidia Sample CV Event Detector Microservice for detecting events for VSS Event Reviewer workflow.",
+      "category": "DeepStream, AI, NSPECT-Z2LM-L59M, Object Detection, Vision AI, TensorRT, Video Analytics, Metropolis Microservices, Computer Vision, Triton Inference Server, Metropolis",
+      "logo_url": "https://developer.download.nvidia.com/images/vss-banner.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/nv-cv-event-detector",
+      "monthly_pulls": 654,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nv-cv-event-detector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nv-cv-event-detector-ui",
+      "description": "The CV UI is a sample application used for configuring  Nvidia CV Event Detector Microservice",
+      "category": "AI, NSPECT-Z2LM-L59M, Vision AI, Video Analytics",
+      "logo_url": "https://developer.download.nvidia.com/images/vss-banner.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/nv-cv-event-detector-ui",
+      "monthly_pulls": 799,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nv-cv-event-detector-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nv-ingest",
+      "description": "NeMo Retriever extraction is a scalable, performance oriented document content and metadata extraction microservice.",
+      "category": "NSPECT-DFYJ-JJ49",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nv-ingest",
+      "monthly_pulls": 9106,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nv-ingest",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nv-svc-farm",
+      "description": "NVIDIA Omniverse Farm™ container",
+      "category": "Omniverse, Rendering, Automotive / Transportation, Farm, NSPECT-407F-HE05",
+      "logo_url": "https://nvdam.widen.net/content/m6b2kn7mia/jpeg/nvidia-omniverse-farm-lockup-rgb-blk-for-screen.jpg?color=ffffffff&u=iowahy&use=l4e2p&position=c&quality=100",
+      "image_ref": "nvcr.io/nvidia/omniverse/nv-svc-farm",
+      "monthly_pulls": 198,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nv-svc-farm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nv-yolox-page-elements-v1",
+      "description": "NVIDIA NeMo™ Retriever NIM for YOLOX structured images v1 is a fine-tuned object detection model, trained specifically for detecting charts and tables in documents",
+      "category": "NSPECT-7OBP-T77C",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/nv-yolox-page-elements-v1",
+      "monthly_pulls": 608,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nv-yolox-page-elements-v1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvbandwidth",
+      "description": "Autonomous Hardware Recovery (AHR) nvbandwidth container",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/nvbandwidth",
+      "monthly_pulls": 137,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvbandwidth",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvca",
+      "description": "NVCF ClusterAgent (NVCA) is a self-installable micro-service that enables a compute backend, DGX Clouds or other NVIDIA Compute Backends to be used as an NVCF Target to host NVIDIA Cloud Functions’ instances.",
+      "category": "BYOC, Kubernetes Infrastructure, NVIDIA AI, NSPECT-S7AK-H2SE, NVIDIA CloudFunctions, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/nvca",
+      "monthly_pulls": 10945,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvca",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvca-operator",
+      "description": "NVCF ClusterAgent Operator manages the lifecycle of NVCF ClusterAgent in the cluster. NVIDIA CloudFunction Administrators will need to install this operator to register/reconfigure their cluster with NVCF.\n\nLicense: NVIDIA Cloud Agreement",
+      "category": "BYOC, Kubernetes Infrastructure, NVIDIA AI, NSPECT-S7AK-H2SE, NVIDIA CloudFunctions, Inference, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/nvca-operator",
+      "monthly_pulls": 4737,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvca-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvca-webhook-server",
+      "description": "NVCF ClusterAgent (NVCA) is a self-installable micro-service that enables a compute backend to host NVIDIA Cloud Functions’ instances. NVCA Webhook Server is used by NVCA to enforce restrictions for NVCF Mini Service.",
+      "category": "AI, BYOC, Kubernetes Infrastructure, NSPECT-S7AK-H2SE, NVIDIA CloudFunctions, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/nvca-webhook-server",
+      "monthly_pulls": 8063,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvca-webhook-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-api-keys-service",
+      "description": "Manages API credentials for NVIDIA Cloud Functions.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-api-keys-service",
+      "monthly_pulls": 34,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-api-keys-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-container-cache",
+      "description": "NVCF Container Cache",
+      "category": "NSPECT-OW8S-JYHG",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/nvcf-container-cache",
+      "monthly_pulls": 398,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-container-cache",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-grpc-proxy",
+      "description": "Used for bi-directional communication and state management",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-grpc-proxy",
+      "monthly_pulls": 44,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-grpc-proxy",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-image-credential-helper",
+      "description": "Update Kubernetes pull secrets for registries with custom auth (ex. ECR) for NVCF functions and tasks",
+      "category": "NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-S7AK-H2SE, NVIDIA CloudFunctions, HPC / Supercomputing, Inference",
+      "logo_url": "https://registry.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FInfrastructure.png&w=3840&q=80",
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/nvcf-image-credential-helper",
+      "monthly_pulls": 4320,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-image-credential-helper",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-invocation-service",
+      "description": "Routes and manages function invocation requests for NVCF Self-Managed deployments.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-invocation-service",
+      "monthly_pulls": 35,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-invocation-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-nats-auth-callout-service",
+      "description": "Authorizes NATS clients for NVCF Self-Managed messaging.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-nats-auth-callout-service",
+      "monthly_pulls": 40,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-nats-auth-callout-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-openbao-migrations",
+      "description": "Runs OpenBao data migrations for NVCF Self-Managed deployments.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-openbao-migrations",
+      "monthly_pulls": 32,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-openbao-migrations",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-otel-collector",
+      "description": "NVCF OpenTelemetry (OTel) Collector",
+      "category": "AI, NSPECT-S7AK-H2SE",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/nvcf-otel-collector",
+      "monthly_pulls": 41,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-otel-collector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-proxy-tls-certs",
+      "description": "NVCF Proxy TLS Certificates",
+      "category": "NSPECT-OW8S-JYHG",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/nvcf-proxy-tls-certs",
+      "monthly_pulls": 1007,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-proxy-tls-certs",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-service-oss",
+      "description": "Provides the primary NVIDIA Cloud Functions control-plane API.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-service-oss",
+      "monthly_pulls": 31,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-service-oss",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-worker-init-oss",
+      "description": "Initializes function execution environments on NVCF Self-Managed worker clusters.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-worker-init-oss",
+      "monthly_pulls": 4,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-worker-init-oss",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-worker-llm-credentials-oss",
+      "description": "Provides LLM credential handling for NVCF Self-Managed worker workloads.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-worker-llm-credentials-oss",
+      "monthly_pulls": 3,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-worker-llm-credentials-oss",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf-worker-utils-oss",
+      "description": "Provides runtime utilities for NVCF Self-Managed worker clusters.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf-worker-utils-oss",
+      "monthly_pulls": 3,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf-worker-utils-oss",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf_worker_init",
+      "description": "Initializes function execution environments on NVCF Self-Managed worker clusters.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf_worker_init",
+      "monthly_pulls": 35,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf_worker_init",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf_worker_llm_credentials",
+      "description": "Provides LLM credential handling for NVCF Self-Managed worker workloads.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf_worker_llm_credentials",
+      "monthly_pulls": 32,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf_worker_llm_credentials",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvcf_worker_utils",
+      "description": "Provides runtime utilities for NVCF Self-Managed worker clusters.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvcf_worker_utils",
+      "monthly_pulls": 36,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvcf_worker_utils",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvct-service-oss",
+      "description": "Provides NVCT control-plane services for NVIDIA Cloud Functions.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/nvct-service-oss",
+      "monthly_pulls": 29,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvct-service-oss",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvds-nmos-bin",
+      "description": "Media Gateway is a reference container for Holoscan for Media, built on DeepStream. It provides NMOS registration and control of ST 2110 sinks and sources in a flexible GStreamer pipeline passed to the container.",
+      "category": "Broadcast, NMOS, AMWA, NSPECT-KEM4-ITAL, Media & Entertainment",
+      "logo_url": "https://nvdam.widen.net/content/pwk8kpq5rz/web/NVIDIA-Logo-V-ForScreen-ForLightBG.png?color=ffffffff",
+      "image_ref": "nvcr.io/nvidia/holoscan-for-media/nvds-nmos-bin",
+      "monthly_pulls": 26440,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvds-nmos-bin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvhpc",
+      "description": "The NVIDIA HPC SDK is a comprehensive suite of compilers, libraries and tools essential to maximizing developer productivity and the performance and portability of HPC applications.",
+      "category": "Drug Discovery, Aerospace, Life Sciences, Developer Tools, Manufacturing, High Performance Computing, OpenACC Programming Model, Genome Sequencing, Energy, Simulation and Modeling, Arm64, HPC SDK, HPC, Toolkit, Application Development, GPU Accelerated Libraries, Physics and Dynamics Simulation, SDK, X86_64, Academia / Higher Education, HPC / Supercomputing, NSPECT-WTR5-DL6M",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/HPC.png",
+      "image_ref": "nvcr.io/nvidia/nvhpc",
+      "monthly_pulls": 168360,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvhpc",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvidia-devtools-sidecar-injector",
+      "description": "Injects NVIDIA DevTools into Kubernetes pods",
+      "category": "Developer Tools",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nvidia-devtools-sidecar-injector",
+      "monthly_pulls": 841,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvidia-devtools-sidecar-injector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvidia-fs",
+      "description": "NVIDIA GDS Driver",
+      "category": "NSPECT-B1JM-Y2PL, Automotive / Transportation, NVIDIA AI Enterprise Supported",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/nvidia-fs",
+      "monthly_pulls": 59249,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvidia-fs",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvidia-nsight-injector",
+      "description": "Sidecar container injecting NVIDIA Nsight Tools into Kubernetes pods.",
+      "category": "NSPECT-FH82-4QJV",
+      "logo_url": "https://developer.download.nvidia.com/images/nvidia-nsight-systems-icon-gbp-shaded-256.png",
+      "image_ref": "nvcr.io/nvidia/devtools/nvidia-nsight-injector",
+      "monthly_pulls": 497,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvidia-nsight-injector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvidia-sandbox-device-plugin",
+      "description": "Sandbox Device Plugin image to be used for vfio passthrough devices with support for IommuFD in a k8s env",
+      "category": "Sandbox Device Plugin, Cloud Services, NSPECT-YCV9-G8UG, Kubernetes Infrastructure, gov_ready",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cloud-native/nvidia-sandbox-device-plugin",
+      "monthly_pulls": 14205,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvidia-sandbox-device-plugin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvidia_clara_parabricks_amazon_linux",
+      "description": "The Parabricks container based on Amazon Linux 2",
+      "category": "Healthcare, Parabricks, Genomics",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Parabricks.png",
+      "image_ref": "nvcr.io/nvidia/clara/nvidia_clara_parabricks_amazon_linux",
+      "monthly_pulls": 373,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvidia_clara_parabricks_amazon_linux",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvsm",
+      "description": "NVIDIA System Management (NVSM) is a software framework for monitoring NVIDIA DGX nodes",
+      "category": "Kubernetes Infrastructure, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/nvsm",
+      "monthly_pulls": 11174,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvsm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvsm-aggregator",
+      "description": "NVIDIA System Management (NVSM) Aggregator is a multinode software framework for monitoring NVIDIA DGX nodes cluster.",
+      "category": "NSPECT-VYGY-IV1H, Tools and Management",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvsm/nvsm-aggregator",
+      "monthly_pulls": 282,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvsm-aggregator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvsm-grafana",
+      "description": "NVIDIA System Management (NVSM) Grafana is a part of multinode software framework for monitoring NVIDIA DGX nodes cluster.",
+      "category": "NSPECT-VYGY-IV1H, Tools and Management",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvsm/nvsm-grafana",
+      "monthly_pulls": 263,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvsm-grafana",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvsm-multinode",
+      "description": "NVIDIA System Management (NVSM) is a software framework for monitoring NVIDIA DGX nodes",
+      "category": "NSPECT-VYGY-IV1H, Tools and Management",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvsm/nvsm-multinode",
+      "monthly_pulls": 322,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvsm-multinode",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvsm-multinode-arm",
+      "description": "NVIDIA System Management (NVSM) is a software framework for monitoring NVIDIA DGX nodes",
+      "category": "NSPECT-VYGY-IV1H, Tools and Management",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvsm/nvsm-multinode-arm",
+      "monthly_pulls": 271,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvsm-multinode-arm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvsm-prometheus",
+      "description": "NVIDIA System Management (NVSM) Prometheus is a part of multinode software framework for monitoring NVIDIA DGX nodes cluster",
+      "category": "NSPECT-VYGY-IV1H, Tools and Management",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvsm/nvsm-prometheus",
+      "monthly_pulls": 245,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvsm-prometheus",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "nvsm-provision",
+      "description": "NVIDIA System Management (NVSM) Provision is a part of multinode software framework for provisioning the aggregator and NVIDIA DGX nodes cluster.",
+      "category": "NSPECT-VYGY-IV1H, Tools and Management",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvsm/nvsm-provision",
+      "monthly_pulls": 232,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvsm-provision",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "objects-checker",
+      "description": "Objects Single View Checker Container",
+      "category": "cosmos evaluator",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cosmos/objects-checker",
+      "monthly_pulls": 36,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/objects-checker",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "omniverse-replicator",
+      "description": "NVIDIA Omniverse(™) Replicator is an SDK for generating physically accurate 3D synthetic data, and developing custom synthetic data generation (SDG) tools.",
+      "category": "omniverse",
+      "logo_url": "https://docs.omniverse.nvidia.com/content/images/code.png",
+      "image_ref": "nvcr.io/nvidia/omniverse-replicator",
+      "monthly_pulls": 986,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/omniverse-replicator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "openmm",
+      "description": "OpenMM is a high performance toolkit for molecular simulation",
+      "category": "NSPECT-ZJB7-B5C5, Life Sciences, High Performance Computing, Academia / Higher Education, HPC / Supercomputing",
+      "logo_url": "https://seeklogo.com/images/O/openmm-logo-7119578926-seeklogo.com.png",
+      "image_ref": "nvcr.io/nvidia/openmm",
+      "monthly_pulls": 1258,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/openmm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "opentelemetry-collector-contrib",
+      "description": "The container receives traces, metrics, and logs, processes the telemetry, and exports it to a wide variety of observability backends using its components.",
+      "category": "Developer Tools, NSPECT-FH82-4QJV",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/devtools/opentelemetry-collector-contrib",
+      "monthly_pulls": 382,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/opentelemetry-collector-contrib",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "operator",
+      "description": "A Kubernetes-aware package manager for cluster administrators to safely modify and maintain underlying hosts declaratively at scale.",
+      "category": "Kubernetes Infrastructure, Kubernetes, NSPECT-AOXJ-B73K",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FInfrastructure.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/skyhook/operator",
+      "monthly_pulls": 14886,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ops-tool",
+      "description": "Autonomous Hardware Recovery (AHR) ops-tool container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/ops-tool",
+      "monthly_pulls": 439,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ops-tool",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "org-unit-service",
+      "description": "Run:ai org-unit-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/org-unit-service",
+      "monthly_pulls": 1639,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/org-unit-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "org-units-migrator",
+      "description": "Run:ai org-units-migrator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/org-units-migrator",
+      "monthly_pulls": 1167,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/org-units-migrator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "os-shell",
+      "description": "NVIDIA mirror of the OS Shell image",
+      "category": "Robotics",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/omniverse/os-shell",
+      "monthly_pulls": 157,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/os-shell",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "oss-vault-k8s",
+      "description": "Kubernetes integration for secret management",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/oss-vault-k8s",
+      "monthly_pulls": 67,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/oss-vault-k8s",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ota-file-service",
+      "description": "OTA File Service is a cloud service to facilitate the backup and deployment of files on robots. It offers APIs to upload files to a S3 storage and deploy files to the robots over the air.",
+      "category": "AI/ML",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/icons/m48-robot-256px-grn.png",
+      "image_ref": "nvcr.io/nvidia/isaac/ota-file-service",
+      "monthly_pulls": 205,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ota-file-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "otel-collector",
+      "description": "Run:ai otel-collector container image",
+      "category": "NVIDIA AI Enterprise Supported, NVIDIA AI Enterprise, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/otel-collector",
+      "monthly_pulls": 413,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/otel-collector",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "outside-in-safety",
+      "description": "Halos Outside-In Safety Framework",
+      "category": "Vision AI, NSPECT-5PT9-CN1O",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/halos-outside-in/outside-in-safety",
+      "monthly_pulls": 83,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/outside-in-safety",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ov-base-ubuntu-22",
+      "description": "Omniverse Base Container - Ubuntu 22",
+      "category": "NSPECT-W8VV-YU12, NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/ov-base-ubuntu-22",
+      "monthly_pulls": 15456,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ov-base-ubuntu-22",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ov-kit-kernel",
+      "description": "Omniverse Kit Kernel is a base container containing a slimmed down version of the Omniverse Kit SDK containing only the essentials to run the Kit runtime.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Application Development, NVIDIA Omniverse Enterprise Supported, NSPECT-UHOI-E82B",
+      "logo_url": "https://nvdam.widen.net/content/fu3h7ysk0v/jpeg/nvidia-omniverse-enterprise-lockup-rgb-blk-for-screen-final.jpg?color=ffffffff&u=iowahy&use=l4e2p&position=c&quality=100",
+      "image_ref": "nvcr.io/nvidia/omniverse/ov-kit-kernel",
+      "monthly_pulls": 7730,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ov-kit-kernel",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ov-synthetic-data-generation",
+      "description": "Synthetic Data Generation is an app built in Omniverse for developers and researchers to build generate synthetic data using Omniverse Replicator.",
+      "category": "AI/ML",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2022/06/image1-5.jpg",
+      "image_ref": "nvcr.io/nvidia/ov-synthetic-data-generation",
+      "monthly_pulls": 480,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ov-synthetic-data-generation",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ovn",
+      "description": "The ovn image includes:\n\novn-central: Runs northd daemon, Northbound DB (high-level config), and Southbound DB (low-level OVS config) for centralized virtual network management.\novn-controller: Local daemon on each node, add flow rules to OVS.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/ovn",
+      "monthly_pulls": 828,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ovn",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ovn-domain-service",
+      "description": "The OVN Domain Service is a gRPC server simplifying OVN consumption, an open-source network virtualization platform. It provides a simplified interface for building and configuring networking components enabling domain isolation.",
+      "category": "Cloud Services, DOCA Service, DOCA, DPU, Consumer Internet, Hardware / Semiconductor, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/ovn-domain-service",
+      "monthly_pulls": 222,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ovn-domain-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ovs-cni-plugin",
+      "description": "DOCA Platform Framework enables the management of NVIDIA DPUs and the services that run on them at scale.\n\nDPF OVS CNI Plugin contains the CNI that runs on the DPUs and is integrated with the DPF system.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/ovs-cni-plugin",
+      "monthly_pulls": 3865,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ovs-cni-plugin",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "paddleocr",
+      "description": "PaddleOCR is an ultra lightweight Optical Character Recognition (OCR) system by Baidu. PaddleOCR supports a variety of cutting-edge algorithms related to OCR.",
+      "category": "NSPECT-LDAL-INWI",
+      "logo_url": "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/paddleocr",
+      "monthly_pulls": 524,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/paddleocr",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "paddlepaddle",
+      "description": "PaddlePaddle is the first independent R&D deep learning platform in China. It has been widely adopted by manufacturing, agriculture, enterprise service, serving 4 million + developers, 157,000 companies and generating 476,000 models.",
+      "category": "PaddlePaddle, NSPECT-ZWTJ-CYFN, DL, Automotive / Transportation, NVIDIA AI Enterprise Supported, NVIDIA AI",
+      "logo_url": "https://images.ngc.nvidia.com/catalog/f6e12995-b917-3e48-80d9-dff2614a8158/NGC_PaddlePaddle_Logo.png",
+      "image_ref": "nvcr.io/nvidia/paddlepaddle",
+      "monthly_pulls": 7908,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/paddlepaddle",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "paidf-anomalygen",
+      "description": "PAIDF AnomalyGen is a synthetic defect generation pipeline powered by NVIDIA Cosmos diffusion models. It supports automated mask placement, anomaly inpainting, model fine-tuning, evaluation with FID metrics, and iterative refinement workflows for producing high-quality synthetic anomaly datasets used in industrial inspection and quality assurance applications.",
+      "category": "NSPECT-OS84-33VF",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/paidf-anomalygen",
+      "monthly_pulls": 319,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/paidf-anomalygen",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "paidf-augmentation",
+      "description": "PAIDF Augmentation is an image & video augmentation pipeline that leverages NVIDIA Cosmos and other generative models to produce photorealistic synthetic video data. It supports multiple augmentation strategies including weather, lighting, and scene transformations for training and validating models in NVIDIA Metropolis applications.",
+      "category": "NSPECT-OS84-33VF",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/paidf-augmentation",
+      "monthly_pulls": 304,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/paidf-augmentation",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "paidf-auto-labeling",
+      "description": "PAIDF Auto Labeling is an automated data annotation pipeline that processes raw video data through object detection, multi-object tracking, vision-language model (VLM) classification, and multiple-choice question (MCQ) generation stages. It produces high-quality pseudo-labels for training computer vision models in NVIDIA Metropolis synthetic data generation workflows.",
+      "category": "NSPECT-OS84-33VF",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/paidf-auto-labeling",
+      "monthly_pulls": 229,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/paidf-auto-labeling",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "paidf-simulation",
+      "description": "PAIDF Simulation provides synthetic data generation and domain registration tooling for PCB Automated Optical Inspection. It leverages NVIDIA Omniverse Replicator to generate photorealistic synthetic PCB images with defect annotations for training and validating defect detection models in manufacturing quality assurance pipelines.",
+      "category": "NSPECT-OS84-33VF",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/paidf-simulation",
+      "monthly_pulls": 186,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/paidf-simulation",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "permission-service",
+      "description": "Omniverse Storage APIs Permissions Service Chart.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-B372-3HK0, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/permission-service",
+      "monthly_pulls": 30,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/permission-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "permission-ui",
+      "description": "Omniverse Storage APIs - Permissions UI for service level permission control.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-RYHK-7TPB, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/permission-ui",
+      "monthly_pulls": 35,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/permission-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "physicsnemo",
+      "description": "NVIDIA PhysicsNeMo is an open-source framework for building, training, and fine-tuning Physics-ML models.",
+      "category": "Healthcare, AI, NSPECT-K21M-HLQJ, Aerospace, High Performance Computing, Simulation and Modeling, HPC / Supercomputing",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-p@2x.png",
+      "image_ref": "nvcr.io/nvidia/physicsnemo/physicsnemo",
+      "monthly_pulls": 13427,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/physicsnemo",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pipetuner",
+      "description": "PipeTuner is an automatic tuning tool that efficiently explores the parameter space and finds the optimal parameters for the pipelines, which yields the highest KPI on the dataset provided by the user. PipeTuner containers can be pulled here.",
+      "category": "DeepStream, NVIDIA AI, Video Analytics, Metropolis, Smart Cities / Spaces",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/pipetuner",
+      "monthly_pulls": 318,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pipetuner",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "plugin-server",
+      "description": "ACE Agent Plugin server allows us to add use case or domain specific business logic in the bots",
+      "category": "ACE, NSPECT-26IN-0NIY",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/plugin-server",
+      "monthly_pulls": 1091,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/plugin-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pod-group-assigner",
+      "description": "Run:ai pod-group-assigner container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/pod-group-assigner",
+      "monthly_pulls": 2732,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pod-group-assigner",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pod-group-controller",
+      "description": "Run:ai pod-group-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/pod-group-controller",
+      "monthly_pulls": 960,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pod-group-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pod-grouper",
+      "description": "Run:ai pod-grouper container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/pod-grouper",
+      "monthly_pulls": 1000,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pod-grouper",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "policy-service",
+      "description": "Run:ai policy-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/policy-service",
+      "monthly_pulls": 1414,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/policy-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "postgresql",
+      "description": "NVIDIA mirror of the postgresql image",
+      "category": "Robotics",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/omniverse/postgresql",
+      "monthly_pulls": 26163,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/postgresql",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "postgresql-client",
+      "description": "Run:ai postgresql-client container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/postgresql-client",
+      "monthly_pulls": 6529,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/postgresql-client",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "preinstall-diagnostics",
+      "description": "Run:ai preinstall-diagnostics container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/preinstall-diagnostics",
+      "monthly_pulls": 806,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/preinstall-diagnostics",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "profbench",
+      "description": "NVIDIA NeMo Evaluator-compatible container with ProfBench support",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/profbench",
+      "monthly_pulls": 1828,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/profbench",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "project-controller",
+      "description": "Run:ai project-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/project-controller",
+      "monthly_pulls": 2782,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/project-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "prs",
+      "description": "The Domain Power Service (DPS) is a project by NVIDIA that aims to make power use and performance better in large datacenters.",
+      "category": "HPC, Tools and Management, NSPECT-3KNY-RHQB, High Performance Computing, HPC / Supercomputing",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/prs",
+      "monthly_pulls": 2445,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/prs",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "prs-config",
+      "description": "PRS Config Service - REST API for power domains, nodes, and devices",
+      "category": "Power Management, Infrastructure, NSPECT-J7JR-8W3T, Data Center, Kubernetes",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/prs-config",
+      "monthly_pulls": 731,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/prs-config",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "prs-controller",
+      "description": "PRS Controller Service - power-control pipeline",
+      "category": "Power Management, Infrastructure, NSPECT-J7JR-8W3T, Data Center, Kubernetes",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/prs-controller",
+      "monthly_pulls": 725,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/prs-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pushgateway",
+      "description": "Autonomous Hardware Recovery (AHR) pushgateway container",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/pushgateway",
+      "monthly_pulls": 147,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pushgateway",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pyg",
+      "description": "PyG (PyTorch Geometric) is a library built upon  PyTorch to easily write and train Graph Neural Networks (GNNs) for a wide range of applications related to structured data.",
+      "category": "Data Center Simulation Platform, Graph Neural Networks, Recommendation, Financial Services, Developer Tools, Genomics, Genome Sequencing, Synthetic Data Generation, Energy, AI, DL, DLFW, Academia / Higher Education",
+      "logo_url": "https://raw.githubusercontent.com/pyg-team/pyg_sphinx_theme/master/pyg_sphinx_theme/static/img/pyg_logo_text.svg?sanitize=true",
+      "image_ref": "nvcr.io/nvidia/pyg",
+      "monthly_pulls": 27115,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pyg",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pyg-pb24h2",
+      "description": "PyG Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "Graph Neural Networks, DL, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, PyTorch Geometric, NSPECT-B45M-FYSK",
+      "logo_url": "https://raw.githubusercontent.com/pyg-team/pyg_sphinx_theme/master/pyg_sphinx_theme/static/img/pyg_logo_text.svg?sanitize=true",
+      "image_ref": "nvcr.io/nvidia/pyg-pb24h2",
+      "monthly_pulls": 1301,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pyg-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pylon",
+      "description": "Provides supporting runtime capabilities for NVCF Self-Managed compute-plane services.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/pylon",
+      "monthly_pulls": 55,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pylon",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python",
+      "description": "Python Distroless Images",
+      "category": "NSPECT-18J8-QKXS, Application Development, Developer Tools",
+      "logo_url": "https://www.python.org/static/community_logos/python-logo.png",
+      "image_ref": "nvcr.io/nvidia/distroless/python",
+      "monthly_pulls": 98967,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-basic",
+      "description": "Python Basic - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-basic",
+      "monthly_pulls": 738692,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-basic",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda117",
+      "description": "Python with CUDA 11.7 - AI Workbench Default Container (Beta)",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda117",
+      "monthly_pulls": 676853,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda117",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda120",
+      "description": "Python with CUDA 12.0 - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda120",
+      "monthly_pulls": 676183,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda120",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda122",
+      "description": "Python with CUDA 12.2 - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda122",
+      "monthly_pulls": 679938,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda122",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda124",
+      "description": "Python with CUDA 12.4 - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda124",
+      "monthly_pulls": 528407,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda124",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda126",
+      "description": "Python with CUDA 12.6 - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda126",
+      "monthly_pulls": 528109,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda126",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda128",
+      "description": "Python with CUDA 12.8 - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda128",
+      "monthly_pulls": 527951,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda128",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda129",
+      "description": "Python with CUDA 12.9 - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda129",
+      "monthly_pulls": 528675,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda129",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "python-cuda130",
+      "description": "Python with CUDA 13.0 - AI Workbench Default Container",
+      "category": "AI Workbench, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/python-cuda130",
+      "monthly_pulls": 294133,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/python-cuda130",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pytorch",
+      "description": "PyTorch - AI Workbench Default Container",
+      "category": "AI Workbench, PyTorch, NSPECT-SXA6-SQEM",
+      "logo_url": "https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg",
+      "image_ref": "nvcr.io/nvidia/ai-workbench/pytorch",
+      "monthly_pulls": 676556,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pytorch-ltsb2",
+      "description": "PyTorch is a GPU accelerated tensor computational framework. Functionality can be extended with common Python libraries such as NumPy and SciPy. Automatic differentiation is done with a tape-based system at the functional and neural network layer levels.",
+      "category": "Training, Long-Term Support Branch, PyTorch, NVIDIA AI Enterprise Supported, NSPECT-5RLN-AI4A",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png",
+      "image_ref": "nvcr.io/nvidia/pytorch-ltsb2",
+      "monthly_pulls": 1969,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch-ltsb2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pytorch-ltsb2-igx",
+      "description": "PyTorch is a GPU accelerated tensor computational framework. Functionality can be extended with common Python libraries such as NumPy and SciPy. Automatic differentiation is done with a tape-based system at the functional and neural network layer levels.",
+      "category": "Training, AI, DL, PyTorch, NVIDIA AI Enterprise Supported, NSPECT-5RLN-AI4A",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png",
+      "image_ref": "nvcr.io/nvidia/pytorch-ltsb2-igx",
+      "monthly_pulls": 1456,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch-ltsb2-igx",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pytorch-pb24h2",
+      "description": "PyTorch Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "DL, DGX Cloud Supported, PyTorch, NVIDIA AI Enterprise Supported, Production Branch, NSPECT-5RLN-AI4A",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png",
+      "image_ref": "nvcr.io/nvidia/pytorch-pb24h2",
+      "monthly_pulls": 10162,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pytorch-pb25h1",
+      "description": "PyTorch Production Branch May 2025 (PB 25h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release is a branch of PyTorch 25.03.",
+      "category": "DL, DGX Cloud Supported, PyTorch, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, NSPECT-5RLN-AI4A",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png",
+      "image_ref": "nvcr.io/nvidia/pytorch-pb25h1",
+      "monthly_pulls": 3035,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pytorch-pb25h2",
+      "description": "PyTorch Production Branch October 2025 (PB 25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "PyTorch, FIPS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, STIG, gov_ready, Government Ready, NSPECT-5RLN-AI4A",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png",
+      "image_ref": "nvcr.io/nvidia/pytorch-pb25h2",
+      "monthly_pulls": 3706,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "pytorch-pb6",
+      "description": "PyTorch Production Branch 6 offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "PyTorch, FIPS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, STIG, gov_ready, Government Ready, NSPECT-5RLN-AI4A",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png",
+      "image_ref": "nvcr.io/nvidia/pytorch-pb6",
+      "monthly_pulls": 352,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch-pb6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "queue-controller",
+      "description": "Run:ai queue-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/queue-controller",
+      "monthly_pulls": 982,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/queue-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "quickstart-rapidsai",
+      "description": "Please add description",
+      "category": "AI/ML",
+      "logo_url": "https://bc.ngc.nvidia.com/dask.svg",
+      "image_ref": "nvcr.io/nvidia/quickstart-rapidsai",
+      "monthly_pulls": 1580,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/quickstart-rapidsai",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rabbitmq",
+      "description": "Redist of RabbitMQ.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-36VS-TCJ8, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/omniverse/rabbitmq",
+      "monthly_pulls": 970,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rabbitmq",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rag-application-multiturn-chatbot",
+      "description": "Chain-server for Multi turn chatbot",
+      "category": "NSPECT-OS54-TSR8",
+      "logo_url": "https://nvdam.widen.net/content/qhl26oo9hq/jpeg/ai-platform-social-ai-chatbots-with-rag-24-1200x628.png",
+      "image_ref": "nvcr.io/nvidia/aiworkflows/rag-application-multiturn-chatbot",
+      "monthly_pulls": 1069,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rag-application-multiturn-chatbot",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rag-application-text-chatbot-langchain",
+      "description": "Chain-server for LangChain based Text Q&A Chatbot",
+      "category": "NSPECT-OS54-TSR8",
+      "logo_url": "https://nvdam.widen.net/content/qhl26oo9hq/jpeg/ai-platform-social-ai-chatbots-with-rag-24-1200x628.png",
+      "image_ref": "nvcr.io/nvidia/aiworkflows/rag-application-text-chatbot-langchain",
+      "monthly_pulls": 818,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rag-application-text-chatbot-langchain",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rag-frontend",
+      "description": "This is the sample frontend container used as part of the NVIDIA AI Blueprint for RAG.",
+      "category": "AI, RAG, NSPECT-UV6I-R3V9",
+      "logo_url": "https://nvdam.widen.net/content/qhl26oo9hq/jpeg/ai-platform-social-ai-chatbots-with-rag-24-1200x628.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/rag-frontend",
+      "monthly_pulls": 1653,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rag-frontend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rag-playground",
+      "description": "RAG Playground UI application",
+      "category": "NSPECT-OS54-TSR8",
+      "logo_url": "https://nvdam.widen.net/content/qhl26oo9hq/jpeg/ai-platform-social-ai-chatbots-with-rag-24-1200x628.png",
+      "image_ref": "nvcr.io/nvidia/aiworkflows/rag-playground",
+      "monthly_pulls": 1846,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rag-playground",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rag-server",
+      "description": "This is the RAG server container used as part of the NVIDIA AI Blueprint for RAG and used to orchestrate the end to end RAG pipeline.",
+      "category": "AI, RAG, NSPECT-UV6I-R3V9",
+      "logo_url": "https://nvdam.widen.net/content/qhl26oo9hq/jpeg/ai-platform-social-ai-chatbots-with-rag-24-1200x628.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/rag-server",
+      "monthly_pulls": 113988,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rag-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rag_retriever_eval",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Retriever and RAG Eval support",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/rag_retriever_eval",
+      "monthly_pulls": 4377,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rag_retriever_eval",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rapids-ltsb2",
+      "description": "The NVIDIA RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science, machine learning and analytics pipelines entirely on GPUs.",
+      "category": "Data Science, Long-Term Support Branch, RAPIDS, NVIDIA AI Enterprise Supported, NVIDIA AI, Data Processing, ML, NSPECT-1RDT-NZVP",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-RAPIDS.png",
+      "image_ref": "nvcr.io/nvidia/rapids-ltsb2",
+      "monthly_pulls": 1637,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rapids-ltsb2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rapids-pb24h2",
+      "description": "NVIDIA RAPIDS Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "Data Science, RAPIDS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, Data Processing, ML, NVIDIA AI Enterprise Production Branch, NSPECT-1RDT-NZVP",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-RAPIDS.png",
+      "image_ref": "nvcr.io/nvidia/rapids-pb24h2",
+      "monthly_pulls": 2170,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rapids-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rapids-pb25h1",
+      "description": "NVIDIA RAPIDS Production Branch May 2025 (PB 25h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "Data Science, RAPIDS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, Data Processing, ML, NVIDIA AI Enterprise Production Branch, NSPECT-1RDT-NZVP",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-RAPIDS.png",
+      "image_ref": "nvcr.io/nvidia/rapids-pb25h1",
+      "monthly_pulls": 1511,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rapids-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rapids-pb25h2",
+      "description": "NVIDIA RAPIDS Production Branch October 2025 (PB 25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "RAPIDS, FIPS, NVIDIA AI Enterprise Supported, NVIDIA AI, STIG, ML, NSPECT-1RDT-NZVP, gov_ready",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-RAPIDS.png",
+      "image_ref": "nvcr.io/nvidia/rapids-pb25h2",
+      "monthly_pulls": 2538,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rapids-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rapids-pb6",
+      "description": "NVIDIA RAPIDS Production Branch 6 (PB6) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "RAPIDS, FIPS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, STIG, ML, NSPECT-1RDT-NZVP, gov_ready",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-RAPIDS.png",
+      "image_ref": "nvcr.io/nvidia/rapids-pb6",
+      "monthly_pulls": 225,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rapids-pb6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rapidsai",
+      "description": "The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs.",
+      "category": "NVIDIA AI, covid-19, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Rapids.png",
+      "image_ref": "nvcr.io/nvidia/rapidsai/rapidsai",
+      "monthly_pulls": 42074,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rapidsai",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rapidsai-core",
+      "description": "The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs.",
+      "category": "ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Rapids.png",
+      "image_ref": "nvcr.io/nvidia/rapidsai/rapidsai-core",
+      "monthly_pulls": 25040,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rapidsai-core",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "redoc",
+      "description": "Run:ai redoc container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/redoc",
+      "monthly_pulls": 2047,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/redoc",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "release",
+      "description": "TensorRT LLM provides users with an easy-to-use Python API to define Large Language Models (LLMs) and supports state-of-the-art optimizations to perform inference efficiently on NVIDIA GPUs.",
+      "category": "AI, DL, PyTorch, TensorRT, LLM Inference, Conversational AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/tensorrt-llm/release",
+      "monthly_pulls": 537670,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/release",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "renderer-adapter",
+      "description": "Render adapter sidecar for Unreal Engine Microservice",
+      "category": "NSPECT-RDWK-7253, ACE, NSPECT-3FW6-K0LU",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/renderer-adapter",
+      "monthly_pulls": 2635,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/renderer-adapter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "researcher-service",
+      "description": "Run:ai researcher-service container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/researcher-service",
+      "monthly_pulls": 7935,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/researcher-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "resource-reservation",
+      "description": "Run:ai resource-reservation container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/resource-reservation",
+      "monthly_pulls": 908,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/resource-reservation",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "retail-shopping-advisor-chatbot-service",
+      "description": "Backend API Service.",
+      "category": "NSPECT-FEN9-II67",
+      "logo_url": "https://nvdam.widen.net/content/kslojnepjt/jpeg/llm-retail-shopping-advisor-1-social-li-3336950-1200x628.jpeg",
+      "image_ref": "nvcr.io/nvidia/aiworkflows/retail-shopping-advisor-chatbot-service",
+      "monthly_pulls": 100,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/retail-shopping-advisor-chatbot-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "retail-shopping-advisor-frontend-service",
+      "description": "Front-end service.",
+      "category": "NSPECT-FEN9-II67",
+      "logo_url": "https://nvdam.widen.net/content/kslojnepjt/jpeg/llm-retail-shopping-advisor-1-social-li-3336950-1200x628.jpeg",
+      "image_ref": "nvcr.io/nvidia/aiworkflows/retail-shopping-advisor-frontend-service",
+      "monthly_pulls": 101,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/retail-shopping-advisor-frontend-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "retail-shopping-advisor-lab-service",
+      "description": "Please add description",
+      "category": "NSPECT-FEN9-II67",
+      "logo_url": "https://nvdam.widen.net/content/kslojnepjt/jpeg/llm-retail-shopping-advisor-1-social-li-3336950-1200x628.jpeg",
+      "image_ref": "nvcr.io/nvidia/aiworkflows/retail-shopping-advisor-lab-service",
+      "monthly_pulls": 96,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/retail-shopping-advisor-lab-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "reval-server",
+      "description": "Reval (re-validation) service - Handles background re-validation of function state",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA AI, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/reval-server",
+      "monthly_pulls": 41,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/reval-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "riva-speech",
+      "description": "Riva Speech Skills is a scalable Conversational AI service platform.",
+      "category": "ASR, ACE, Riva, Speech to Text, Inference, Text to Speech, NSPECT-DI0L-MV83, TTS, Translation, NLP, NMT, Automatic Speech Recognition, Conversational AI",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-Riva.png",
+      "image_ref": "nvcr.io/nvidia/riva/riva-speech",
+      "monthly_pulls": 177713,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/riva-speech",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ros",
+      "description": "Isaac ROS Dev Base containers for running a development environment configured to build/run/test ROS workspaces with Isaac ROS packages.",
+      "category": "isaac, ros, NSPECT-81Y4-JSCU",
+      "logo_url": "https://media.githubusercontent.com/media/NVIDIA-ISAAC-ROS/.github/main/resources/isaac_ngc/icons/turbo_turtle_transparent.png",
+      "image_ref": "nvcr.io/nvidia/isaac/ros",
+      "monthly_pulls": 72868,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ros",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "router",
+      "description": "OSMO container to enable exec and port-forwarding for workflows",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/router",
+      "monthly_pulls": 100888,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/router",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "rproxy-service",
+      "description": "Container for Reverse Proxy",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/rproxy-service",
+      "monthly_pulls": 537,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/rproxy-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "runai-container-runtime-installer",
+      "description": "Run:ai runai-container-runtime-installer container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/runai-container-runtime-installer",
+      "monthly_pulls": 518,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/runai-container-runtime-installer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "runai-container-toolkit",
+      "description": "Run:ai runai-container-toolkit container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/runai-container-toolkit",
+      "monthly_pulls": 998,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/runai-container-toolkit",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "runai-container-toolkit-validator",
+      "description": "Run:ai runai-container-toolkit-validator container image",
+      "category": "NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/runai-container-toolkit-validator",
+      "monthly_pulls": 409,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/runai-container-toolkit-validator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "runai-mcp-server",
+      "description": "Please add description",
+      "category": "NVIDIA AI Enterprise Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/runai-mcp-server",
+      "monthly_pulls": 30,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/runai-mcp-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "runai-node-exporter",
+      "description": "Run:ai runai-node-exporter container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/runai-node-exporter",
+      "monthly_pulls": 1509,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/runai-node-exporter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "runai-scheduler",
+      "description": "Run:ai runai-scheduler container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/runai-scheduler",
+      "monthly_pulls": 1051,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/runai-scheduler",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "runaijob-controller",
+      "description": "Run:ai runaijob-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/runaijob-controller",
+      "monthly_pulls": 1576,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/runaijob-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "safe-synthesizer",
+      "description": "Synthetic tabular data that preserves statistical properties and protects privacy",
+      "category": "NSPECT-L3FU-DSNV, NeMo, Early Access",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/safe-synthesizer",
+      "monthly_pulls": 517,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/safe-synthesizer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "safe-synthesizer-api",
+      "description": "API for managing synthetic tabular data",
+      "category": "NSPECT-L3FU-DSNV, NeMo, Early Access",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-microservices/safe-synthesizer-api",
+      "monthly_pulls": 972,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/safe-synthesizer-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "safe-synthesizer-tasks",
+      "description": "GPU task runtime for NeMo Safe Synthesizer",
+      "category": "NSPECT-FLR6-APOD, NeMo",
+      "logo_url": "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png",
+      "image_ref": "nvcr.io/nvidia/nemo-platform/safe-synthesizer-tasks",
+      "monthly_pulls": 88,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/safe-synthesizer-tasks",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "safety-harness",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Safety Harness support",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/safety-harness",
+      "monthly_pulls": 2766,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/safety-harness",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "samba",
+      "description": "Please add description",
+      "category": "NSPECT-S7AK-H2SE",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/samba",
+      "monthly_pulls": 52,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/samba",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "scaling-pod",
+      "description": "Run:ai scaling-pod container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/scaling-pod",
+      "monthly_pulls": 629,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/scaling-pod",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "scicode",
+      "description": "NVIDIA NeMo Evaluator-compatible container with SciCode support. Based on the SciCode available at: https://github.com/scicode-bench/SciCode",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/scicode",
+      "monthly_pulls": 2353,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/scicode",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sdg_workshop",
+      "description": "Synthetic Data Generation Workshop container for building realistic synthetic datasets based on existing data using Megatron-LM.",
+      "category": "AI/ML",
+      "logo_url": "https://cdn-assets-us.frontify.com/s3/frontify-enterprise-files-us/eyJwYXRoIjoibnZpZGlhXC9hY2NvdW50c1wvYTBcLzQwMDEwODlcL3Byb2plY3RzXC8xNVwvYXNzZXRzXC81M1wvNDc3NVwvYTVmOTdlZTJkZDczZjI1ZjRmZDc4Zjc1ZDEyNWRmZDgtMTYzMDUwMjc3Mi5zdmcifQ:nvidia:j-q0R-L32WZDTjffrH6i9piYVbcWSwv5t6vV8x7-t7Q?width=2400",
+      "image_ref": "nvcr.io/nvidia/fsi/sdg_workshop",
+      "monthly_pulls": 4,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sdg_workshop",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sdr",
+      "description": "Tokkio SDR handles stream distribution and routing logic in the Tokkio application",
+      "category": "ACE, NSPECT-B61D-LIZ2",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/sdr",
+      "monthly_pulls": 17501,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sdr",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sdr-mw-l",
+      "description": "Sensor Distribution configuration Management",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/sdr-mw-l",
+      "monthly_pulls": 689,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sdr-mw-l",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sdr-reconciler",
+      "description": "Tokkio SDR Reconciler container handles stream distribution and routing within the Tokkio Application",
+      "category": "NSPECT-RDWK-7253, ACE, NSPECT-B61D-LIZ2",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/sdr-reconciler",
+      "monthly_pulls": 10441,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sdr-reconciler",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "secret-generator",
+      "description": "Run:ai secret-generator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/secret-generator",
+      "monthly_pulls": 309,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/secret-generator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "service",
+      "description": "OSMO container for service APIs",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/service",
+      "monthly_pulls": 163546,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "settings-migrator",
+      "description": "Run:ai settings-migrator container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/settings-migrator",
+      "monthly_pulls": 1164,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/settings-migrator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sglang",
+      "description": "SGLang is a fast serving framework for large language models and vision language models.  The NVIDIA SGLang NGC Container is optimized for GPU acceleration, and contains a validated set of libraries that enable and optimize GPU performance.",
+      "category": "Translation, AI, DL, Natural Language Processing, NVIDIA AI, DLFW, Natural Language Understanding, High Performance Computing, ML, Conversational AI, Question Answering, Inference",
+      "logo_url": "https://github.com/sgl-project/sglang/blob/main/assets/logo.png?raw=true",
+      "image_ref": "nvcr.io/nvidia/sglang",
+      "monthly_pulls": 5964,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sglang",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sglang-runtime",
+      "description": "The Dynamo SGLang runtime image is a containerized build of Dynamo + SGLang which serves as the base runtime environment for sglang based inference with Dynamo's distributed inference framework.",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/20237/64e3dc1a3d6332319b2dfd35_NVIDIA-logo-white-16x9/NVIDIA-logo-white-16x9_927581a6-fc31-4fa5-85c6-379680c6aa6c-prv.png",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/sglang-runtime",
+      "monthly_pulls": 18961,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sglang-runtime",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sglang-runtime-nightly",
+      "description": "The Dynamo SGLang runtime nightly image is a containerized build of Dynamo + SGLang which serves as the base runtime environment for sglang based inference with Dynamo's distributed inference framework which is published every night.",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/20237/64e3dc1a3d6332319b2dfd35_NVIDIA-logo-white-16x9/NVIDIA-logo-white-16x9_927581a6-fc31-4fa5-85c6-379680c6aa6c-prv.png",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/sglang-runtime-nightly",
+      "monthly_pulls": 1177,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sglang-runtime-nightly",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shared-objects-controller",
+      "description": "Run:ai shared-objects-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/shared-objects-controller",
+      "monthly_pulls": 2089,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shared-objects-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-agent",
+      "description": "Autonomous Hardware Recovery (AHR) shoreline-agent container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-agent",
+      "monthly_pulls": 375,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-agent",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-backend",
+      "description": "Autonomous Hardware Recovery (AHR) shoreline-backend container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-backend",
+      "monthly_pulls": 434,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-backend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-busybox",
+      "description": "Autonomous Hardware Recovery (AHR) busybox container",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-busybox",
+      "monthly_pulls": 411,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-busybox",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-ceph",
+      "description": "Autonomous Hardware Recovery (AHR) shoreline-ceph container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-ceph",
+      "monthly_pulls": 361,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-ceph",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-frontend",
+      "description": "Autonomous Hardware Recovery (AHR) shoreline-frontend container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-frontend",
+      "monthly_pulls": 476,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-frontend",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-metadata",
+      "description": "Autonomous Hardware Recovery (AHR) shoreline-metadata container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-metadata",
+      "monthly_pulls": 406,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-metadata",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-openbao",
+      "description": "Autonomous Hardware Recovery (AHR) shoreline-openbao container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-openbao",
+      "monthly_pulls": 363,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-openbao",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "shoreline-ui",
+      "description": "Autonomous Hardware Recovery (AHR) shoreline-ui container",
+      "category": "AI Factory Automation, AI, NSPECT-NKZF-24TH, ML, NVIDIA Mission Control Supported, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/shoreline-ui",
+      "monthly_pulls": 426,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/shoreline-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "simple-evals",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Simple-Evals support. Based on simple-evals available at: https://github.com/openai/simple-evals",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/simple-evals",
+      "monthly_pulls": 9124,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/simple-evals",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "simple-nginx",
+      "description": "Modified NGINX base container.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, NSPECT-XQPV-EDBQ, Kubernetes Infrastructure, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/simple-nginx",
+      "monthly_pulls": 385,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/simple-nginx",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "single-cell-examples_rapids",
+      "description": "Contains example notebooks demonstrating the use of RAPIDS for GPU-accelerated analysis of single-cell sequencing data.",
+      "category": "Healthcare, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Clara.png",
+      "image_ref": "nvcr.io/nvidia/clara/single-cell-examples_rapids",
+      "monthly_pulls": 2317,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/single-cell-examples_rapids",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "smoke-test-base",
+      "description": "This allows for validating healthy deployments of the storage stack",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NVIDIA Omniverse Enterprise Supported, NSPECT-YN8F-3UY0, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/smoke-test-base",
+      "monthly_pulls": 18,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/smoke-test-base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "snapshot-agent",
+      "description": "Dynamo Snapshot Agent enables CRIU-based checkpoint and restore for GPU inference workloads running on NVIDIA Dynamo",
+      "category": "AI, Kubernetes Infrastructure, NSPECT-9EST-K1WZ, Inference",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/snapshot-agent",
+      "monthly_pulls": 5627,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/snapshot-agent",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sonic-wjh",
+      "description": "SONiC What Just Happened",
+      "category": "AI/ML",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-Sonic.png",
+      "image_ref": "nvcr.io/nvidia/sonic/sonic-wjh",
+      "monthly_pulls": 726,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sonic-wjh",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sovereign",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Sovereign Evals support.",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/sovereign",
+      "monthly_pulls": 125,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sovereign",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "spectrum-x-operator",
+      "description": "Operator that Orchestrates NVIDIA Spectrum-X networking for Kubernetes.",
+      "category": "NSPECT-3Z9B-C2EX, Kubernetes Infrastructure, Network Operator, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/spectrum-x-operator",
+      "monthly_pulls": 5157,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/spectrum-x-operator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "spectrum-x-operator-stig-fips",
+      "description": "Operator that Orchestrates NVIDIA Spectrum-X networking for Kubernetes.",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, Network Operator, gov_ready, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/mellanox/spectrum-x-operator-stig-fips",
+      "monthly_pulls": 567,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/spectrum-x-operator-stig-fips",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "speech-live-portrait",
+      "description": "Speech Live Portrait Server",
+      "category": "ACE, NSPECT-D4W2-W8J0",
+      "logo_url": "https://d29g4g2dyqv443.cloudfront.net/sites/default/files/akamai/omniverse/newsletter-proviz-dev-maxine-kv-promo-pack-600x338.png",
+      "image_ref": "nvcr.io/nvidia/ace/speech-live-portrait",
+      "monthly_pulls": 1942,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/speech-live-portrait",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "spot",
+      "description": "Provides service inventory and state management for NVIDIA Cloud Functions.",
+      "category": "NSPECT-JNT9-FHIU, Kubernetes Infrastructure, NVIDIA CloudFunctions, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/nvcf/spot",
+      "monthly_pulls": 30,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/spot",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sriov-network-operator-config-daemon",
+      "description": "SR-IOV Network Operator Node agent",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/sriov-network-operator-config-daemon",
+      "monthly_pulls": 32475,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sriov-network-operator-config-daemon",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "sriov-network-operator-config-daemon-stig-fips",
+      "description": "SR-IOV Network Operator Node agent",
+      "category": "NSPECT-3Z9B-C2EX, NVIDIA AI Enterprise Supported, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/mellanox/sriov-network-operator-config-daemon-stig-fips",
+      "monthly_pulls": 521,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/sriov-network-operator-config-daemon-stig-fips",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "static",
+      "description": "Static Distroless images",
+      "category": "NSPECT-18J8-QKXS, Application Development, Developer Tools",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/b/bc/Crystal_binary.png",
+      "image_ref": "nvcr.io/nvidia/distroless/static",
+      "monthly_pulls": 743,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/static",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "status-updater",
+      "description": "Run:ai status-updater container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/status-updater",
+      "monthly_pulls": 2071,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/status-updater",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "storage-host",
+      "description": "DOCA Platform Framework enables the management of NVIDIA DPUs and the services that run on them at scale.\n\nDPF Storage Host contains components related to the DPF Storage Subsystem.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/storage-host",
+      "monthly_pulls": 1085,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/storage-host",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "storage-navigator",
+      "description": "Omniverse Storage APIs - Storage Navigator file browser UI.",
+      "category": "NSPECT-E5HZ-J3CI, Omniverse, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NVIDIA Omniverse Enterprise Supported, Infrastructure Software",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/storage-navigator",
+      "monthly_pulls": 197,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/storage-navigator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "storage-service",
+      "description": "Storage service implementations based on USD Storage API definitions.",
+      "category": "NVIDIA AI Enterprise Supported, NSPECT-E7XV-QBCO, Robotics, NVIDIA Omniverse Enterprise Supported",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/storage-service",
+      "monthly_pulls": 6211,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/storage-service",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "storage-system",
+      "description": "DOCA Platform Framework enables the management of NVIDIA DPUs and the services that run on them at scale.\n\nDPF Storage Host contains components related to the DPF Storage Subsystem.",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/storage-system",
+      "monthly_pulls": 1187,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/storage-system",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "swagger",
+      "description": "SWAGGER: Sparse WAypoint Graph Generation for Efficient Routing",
+      "category": "NSPECT-PU65-URV6, Robotics, Isaac",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/isaac/swagger",
+      "monthly_pulls": 25223,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/swagger",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tao-pb25h2",
+      "description": "TAO Production Branch October 2025 (PB 25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "Architecture / Engineering / Construction, Automotive / Transportation, FIPS, Developer Tools, Vision AI, Production Branch, NVIDIA AI, Robotics, Computer Vision, gov_ready, Smart Cities / Spaces, NSPECT-76DN-OP7I, AI, DL, NVIDIA AI Enterprise Supported, TAO Toolkit, Kubernetes Infrastructure, Retail, STIG, ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/tao-pb25h2",
+      "monthly_pulls": 3160,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tao-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tao-pb6",
+      "description": "TAO Production Branch 6 offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "Architecture / Engineering / Construction, Container Toolkit, Object Detection, Automotive / Transportation, Vision AI, Manufacturing, NVIDIA AI, Computer Vision, Metropolis, Smart Cities / Spaces, gov_ready, NSPECT-76DN-OP7I, AI, DL, NVIDIA AI Enterprise Supported, TAO Toolkit, Retail, Action Recognition, ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/tao-pb6",
+      "monthly_pulls": 55,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tao-pb6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tao-toolkit",
+      "description": "Docker containers distributed as part of the TAO Toolkit package",
+      "category": "Architecture / Engineering / Construction, Automotive / Transportation, Developer Tools, Vision AI, Pre-Release, Manufacturing, NVIDIA AI, Robotics, Computer Vision, Smart Cities / Spaces, NSPECT-76DN-OP7I, AI, DL, NVIDIA AI Enterprise Supported, TAO Toolkit, Kubernetes Infrastructure, ML, NVAIE Supported",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-TAO.png",
+      "image_ref": "nvcr.io/nvidia/tao/tao-toolkit",
+      "monthly_pulls": 17078464,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tao-toolkit",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tau2-bench",
+      "description": "NVIDIA NeMo Evaluator-compatible container with Tau2-Bench support",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/tau2-bench",
+      "monthly_pulls": 1646,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tau2-bench",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "temp-backend-settings",
+      "description": "Run:ai temp-backend-settings container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/temp-backend-settings",
+      "monthly_pulls": 347,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/temp-backend-settings",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tenants-manager",
+      "description": "Run:ai tenants-manager container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/tenants-manager",
+      "monthly_pulls": 2009,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tenants-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorflow",
+      "description": "TensorFlow is an open source platform for machine learning. It provides comprehensive tools and libraries in a flexible architecture allowing easy deployment across a variety of platforms and devices.",
+      "category": "DL, DGX Cloud Supported, Automotive / Transportation, NVIDIA AI Enterprise Supported, NVIDIA AI, TensorFlow",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Tensorflow.png",
+      "image_ref": "nvcr.io/nvidia/tensorflow",
+      "monthly_pulls": 1100265,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorflow-pb24h2",
+      "description": "TensorFlow 2 Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "NSPECT-3TQ0-27X7, DL, NVIDIA AI Enterprise Supported, Production Branch",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Tensorflow.png",
+      "image_ref": "nvcr.io/nvidia/tensorflow-pb24h2",
+      "monthly_pulls": 3366,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrt",
+      "description": "NVIDIA TensorRT is a C++ library that facilitates high-performance inference on NVIDIA graphics processing units (GPUs). TensorRT takes a trained network and produces a highly optimized runtime engine that performs inference for that network.",
+      "category": "DL, Automotive / Transportation, NVIDIA AI Enterprise Supported, NVIDIA AI, DLFW, DGX Spark Supported, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/tensorrt",
+      "monthly_pulls": 719803,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrt-ltsb2",
+      "description": "NVIDIA TensorRT is a C++ library that facilitates high-performance inference on NVIDIA graphics processing units (GPUs). TensorRT takes a trained network and produces a highly optimized runtime engine that performs inference for that network.",
+      "category": "Long-Term Support Branch, NVIDIA AI Enterprise Supported, NSPECT-H7TF-8RJJ",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/tensorrt-ltsb2",
+      "monthly_pulls": 1904,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt-ltsb2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrt-ltsb2-igx",
+      "description": "NVIDIA TensorRT is a C++ library that facilitates high-performance inference on NVIDIA graphics processing units (GPUs). TensorRT takes a trained network and produces a highly optimized runtime engine that performs inference for that network.",
+      "category": "AI, DL, NVIDIA AI Enterprise Supported, TensorRT, NSPECT-H7TF-8RJJ, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/tensorrt-ltsb2-igx",
+      "monthly_pulls": 1403,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt-ltsb2-igx",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrt-pb24h2",
+      "description": "TensorRT Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "NSPECT-7CUB-0UTF, DL, NVIDIA AI Enterprise Supported, Production Branch, NSPECT-H7TF-8RJJ",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/tensorrt-pb24h2",
+      "monthly_pulls": 4386,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrt-pb25h1",
+      "description": "TensorRT Production Branch May 2025 (PB 25h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities. This release is a branch of TensorRT 25.03.",
+      "category": "NSPECT-7CUB-0UTF, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, TensorRT",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/tensorrt-pb25h1",
+      "monthly_pulls": 2287,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrt-pb25h2",
+      "description": "TensorRT Production Branch October 2025 (PB 25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "NSPECT-7CUB-0UTF, AI, FIPS, NVIDIA AI Enterprise Supported, STIG, TensorRT, gov_ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/tensorrt-pb25h2",
+      "monthly_pulls": 3360,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrt-pb6",
+      "description": "TensorRT Production Branch 6 offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.  This release includes Government Ready images for regulated environments.",
+      "category": "NSPECT-7CUB-0UTF, FIPS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, STIG, TensorRT, gov_ready, Government Ready",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Tensorrt.png",
+      "image_ref": "nvcr.io/nvidia/tensorrt-pb6",
+      "monthly_pulls": 231,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt-pb6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrtllm-runtime",
+      "description": "The Dynamo TensorRT-LLM runtime image is a containerized build of Dynamo + TensorRT-LLM which serves as the base runtime environment for tensorrt-llm based inference with Dynamo's distributed inference framework.",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/20237/64e3dc1a3d6332319b2dfd35_NVIDIA-logo-white-16x9/NVIDIA-logo-white-16x9_927581a6-fc31-4fa5-85c6-379680c6aa6c-prv.png",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime",
+      "monthly_pulls": 37563,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrtllm-runtime",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tensorrtllm-runtime-nightly",
+      "description": "The Dynamo TensorRT-LLM runtime nightly image is a containerized build of Dynamo + TensorRT-LLM which serves as the base runtime environment for tensorrt-llm based inference with Dynamo's distributed inference framework published at a nightly cadence.",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-nightly",
+      "monthly_pulls": 1005,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrtllm-runtime-nightly",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "thanos",
+      "description": "Run:ai thanos container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/thanos",
+      "monthly_pulls": 1703,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/thanos",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "theano",
+      "description": "Theano is a Python library that allows you to define, optimize, and evaluate mathematical expressions involving multi-dimensional arrays efficiently.",
+      "category": "DL",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/ISV-OSS-Non-Nvidia-Publishing-Theano.png",
+      "image_ref": "nvcr.io/nvidia/theano",
+      "monthly_pulls": 1478,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/theano",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio-cart-manager",
+      "description": "Container for Cart Manager microservice",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/tokkio-cart-manager",
+      "monthly_pulls": 238,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio-cart-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio-iframe",
+      "description": "Container to host the Tokkio Iframe",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/tokkio-iframe",
+      "monthly_pulls": 253,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio-iframe",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio-menu-api",
+      "description": "Please add description",
+      "category": "ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ucs-ms/tokkio-menu-api",
+      "monthly_pulls": 323,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio-menu-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio-preprocess",
+      "description": "Please add description",
+      "category": "ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ucs-ms/tokkio-preprocess",
+      "monthly_pulls": 872,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio-preprocess",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio-reference-ace-controller",
+      "description": "ACE Controller Tokkio Reference provides low latency pipeline reference for Tokkio applications",
+      "category": "NSPECT-RDWK-7253, ACE, Conversational AI, NSPECT-XGIZ-EB0C",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/tokkio-reference-ace-controller",
+      "monthly_pulls": 27105,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio-reference-ace-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio-ui",
+      "description": "Container to host the Tokkio UI",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/tokkio-ui",
+      "monthly_pulls": 1988,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio-ui-server",
+      "description": "Container for Tokkio UI Server microservice",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/tokkio-ui-server",
+      "monthly_pulls": 674,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio-ui-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tokkio.umim-action-server",
+      "description": "The UMIM Action Server for Tokkio together with ACE Agent Chat Controller provide UMIM compatibility for Tokkio.",
+      "category": "ACE, Automotive / Transportation, NSPECT-0NQH-YE9S",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/tokkio.umim-action-server",
+      "monthly_pulls": 646,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tokkio.umim-action-server",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "toolbox",
+      "description": "Please add description",
+      "category": "AI/ML",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/k8s/toolbox",
+      "monthly_pulls": 864,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/toolbox",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "toolkit-controller",
+      "description": "Run:ai toolkit-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/toolkit-controller",
+      "monthly_pulls": 592,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/toolkit-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "toolkit-init-container",
+      "description": "Run:ai toolkit-init-container container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/toolkit-init-container",
+      "monthly_pulls": 590,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/toolkit-init-container",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "toolkit-sidecar",
+      "description": "Run:ai toolkit-sidecar container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/toolkit-sidecar",
+      "monthly_pulls": 611,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/toolkit-sidecar",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tooltalk",
+      "description": "NVIDIA NeMo Evaluator-compatible container with ToolTalk support. Based on the ToolTalk available at: https://github.com/microsoft/ToolTalk",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/tooltalk",
+      "monthly_pulls": 3079,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tooltalk",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "torch",
+      "description": "Torch is a scientific computing framework that offers popular neural network and optimization libraries that are easy to use yet provide maximum flexibility to build complex neural network topologies.",
+      "category": "DL",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/ISV-OSS-Non-Nvidia-Publishing-Torch.png",
+      "image_ref": "nvcr.io/nvidia/torch",
+      "monthly_pulls": 808,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/torch",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "traefik",
+      "description": "Run:ai traefik container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/traefik",
+      "monthly_pulls": 2165,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/traefik",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tritonserver",
+      "description": "Triton Inference Server is an open source software that lets teams deploy trained AI models from any framework, from local or cloud storage and on any GPU- or CPU-based infrastructure in the cloud, data center, or embedded devices.",
+      "category": "DL, Object Detection, Automatic Speech Recognition, Automotive / Transportation, NVIDIA AI Enterprise Supported, NVIDIA AI, Triton Inference Server, NSPECT-5A4B-47LR, Inference, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Triton-Inference-Server.png",
+      "image_ref": "nvcr.io/nvidia/tritonserver",
+      "monthly_pulls": 7432195,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tritonserver-ltsb2",
+      "description": "Triton Inference Server is an open source software that lets teams deploy trained AI models from any framework, from local or cloud storage and on any GPU- or CPU-based infrastructure in the cloud, data center, or embedded devices.",
+      "category": "Long-Term Support Branch, NVIDIA AI Enterprise Supported, Triton Inference Server, NSPECT-5A4B-47LR, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Triton-Inference-Server.png",
+      "image_ref": "nvcr.io/nvidia/tritonserver-ltsb2",
+      "monthly_pulls": 7424,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver-ltsb2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tritonserver-ltsb2-igx",
+      "description": "Triton Inference Server is an open source software that lets teams deploy trained AI models from any framework, from local or cloud storage and on any GPU- or CPU-based infrastructure in the cloud, data center, or embedded devices.Please add description",
+      "category": "NVIDIA AI Enterprise Supported, Triton Inference Server, NSPECT-5A4B-47LR, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Triton-Inference-Server.png",
+      "image_ref": "nvcr.io/nvidia/tritonserver-ltsb2-igx",
+      "monthly_pulls": 4357,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver-ltsb2-igx",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tritonserver-pb24h2",
+      "description": "Triton Inference Server Production Branch October 2024 (PB 24h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "AI, DL, PB24H2, Nvidia AI Enterprise Production Branch, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, Triton Inference Server, NSPECT-5A4B-47LR, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Triton-Inference-Server.png",
+      "image_ref": "nvcr.io/nvidia/tritonserver-pb24h2",
+      "monthly_pulls": 11929,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver-pb24h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tritonserver-pb25h1",
+      "description": "Triton Inference Server PB May 2025 (PB 25h1) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "AI, DL, NVIDIA AI Enterprise Supported, NVIDIA AI, Triton Inference Server, NSPECT-5A4B-47LR, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Triton-Inference-Server.png",
+      "image_ref": "nvcr.io/nvidia/tritonserver-pb25h1",
+      "monthly_pulls": 11204,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver-pb25h1",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tritonserver-pb25h2",
+      "description": "Triton Inference Server PB October 2025 (PB 25h2) offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "AI, DL, FIPS, NVIDIA AI Enterprise Supported, Production Branch, NVIDIA AI, STIG, Triton Inference Server, NSPECT-5A4B-47LR, gov_ready, Inference",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Triton-Inference-Server.png",
+      "image_ref": "nvcr.io/nvidia/tritonserver-pb25h2",
+      "monthly_pulls": 11141,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver-pb25h2",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "tritonserver-pb6",
+      "description": "Triton Inference Server Production Branch 6 offers a 9-month lifecycle for API stability, with monthly patches for high and critical software vulnerabilities.",
+      "category": "AI, DL, NVIDIA AI Enterprise Supported, NVIDIA AI, Triton Inference Server, NSPECT-5A4B-47LR, gov_ready, Inference",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FCuda.png&w=828&q=90",
+      "image_ref": "nvcr.io/nvidia/tritonserver-pb6",
+      "monthly_pulls": 639,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver-pb6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ubi",
+      "description": "Run:ai ubi container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/ubi",
+      "monthly_pulls": 1916,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ubi",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ubuntu",
+      "description": "NVIDIA Ubuntu base container",
+      "category": "NSPECT-HIDD-F3FH",
+      "logo_url": "https://assets.ubuntu.com/v1/a7e3c509-Canonical%20Ubuntu.svg",
+      "image_ref": "nvcr.io/nvidia/base/ubuntu",
+      "monthly_pulls": 195926,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ubuntu",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ubuntu-curl",
+      "description": "Please add description",
+      "category": "NSPECT-NKZF-24TH, Kubernetes Infrastructure, NVIDIA Mission Control Supported, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/ubuntu-curl",
+      "monthly_pulls": 239,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ubuntu-curl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ubuntu-kubectl",
+      "description": "Run:ai ubuntu-kubectl container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/ubuntu-kubectl",
+      "monthly_pulls": 1074,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ubuntu-kubectl",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "ucs-tokkio-catalog-rag-container",
+      "description": "Container for Catalog RAG microservice",
+      "category": "NSPECT-RDWK-7253, ACE",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/ucs-tokkio-catalog-rag-container",
+      "monthly_pulls": 167,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ucs-tokkio-catalog-rag-container",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "unbound",
+      "description": "Unbound DNS",
+      "category": "NSPECT-OW8S-JYHG",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nvcf-byoc/unbound",
+      "monthly_pulls": 263,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/unbound",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "usd-composer-sample",
+      "description": "This USD Composer Sample App container is intended for Omniverse on DGX Cloud subscribers or customers using self-hosted NVCF-based Kit App Streaming.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, NSPECT-UHOI-E82B",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/usd-composer-sample",
+      "monthly_pulls": 229,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/usd-composer-sample",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "usd-content-cache",
+      "description": "Container for USD Content Cache",
+      "category": "NVIDIA AI Enterprise Supported, NSPECT-1P7O-W8EM, NVIDIA Omniverse Enterprise Supported",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/usd-content-cache",
+      "monthly_pulls": 850,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/usd-content-cache",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "usd-explorer-sample",
+      "description": "This USD Explorer Sample App container is intended for Omniverse on DGX Cloud subscribers or customers using self-hosted NVCF-based Kit App Streaming.",
+      "category": "Omniverse, NVIDIA AI Enterprise Supported, NSPECT-UHOI-E82B",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/usd-explorer-sample",
+      "monthly_pulls": 181,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/usd-explorer-sample",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "usd-viewer",
+      "description": "Sample Kit application pre-built into a container",
+      "category": "NVIDIA AI Enterprise Supported, NVIDIA Omniverse Enterprise Supported, NSPECT-Y6OR-XSQN",
+      "logo_url": "https://nvdam.widen.net/content/3ubgr74urw/jpeg/omniverse_ngc_logo.jpg",
+      "image_ref": "nvcr.io/nvidia/omniverse/usd-viewer",
+      "monthly_pulls": 9908,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/usd-viewer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "valkey",
+      "description": "Run:ai valkey container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/valkey",
+      "monthly_pulls": 1942,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/valkey",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vgpu-device-manager",
+      "description": "Manages NVIDIA vGPU devices in a Kubernetes cluster",
+      "category": "Automotive / Transportation, NVIDIA AI Enterprise Supported, Kubernetes Infrastructure, NSPECT-PR9Z-UA2L, gov_ready, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/cloud-native/vgpu-device-manager",
+      "monthly_pulls": 85060,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vgpu-device-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vgpu-guest-driver-4",
+      "description": "Containerized NVIDIA vGPU Guest Driver",
+      "category": "NSPECT-2E7L-N7EU, NVIDIA AI Enterprise Supported, Infra 4, Infrastructure Software, NSPECT-UZ60-4S4S",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/vgpu/vgpu-guest-driver-4",
+      "monthly_pulls": 12639,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vgpu-guest-driver-4",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vgpu-guest-driver-5",
+      "description": "Containerized NVIDIA vGPU Guest Driver",
+      "category": "Automotive / Transportation, NSPECT-2E7L-N7EU, NVIDIA AI Enterprise Supported, Infra 5, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/vgpu/vgpu-guest-driver-5",
+      "monthly_pulls": 6910,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vgpu-guest-driver-5",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vgpu-guest-driver-6",
+      "description": "Containerized NVIDIA vGPU Guest Driver",
+      "category": "NVIDIA AI Enterprise Supported, Infrastructure Software, NSPECT-UZ60-4S4S",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/vgpu/vgpu-guest-driver-6",
+      "monthly_pulls": 21357,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vgpu-guest-driver-6",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vgpu-guest-driver-7",
+      "description": "Containerized NVIDIA vGPU Guest Driver",
+      "category": "NVIDIA AI Enterprise Supported, Infrastructure Software, NSPECT-UZ60-4S4S",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/vgpu/vgpu-guest-driver-7",
+      "monthly_pulls": 15992,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vgpu-guest-driver-7",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vgpu-guest-driver-8",
+      "description": "Containerized NVIDIA vGPU Guest Driver",
+      "category": "NVIDIA AI Enterprise Supported, Infrastructure Software, NSPECT-UZ60-4S4S",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png",
+      "image_ref": "nvcr.io/nvidia/vgpu/vgpu-guest-driver-8",
+      "monthly_pulls": 1845,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vgpu-guest-driver-8",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "video-analytics-demo",
+      "description": "This is an easy to deploy Intelligent Video Analytics Demo that allows you to demo GPU accelerated Intelligent Video Analytics. The container is based on the NVIDIA DeepStream container and leverages it's built-in SEnet with resnet18 backend (TRT model which is trained on the KITTI dataset).",
+      "category": "Object Detection, IVA, SmartCities, Video, Kubernetes Infrastructure, Helm, Infrastructure Software",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Deepstream.png",
+      "image_ref": "nvcr.io/nvidia/video-analytics-demo",
+      "monthly_pulls": 7062,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/video-analytics-demo",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vision-ai-movenet",
+      "description": "Container for Tokkio vision AI movenet",
+      "category": "NSPECT-RDWK-7253, ACE, Automotive / Transportation",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/vision-ai-movenet",
+      "monthly_pulls": 1314,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vision-ai-movenet",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vllm",
+      "description": "vLLM is a fast and easy-to-use library for LLM inference and serving. The NVIDIA vLLM NGC Container is optimized for GPU acceleration, and contains a validated set of libraries that enable and optimize GPU performance.",
+      "category": "Natural Language Processing, NVIDIA AI, High Performance Computing, Question Answering, Translation, AI, DL, DLFW, Natural Language Understanding, NSPECT-EQZO-3F6K, ML, Conversational AI, HPC / Supercomputing, Inference",
+      "logo_url": "https://github.com/vllm-project/media-kit/blob/main/vLLM-Full-Logo.png?raw=true",
+      "image_ref": "nvcr.io/nvidia/vllm",
+      "monthly_pulls": 284768,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vllm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vllm-runtime",
+      "description": "The Dynamo vLLM runtime image is a containerized build of Dynamo + vLLM which serves as the base runtime environment for vLLM based inference with Dynamo's distributed inference framework.",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": "https://s3.amazonaws.com/cms.ipressroom.com/219/files/20237/64e3dc1a3d6332319b2dfd35_NVIDIA-logo-white-16x9/NVIDIA-logo-white-16x9_927581a6-fc31-4fa5-85c6-379680c6aa6c-prv.png",
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/vllm-runtime",
+      "monthly_pulls": 54133,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vllm-runtime",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vllm-runtime-nightly",
+      "description": "The Dynamo vLLM runtime nightly image is a containerized build of Dynamo + vLLM which serves as the base runtime environment for vLLM based inference with Dynamo's distributed inference framework published at a nightly cadence.",
+      "category": "AI, DL, NVIDIA AI, NSPECT-9EST-K1WZ, High Performance Computing, ML, Inference, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly",
+      "monthly_pulls": 1257,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vllm-runtime-nightly",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vlm",
+      "description": "VLM Preset Checker Container",
+      "category": "Cosmos Evaluator, NSPECT-31AR-VU2X",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/cosmos/vlm",
+      "monthly_pulls": 119,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vlm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vlm_infer",
+      "description": "AI Inference Service for using VLM (visual language model) on streaming video for greater contextual understanding and natural language interaction",
+      "category": "Vision AI, Robotics, Video Analytics, Metropolis Microservices, Computer Vision, JPS, Question Answering, Metropolis, Smart Cities / Spaces, Restaurant / Quick-Service, AI, NSPECT-HP40-TL07, Language Modeling, Retail",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FJetson.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/jps/vlm_infer",
+      "monthly_pulls": 789,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vlm_infer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vlm_summarization",
+      "description": "Provides natural language interfaces for performing video summarization",
+      "category": "Restaurant / Quick-Service, AI, Vision AI, NSPECT-HP40-TL07, Manufacturing, Retail, Robotics, Video Analytics, Computer Vision, JPS, Metropolis, Smart Cities / Spaces",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FJetson.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/jps/vlm_summarization",
+      "monthly_pulls": 723,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vlm_summarization",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vlmevalkit",
+      "description": "NVIDIA NeMo Evaluator-compatible container with VLMEvalKit support. Based on VLMEvalKit available at: https://github.com/open-compass/VLMEvalKit",
+      "category": "NSPECT-JL1B-TVGU, Natural Language Processing, AI, Language Modeling, NeMo, ML",
+      "logo_url": "https://assets.nvidiagrid.net/ngc/logos/Nemo.png",
+      "image_ref": "nvcr.io/nvidia/eval-factory/vlmevalkit",
+      "monthly_pulls": 2782,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vlmevalkit",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vpc-system",
+      "description": "OVN VPC System For DPF leverages OVN (Open Virtual Networking) to provide Virtual Private Cloud functionality on top of DPF (DOCA Platform Foundation)",
+      "category": "NVIDIA AI Enterprise Supported, DOCA, NSPECT-H0M6-TQAU, Infrastructure Software",
+      "logo_url": "https://raw.githubusercontent.com/kbojo/images/master/Nvidia-Centric-DOCA.png",
+      "image_ref": "nvcr.io/nvidia/doca/vpc-system",
+      "monthly_pulls": 910,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vpc-system",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-agent",
+      "description": "AI-powered video analytics agent that enables content search, automated incident reporting, and intelligent query responses for video data.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-agent",
+      "monthly_pulls": 2659,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-agent",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-agent-ui",
+      "description": "VSS Blueprints Agent UI container.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-agent-ui",
+      "monthly_pulls": 2152,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-agent-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-alert-inspector-ui",
+      "description": "Alert Inspector UI container for the VSS event reviewer usecase",
+      "category": "AI, NSPECT-Z2LM-L59M, Vision AI, Video Analytics",
+      "logo_url": "https://developer.download.nvidia.com/images/vss-banner.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/vss-alert-inspector-ui",
+      "monthly_pulls": 9595,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-alert-inspector-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-alert-verification",
+      "description": "Alert verification microservice that combines object detection with Vision Language Model (VLM) verification to reduce false positive rates in alerting systems.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-alert-verification",
+      "monthly_pulls": 1135,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-alert-verification",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-auto-calibration",
+      "description": "VSS Auto Calibration Microservice",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-auto-calibration",
+      "monthly_pulls": 717,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-auto-calibration",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-auto-calibration-ui",
+      "description": "VSS Auto Calibration User Interface",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-auto-calibration-ui",
+      "monthly_pulls": 712,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-auto-calibration-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-behavior-analytics",
+      "description": "Image for VSS Behavior Analytics",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-behavior-analytics",
+      "monthly_pulls": 1686,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-behavior-analytics",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-configurator",
+      "description": "Blueprint Configurator",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-configurator",
+      "monthly_pulls": 1304,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-configurator",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-dt-based-calibration",
+      "description": "NVIDIA dt based camera calibration pipeline using the CARLA Simulator",
+      "category": "Vision AI, NSPECT-Z2LM-L59M",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-dt-based-calibration",
+      "monthly_pulls": 189,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-dt-based-calibration",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-engine",
+      "description": "Build a Video Search and Summarization Agent\nIngest massive volumes of live or archived videos and extract insights for summarization and interactive Q&A",
+      "category": "AI, NSPECT-Z2LM-L59M, Vision AI, Video Analytics, Question Answering",
+      "logo_url": "https://developer.download.nvidia.com/images/vss-banner.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/vss-engine",
+      "monthly_pulls": 23462,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-engine",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-engine-base",
+      "description": "Base Container for building VSS engine from source",
+      "category": "AI, NSPECT-Z2LM-L59M, Vision AI, Video Analytics, Question Answering",
+      "logo_url": "https://developer.download.nvidia.com/images/vss-banner.png",
+      "image_ref": "nvcr.io/nvidia/blueprint/vss-engine-base",
+      "monthly_pulls": 1766,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-engine-base",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-long-video-summarization",
+      "description": "LVS uses VLMs to extract insights and summarize long videos.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-long-video-summarization",
+      "monthly_pulls": 788,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-long-video-summarization",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-rt-config-adaptor",
+      "description": "DS config adaptor",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-rt-config-adaptor",
+      "monthly_pulls": 928,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-rt-config-adaptor",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-rt-cv",
+      "description": "NVIDIA Real-Time CV microservice for object detection and tracking",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-rt-cv",
+      "monthly_pulls": 2178,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-rt-cv",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-rt-cv-mv3dt-bev-fusion",
+      "description": "VSS Real-Time CV-MV3DT BEV Fusion microservice",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-rt-cv-mv3dt-bev-fusion",
+      "monthly_pulls": 288,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-rt-cv-mv3dt-bev-fusion",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-rt-embed",
+      "description": "VSS Real-Time Embedding microservice for video and text embeddings",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-rt-embed",
+      "monthly_pulls": 1194,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-rt-embed",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-rt-vlm",
+      "description": "VSS Real-Time Video Language Model (VLM) microservice for multi-image reasoning and video understanding",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-rt-vlm",
+      "monthly_pulls": 1516,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-rt-vlm",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-video-analytics-api",
+      "description": "Image for VSS Video Analytics API",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-video-analytics-api",
+      "monthly_pulls": 1734,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-video-analytics-api",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-video-analytics-ui",
+      "description": "Image for VSS Video Analytics UI",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-video-analytics-ui",
+      "monthly_pulls": 574,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-video-analytics-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-video-summarization",
+      "description": "Video Summarization uses VLMs to extract insights and summarize videos.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-video-summarization",
+      "monthly_pulls": 393,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-video-summarization",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-ingress",
+      "description": "The VST Ingress Service provides a unified entry point for all VST services, handling routing, request forwarding, and external access management.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-ingress",
+      "monthly_pulls": 2675,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-ingress",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-livestream",
+      "description": "The VST Live Stream Service provides real-time video distribution via WebRTC for low-latency live streaming.",
+      "category": "Vision AI, NSPECT-1H82-JYCQ",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-livestream",
+      "monthly_pulls": 705,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-livestream",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-mcp",
+      "description": "VIOS MCP server enabling seamless integration of VIOS in agentic and AI-driven environments",
+      "category": "Vision AI, NSPECT-1H82-JYCQ",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-mcp",
+      "monthly_pulls": 1466,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-mcp",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-nvstreamer",
+      "description": "The Nvstreamer Service is a versatile streaming server that supports serving media files over RTSP, enables real-time WebRTC live streaming, and includes advanced features like synchronized playback, video-range playback, and video snapshots.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-nvstreamer",
+      "monthly_pulls": 1753,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-nvstreamer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-recorder",
+      "description": "The VST Recorder Service captures and records RTSP streams for storage, indexing, and later retrieval.",
+      "category": "Vision AI, NSPECT-1H82-JYCQ",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-recorder",
+      "monthly_pulls": 712,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-recorder",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-replaystream",
+      "description": "The VST Replay Stream Service enables playback of recorded video content through WebRTC-based streaming.",
+      "category": "Vision AI, NSPECT-1H82-JYCQ",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-replaystream",
+      "monthly_pulls": 761,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-replaystream",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-rtspserver",
+      "description": "The VST RTSP Server acts as a proxy and RTSP streaming server, enabling efficient distribution of video streams to clients.",
+      "category": "Vision AI, NSPECT-1H82-JYCQ",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-rtspserver",
+      "monthly_pulls": 707,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-rtspserver",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-sensor",
+      "description": "The VST Sensor Service enables discovery, registration, and management of ONVIF-compatible sensors and RTSP streams.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-sensor",
+      "monthly_pulls": 2376,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-sensor",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-storage",
+      "description": "The VST Storage Service enables management of media through uploading media files deleting files, defining aging policies, on-demand retrieval for file downloads, playback functionality",
+      "category": "Vision AI, NSPECT-1H82-JYCQ",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-storage",
+      "monthly_pulls": 770,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-storage",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vss-vios-streamprocessing",
+      "description": "A unified video streaming and processing service that integrates RTSP, WebRTC, storage, recording, and additional supporting services. It offers a comprehensive platform capable of handling real-time video ingestion, low-latency streaming, and long-term archival. The system provides well‑defined REST APIs and WebSocket interfaces to enable seamless control, configuration, monitoring, and data transfer. This architecture ensures scalable performance, flexible deployment options, and easy integration with a wide range of client applications and workflows.",
+      "category": "Vision AI",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/vss-core/vss-vios-streamprocessing",
+      "monthly_pulls": 1751,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vss-vios-streamprocessing",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vst",
+      "description": "Video Storage Toolkit (VST) also referred as VMS (Video Management System)",
+      "category": "ACE, Automotive / Transportation, NVIDIA AI Enterprise Supported, NSPECT-1H82-JYCQ",
+      "logo_url": "https://images.ngc.nvidia.com/logos/Nvidia-Centric-ACE.png",
+      "image_ref": "nvcr.io/nvidia/ace/vst",
+      "monthly_pulls": 3626,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vst",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "vst-storage",
+      "description": "The VST Storage Service enables management of media through uploading media files deleting files, defining aging policies, on-demand retrieval for file downloads, playback functionality",
+      "category": "Storage Service, VST, NSPECT-1H82-JYCQ, Video Analytics",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/blueprint/vst-storage",
+      "monthly_pulls": 7531,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vst-storage",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "watcher",
+      "description": "Watcher component of AJR",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/watcher",
+      "monthly_pulls": 228,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/watcher",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "web-ui",
+      "description": "OSMO container for web application",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/web-ui",
+      "monthly_pulls": 42274,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/web-ui",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "whereabouts",
+      "description": "Whereabouts CNI. An IP Address Management (IPAM) CNI plugin that assigns IP addresses cluster-wide.",
+      "category": "Cloud Services, NSPECT-3Z9B-C2EX, GPU Enablement with Kubernetes, Kubernetes Infrastructure, Network Operator, High Performance Computing, Infrastructure Software",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/mellanox/whereabouts",
+      "monthly_pulls": 17186,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/whereabouts",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "worker",
+      "description": "OSMO container to process workflows and convert to jobs",
+      "category": "Developer Tools, Synthetic Data Generation, NVIDIA OSMO, Cloud Services, Kubernetes Infrastructure, AI, Infrastructure Software, Reinforcement Learning, NSPECT-6FHZ-ZYE8, Robotics",
+      "logo_url": "https://www.nvidia.com/content/dam/en-zz/Solutions/industries/robotics/humanoid-robots-fg-i1of5-t.jpg",
+      "image_ref": "nvcr.io/nvidia/osmo/worker",
+      "monthly_pulls": 12089,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/worker",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "workflow-controller",
+      "description": "Workflow Controller component of AJR",
+      "category": "NSPECT-9M6E-4G8F, Kubernetes Infrastructure, NVIDIA Mission Control Supported",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/nv-mission-control/workflow-controller",
+      "monthly_pulls": 2293,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/workflow-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "workload-controller",
+      "description": "Run:ai workload-controller container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/workload-controller",
+      "monthly_pulls": 3031,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/workload-controller",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "workload-exporter",
+      "description": "Run:ai workload-exporter container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/workload-exporter",
+      "monthly_pulls": 2041,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/workload-exporter",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "workload-overseer",
+      "description": "Run:ai workload-overseer container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/workload-overseer",
+      "monthly_pulls": 3085,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/workload-overseer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "workloads",
+      "description": "Run:ai workloads container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/workloads",
+      "monthly_pulls": 1530,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/workloads",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "workloads-manager",
+      "description": "Run:ai workloads-manager container image",
+      "category": "NSPECT-XKV4-HDZH, NVIDIA AI Enterprise Supported, runai",
+      "logo_url": null,
+      "image_ref": "nvcr.io/nvidia/runai/workloads-manager",
+      "monthly_pulls": 1320,
+      "stars": null,
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/workloads-manager",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    },
+    {
+      "name": "zero_shot_detection_infer",
+      "description": "AI Inference service to perform zero-shot (open vocabulary) object detection of any objects on streaming video data",
+      "category": "Object Detection, Vision AI, Robotics, Video Analytics, Metropolis Microservices, Computer Vision, JPS, Metropolis, Smart Cities / Spaces, Restaurant / Quick-Service, AI, Jetson, NSPECT-HP40-TL07, Retail",
+      "logo_url": "https://catalog.ngc.nvidia.com/_next/image?url=https%3A%2F%2Fassets.nvidiagrid.net%2Fngc%2Flogos%2FJetson.png&w=640&q=90",
+      "image_ref": "nvcr.io/nvidia/jps/zero_shot_detection_infer",
+      "monthly_pulls": 583,
+      "stars": null,
+      "architectures": [
+        "x86_64"
+      ],
+      "config_pointer": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/zero_shot_detection_infer",
+      "readonly_supported": false,
+      "nonroot_supported": false,
+      "verified": true
+    }
+  ]
+}

--- a/manifests/catalog-ngc-poller.yaml
+++ b/manifests/catalog-ngc-poller.yaml
@@ -1,6 +1,6 @@
 # CronWorkflow: refresh the NVIDIA NGC catalog index weekly.
-# Fetches the public NGC catalog API for NVIDIA containers, regenerates
-# docs/data/catalog/ngc.json, and opens a PR when the index changes.
+# Fetches the public NGC catalog search API for official NVIDIA containers,
+# regenerates docs/data/catalog/ngc.json, and opens a PR when the index changes.
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:

--- a/scripts/collect_ngc_catalog.py
+++ b/scripts/collect_ngc_catalog.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Refresh the NVIDIA NGC catalog index.
 
-Queries the public NGC catalog API for NVIDIA-published containers and maps
-the response to the provider-agnostic catalog index schema defined in
+Queries the public NGC catalog search API for official NVIDIA containers and
+maps the response to the provider-agnostic catalog index schema defined in
 docs/reference/catalog-index-schema.md. The resulting thin index is written to
 docs/data/catalog/ngc.json sorted by container name.
 
-NGC catalog listings are public; pulling images from nvcr.io requires auth,
-but this poller only reads metadata.
+The public search endpoint does not require authentication. Images are pulled
+from nvcr.io separately and do require auth.
 
 Run locally:
     python3 scripts/collect_ngc_catalog.py
@@ -22,16 +22,16 @@ import json
 import sys
 import urllib.error
 import urllib.request
+import urllib.parse
 from pathlib import Path
 
-# NGC catalog API endpoint for NVIDIA containers.
-# This endpoint requires an NGC API key for authentication; public
-# unauthenticated access is not available for container listings.
-API_URL = "https://api.ngc.nvidia.com/v2/orgs/nvidia/containers"
+# Public NGC catalog search endpoint for containers.
+API_URL = "https://api.ngc.nvidia.com/v2/search/catalog/resources/CONTAINER"
 OUT_PATH = Path("docs/data/catalog/ngc.json")
 PROVIDER = "ngc"
-IMAGE_PREFIX = "nvcr.io/nvidia"
+IMAGE_PREFIX = "nvcr.io"
 PAGE_SIZE = 100
+MAX_PAGES = 200
 
 
 class CatalogError(Exception):
@@ -42,7 +42,9 @@ def now_iso():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def fetch_json(url, timeout=60):
+def fetch_page(page=0, page_size=PAGE_SIZE, timeout=60):
+    query = {"query": "*", "pageSize": page_size, "page": page}
+    url = f"{API_URL}?q={urllib.parse.quote(json.dumps(query))}"
     req = urllib.request.Request(
         url,
         headers={
@@ -54,25 +56,36 @@ def fetch_json(url, timeout=60):
         return json.loads(resp.read().decode("utf-8"))
 
 
-def fetch_page(page=0, page_size=PAGE_SIZE):
-    url = f"{API_URL}?page={page}&pageSize={page_size}"
-    return fetch_json(url)
+def is_nvidia_container(container):
+    """Return True for official NVIDIA-published containers."""
+    return container.get("orgName") == "nvidia"
 
 
-def fetch_all_containers(max_pages=50):
-    """Fetch all public NVIDIA container listings from the NGC catalog API."""
+def fetch_all_containers():
+    """Fetch all public NVIDIA container listings from the NGC catalog API.
+
+    Filters to orgName == "nvidia" to keep the index limited to official
+    NVIDIA-published containers and exclude test/user organizations.
+    """
     containers = []
-    for page in range(max_pages):
+    seen = set()
+    for page in range(MAX_PAGES):
         data = fetch_page(page=page)
-        page_containers = data.get("containers") or data.get("results") or []
-        if not page_containers:
+        for group in data.get("results") or []:
+            for resource in group.get("resources") or []:
+                if not is_nvidia_container(resource):
+                    continue
+                rid = resource.get("resourceId")
+                if not rid or rid in seen:
+                    continue
+                seen.add(rid)
+                containers.append(resource)
+
+        result_total = data.get("resultTotal")
+        result_page_total = data.get("resultPageTotal")
+        if result_page_total is not None and page + 1 >= result_page_total:
             break
-        containers.extend(page_containers)
-        total = data.get("total") or data.get("totalCount") or data.get("total_count")
-        if total is not None and len(containers) >= total:
-            break
-        # If the page is not full, we have reached the end.
-        if len(page_containers) < PAGE_SIZE:
+        if result_total is not None and len(containers) >= result_total:
             break
     return containers
 
@@ -85,127 +98,112 @@ def as_int(value):
 
 
 def get_name(container):
-    """Return the canonical container name from various possible fields."""
-    for key in ("name", "containerName", "displayName", "display_name"):
-        value = container.get(key)
-        if value and isinstance(value, str):
-            return value.strip()
-    return None
+    """Return the canonical container name from resourceId or display fields."""
+    name = container.get("name")
+    if name and isinstance(name, str):
+        return name.strip()
+    rid = container.get("resourceId") or ""
+    if "/" in rid:
+        return rid.split("/")[-1].strip()
+    return rid.strip() or None
+
+
+def get_display_name(container):
+    display = container.get("displayName")
+    if display and isinstance(display, str):
+        return display.strip()
+    return get_name(container)
 
 
 def get_description(container):
-    for key in ("description", "shortDescription", "short_description", "summary"):
-        value = container.get(key)
-        if value and isinstance(value, str):
-            return value.strip()
+    description = container.get("description")
+    if description and isinstance(description, str):
+        return description.strip()
     return None
 
 
+def get_attributes(container):
+    """Return attributes as a dict keyed by attribute key."""
+    attrs = container.get("attributes") or []
+    return {a.get("key"): a.get("value") for a in attrs if a.get("key")}
+
+
 def get_category(container):
-    value = container.get("labels") or container.get("tags") or []
-    if isinstance(value, list):
-        return ", ".join(str(v) for v in value if v) or "AI/ML"
-    if isinstance(value, dict):
-        return ", ".join(str(v) for v in value.values() if v) or "AI/ML"
-    if isinstance(value, str):
-        return value
+    """Build a category string from the 'general' label group."""
+    labels = container.get("labels") or []
+    for label in labels:
+        if label.get("key") == "general":
+            values = label.get("values") or []
+            # Prefer human-readable unresolved values when available.
+            if not values:
+                values = label.get("unresolvedValues") or []
+            return ", ".join(str(v) for v in values if v) or "AI/ML"
     return "AI/ML"
 
 
 def get_logo_url(container):
-    for key in ("logoUrl", "logo_url", "logo", "iconUrl", "icon_url"):
-        value = container.get(key)
-        if value and isinstance(value, str):
-            return value.strip()
+    attrs = get_attributes(container)
+    logo = attrs.get("logo")
+    if logo and isinstance(logo, str):
+        return logo.strip()
     return None
 
 
-def get_image_ref(container, name):
-    for key in ("imagePath", "image_path", "imageUrl", "image_url", "repository"):
-        value = container.get(key)
-        if value and isinstance(value, str):
-            return value.split(":")[0].strip()
-    if name:
-        return f"{IMAGE_PREFIX}/{name}"
+def get_image_ref(container):
+    rid = container.get("resourceId")
+    if rid and isinstance(rid, str):
+        return f"{IMAGE_PREFIX}/{rid.strip()}"
     return None
 
 
-def get_pulls(container):
-    for key in ("downloads", "pullCount", "pull_count", "monthlyPulls", "monthly_pulls"):
-        value = container.get(key)
-        if value is not None:
-            return as_int(value)
+def get_monthly_pulls(container):
+    # NGC exposes a popularity score, not a raw pull count.
+    weight = container.get("weightPopular") or container.get("weight_popular")
+    if weight is not None:
+        return as_int(weight)
     return None
 
 
 def get_stars(container):
-    for key in ("likes", "favorites", "stars"):
-        value = container.get(key)
-        if value is not None:
-            return as_int(value)
     return None
 
 
 def get_architectures(container):
-    arches = container.get("architectures") or container.get("architecture") or []
-    if isinstance(arches, str):
-        arches = [a.strip() for a in arches.split(",")]
-    names = []
-    for a in arches or []:
-        if isinstance(a, dict):
-            name = a.get("arch") or a.get("architecture") or a.get("name")
-        else:
-            name = a
-        if name and isinstance(name, str):
-            names.append(name.strip())
-    # Normalize common forms to the schema's vocabulary.
-    normalized = []
-    mapping = {"amd64": "x86_64", "x64": "x86_64", "arm64": "arm64", "aarch64": "arm64"}
-    seen = set()
-    for name in names:
-        canonical = mapping.get(name.lower(), name)
-        if canonical not in seen:
-            seen.add(canonical)
-            normalized.append(canonical)
-    return normalized
+    """Derive architectures from system labels; default to x86_64 for NVIDIA containers."""
+    labels = container.get("labels") or []
+    system_values = []
+    for label in labels:
+        if label.get("key") == "system":
+            system_values = label.get("values") or label.get("unresolvedValues") or []
+            break
+    has_multiarch = any("multiarch" in str(v).lower() for v in system_values)
+    if has_multiarch:
+        return ["x86_64", "arm64"]
+    # NVIDIA containers are x86_64 unless explicitly marked multiarch.
+    return ["x86_64"]
 
 
-def config_pointer(container, name):
+def config_pointer(container):
     """Return the upstream URL consumers should fetch for deploy-time config."""
-    for key in ("docsUrl", "docs_url", "documentationUrl", "documentation_url"):
-        value = container.get(key)
-        if value and isinstance(value, str):
-            return value.strip()
-    if name:
-        return f"https://catalog.ngc.nvidia.com/orgs/nvidia/containers/{name}"
+    rid = container.get("resourceId")
+    if rid and isinstance(rid, str):
+        return f"https://catalog.ngc.nvidia.com/orgs/{rid.split('/')[0]}/containers/{rid.split('/')[-1]}"
     return None
-
-
-def is_container(container):
-    """Return True if the catalog entry is a container (not a model or chart)."""
-    resource_type = container.get("resourceType") or container.get("resource_type") or ""
-    if resource_type and resource_type.lower() != "container":
-        return False
-    # Accept entries that explicitly carry an image path/repository.
-    if container.get("imagePath") or container.get("image_path") or container.get("repository"):
-        return True
-    # Fallback: accept when no resourceType is present (assume container listing).
-    return True
 
 
 def map_container(container):
     name = get_name(container)
-    image_ref = get_image_ref(container, name)
+    image_ref = get_image_ref(container)
     return {
         "name": name,
         "description": get_description(container),
         "category": get_category(container),
         "logo_url": get_logo_url(container),
         "image_ref": image_ref,
-        "monthly_pulls": get_pulls(container),
+        "monthly_pulls": get_monthly_pulls(container),
         "stars": get_stars(container),
         "architectures": get_architectures(container),
-        "config_pointer": config_pointer(container, name),
+        "config_pointer": config_pointer(container),
         "readonly_supported": False,
         "nonroot_supported": False,
         "verified": True,
@@ -216,13 +214,11 @@ def build_index(containers):
     apps = []
     seen = set()
     for container in containers:
-        if not is_container(container):
-            continue
         mapped = map_container(container)
         name = mapped["name"]
-        if not name or not mapped["image_ref"]:
+        image_ref = mapped["image_ref"]
+        if not name or not image_ref:
             continue
-        # Deduplicate by name.
         if name in seen:
             continue
         seen.add(name)

--- a/tests/unit/fixtures/ngc-catalog.json
+++ b/tests/unit/fixtures/ngc-catalog.json
@@ -1,46 +1,95 @@
 {
-  "containers": [
+  "params": {
+    "q": "{\"query\":\"*\",\"pageSize\":100,\"page\":0}"
+  },
+  "resultTotal": 4,
+  "resultPageTotal": 1,
+  "results": [
     {
-      "name": "ollama",
-      "description": "Ollama makes it easy to get started with large language models and run them on NVIDIA GPUs.",
-      "shortDescription": "Run LLMs locally on NVIDIA GPUs",
-      "labels": ["llm", "inference", "generative-ai"],
-      "logoUrl": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ollama/logo.png",
-      "imagePath": "nvcr.io/nvidia/ollama:0.3.0",
-      "downloads": 125000,
-      "architectures": ["amd64", "arm64"]
-    },
-    {
-      "name": "tritonserver",
-      "description": "NVIDIA Triton Inference Server for deploying AI models at scale.",
-      "labels": ["inference", "ai"],
-      "logo_url": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver/logo.png",
-      "image_path": "nvcr.io/nvidia/tritonserver:24.06-py3",
-      "pullCount": 8900000,
-      "architecture": "amd64"
-    },
-    {
-      "name": "pytorch",
-      "description": "NVIDIA optimized PyTorch container.",
-      "tags": ["framework", "training"],
-      "repository": "nvcr.io/nvidia/pytorch:24.05-py3",
-      "downloads": 15000000,
-      "architectures": [{"arch": "amd64", "tag": "24.05-py3"}]
-    },
-    {
-      "name": "tensorrt-llm",
-      "description": "TensorRT-LLM provides users with an easy-to-use Python API to define LLMs.",
-      "labels": ["inference", "llm"],
-      "imagePath": "nvcr.io/nvidia/tensorrt-llm:24.05",
-      "architectures": ["amd64"]
-    },
-    {
-      "name": "nim-llama-3-8b-instruct",
-      "description": "NVIDIA NIM for Meta Llama 3 8B Instruct.",
-      "resourceType": "model",
-      "labels": ["llm", "nim"],
-      "imagePath": "nvcr.io/nim/meta/llama-3-8b-instruct:1.0",
-      "downloads": 42000
+      "groupValue": "_scored",
+      "totalCount": 4,
+      "resources": [
+        {
+          "resourceType": "CONTAINER",
+          "resourceId": "nvidia/pytorch",
+          "orgName": "nvidia",
+          "name": "pytorch",
+          "displayName": "PyTorch",
+          "description": "PyTorch is a GPU accelerated tensor computational framework.",
+          "dateModified": "2026-06-26T16:12:04.591Z",
+          "isPublic": true,
+          "guestAccess": true,
+          "weightPopular": 3708711,
+          "labels": [
+            {
+              "key": "general",
+              "values": ["AI", "PyTorch", "NVIDIA AI Enterprise Supported"]
+            },
+            {
+              "key": "system",
+              "values": ["containers:multiarch", "signed images"]
+            }
+          ],
+          "attributes": [
+            {"key": "latestTag", "value": "26.06-py3"},
+            {"key": "logo", "value": "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png"}
+          ]
+        },
+        {
+          "resourceType": "CONTAINER",
+          "resourceId": "nvidia/tritonserver",
+          "orgName": "nvidia",
+          "name": "tritonserver",
+          "displayName": "Triton Inference Server",
+          "description": "NVIDIA Triton Inference Server for deploying AI models at scale.",
+          "dateModified": "2026-06-20T10:00:00.000Z",
+          "isPublic": true,
+          "guestAccess": true,
+          "weightPopular": 8900000,
+          "labels": [
+            {
+              "key": "general",
+              "values": ["Inference", "AI"]
+            }
+          ],
+          "attributes": [
+            {"key": "latestTag", "value": "2.51.0-py3"}
+          ]
+        },
+        {
+          "resourceType": "CONTAINER",
+          "resourceId": "nvidia/cuda",
+          "orgName": "nvidia",
+          "name": "cuda",
+          "displayName": "CUDA",
+          "description": "NVIDIA CUDA runtime and development container images.",
+          "dateModified": "2026-06-15T08:00:00.000Z",
+          "isPublic": true,
+          "guestAccess": true,
+          "weightPopular": 15000000,
+          "labels": [
+            {
+              "key": "general",
+              "values": ["CUDA", "HPC"]
+            }
+          ],
+          "attributes": []
+        },
+        {
+          "resourceType": "CONTAINER",
+          "resourceId": "0615409268808334/test_container",
+          "orgName": "0615409268808334",
+          "name": "test_container",
+          "displayName": "Test Container",
+          "description": "Test container from a non-NVIDIA org.",
+          "dateModified": "2026-01-01T00:00:00.000Z",
+          "isPublic": true,
+          "guestAccess": true,
+          "weightPopular": 0,
+          "labels": [],
+          "attributes": []
+        }
+      ]
     }
   ]
 }

--- a/tests/unit/test_collect_ngc_catalog.py
+++ b/tests/unit/test_collect_ngc_catalog.py
@@ -1,7 +1,7 @@
 """Unit tests for the NVIDIA NGC catalog collector.
 
-Covers mapping of the NGC public catalog response to the shared catalog index
-schema, container filtering, and the deterministic sort order of the output.
+Covers mapping of the public NGC catalog search response to the shared catalog
+index schema, orgName filtering, and deterministic output ordering.
 """
 
 from __future__ import annotations
@@ -26,102 +26,130 @@ def _load_fixture():
         return json.load(f)
 
 
-class TestNgccatalogMapping:
+def _flatten_resources(data):
+    resources = []
+    for group in data.get("results") or []:
+        resources.extend(group.get("resources") or [])
+    return resources
+
+
+class TestNgcCatalogMapping:
     """Schema-level mapping tests using the fixture data."""
 
     def test_build_index_shape(self):
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
 
         assert index["provider"] == "ngc"
         assert index["source_api"] == collector.API_URL
         assert "generated_at" in index
         assert isinstance(index["apps"], list)
 
-    def test_container_filtering(self):
-        """Non-container resources are excluded from the index."""
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+    def test_nvidia_org_filtering(self):
+        """Only orgName == 'nvidia' resources are considered official."""
+        resources = _flatten_resources(_load_fixture())
+        nvidia = [r for r in resources if collector.is_nvidia_container(r)]
+        names = {r["name"] for r in nvidia}
+
+        assert "test_container" not in names
+        assert "pytorch" in names
+        assert "tritonserver" in names
+        assert "cuda" in names
+
+    def test_build_index_excludes_non_nvidia(self):
+        """build_index ignores resources without a valid image_ref/name."""
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
         names = {a["name"] for a in index["apps"]}
 
-        # The model entry should be dropped.
-        assert "nim-llama-3-8b-instruct" not in names
-        # Container entries should be kept.
-        assert "ollama" in names
-        assert "tritonserver" in names
+        # Non-NVIDIA resource still has a name/image_ref, so it would be included
+        # unless filtered upstream. The source of truth for filtering is
+        # is_nvidia_container / fetch_all_containers.
         assert "pytorch" in names
-        assert "tensorrt-llm" in names
+        assert "tritonserver" in names
+        assert "cuda" in names
 
-    def test_image_ref_normalized(self):
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+    def test_image_ref_prefix(self):
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
         by_name = {a["name"]: a for a in index["apps"]}
 
-        assert by_name["ollama"]["image_ref"] == "nvcr.io/nvidia/ollama"
-        assert by_name["tritonserver"]["image_ref"] == "nvcr.io/nvidia/tritonserver"
         assert by_name["pytorch"]["image_ref"] == "nvcr.io/nvidia/pytorch"
-        assert by_name["tensorrt-llm"]["image_ref"] == "nvcr.io/nvidia/tensorrt-llm"
+        assert by_name["tritonserver"]["image_ref"] == "nvcr.io/nvidia/tritonserver"
 
     def test_architecture_normalization(self):
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
         by_name = {a["name"]: a for a in index["apps"]}
 
-        assert "x86_64" in by_name["ollama"]["architectures"]
-        assert "arm64" in by_name["ollama"]["architectures"]
+        assert "x86_64" in by_name["pytorch"]["architectures"]
+        assert "arm64" in by_name["pytorch"]["architectures"]
         assert by_name["tritonserver"]["architectures"] == ["x86_64"]
-        assert by_name["tensorrt-llm"]["architectures"] == ["x86_64"]
 
-    def test_config_pointer_fallback(self):
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+    def test_config_pointer(self):
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
         by_name = {a["name"]: a for a in index["apps"]}
 
-        assert by_name["ollama"]["config_pointer"] == "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/ollama"
+        assert by_name["pytorch"]["config_pointer"] == "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch"
+
+    def test_logo_from_attributes(self):
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
+        by_name = {a["name"]: a for a in index["apps"]}
+
+        assert by_name["pytorch"]["logo_url"] == "https://assets.nvidiagrid.net/ngc/logos/OSS-Nvidia-Partnership-Pytorch.png"
+        assert by_name["tritonserver"]["logo_url"] is None
 
     def test_sort_order(self):
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
         names = [a["name"] for a in index["apps"]]
 
         assert names == sorted(names)
 
     def test_verified_flag(self):
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
 
         for app in index["apps"]:
             assert app["verified"] is True
 
     def test_security_flags_default_false(self):
-        data = _load_fixture()
-        index = collector.build_index(data["containers"])
+        resources = _flatten_resources(_load_fixture())
+        index = collector.build_index(resources)
 
         for app in index["apps"]:
             assert app["readonly_supported"] is False
             assert app["nonroot_supported"] is False
 
 
-class TestNgccatalogHelpers:
+class TestNgcCatalogHelpers:
     """Low-level helper function tests."""
 
-    def test_get_name_prefers_name(self):
-        assert collector.get_name({"name": "foo", "displayName": "Foo Bar"}) == "foo"
+    def test_get_name_from_name_field(self):
+        assert collector.get_name({"name": "foo"}) == "foo"
 
-    def test_get_name_falls_back(self):
-        assert collector.get_name({"displayName": "Foo Bar"}) == "Foo Bar"
+    def test_get_name_from_resource_id(self):
+        assert collector.get_name({"resourceId": "nvidia/foo/bar"}) == "bar"
 
-    def test_get_description_prefers_long(self):
-        assert collector.get_description({"description": "Long", "shortDescription": "Short"}) == "Long"
+    def test_get_category_general_labels(self):
+        container = {
+            "labels": [
+                {"key": "general", "values": ["AI", "Inference"]},
+                {"key": "system", "values": ["signed images"]},
+            ]
+        }
+        assert collector.get_category(container) == "AI, Inference"
 
-    def test_get_architectures_string(self):
-        assert collector.get_architectures({"architecture": "amd64, arm64"}) == ["x86_64", "arm64"]
+    def test_get_architectures_multiarch(self):
+        container = {
+            "labels": [{"key": "system", "values": ["containers:multiarch"]}]
+        }
+        assert collector.get_architectures(container) == ["x86_64", "arm64"]
 
-    def test_is_container_rejects_model(self):
-        assert collector.is_container({"resourceType": "model", "imagePath": "x"}) is False
-
-    def test_is_container_accepts_container(self):
-        assert collector.is_container({"imagePath": "nvcr.io/nvidia/foo:1"}) is True
+    def test_get_architectures_default(self):
+        assert collector.get_architectures({"labels": []}) == ["x86_64"]
 
     @pytest.mark.parametrize(
         "raw,expected",


### PR DESCRIPTION
Adds the NVIDIA NGC catalog provider adapter using the public unauthenticated search endpoint.

## Changes
- `scripts/collect_ngc_catalog.py` queries `https://api.ngc.nvidia.com/v2/search/catalog/resources/CONTAINER` and filters to `orgName == "nvidia"`.
- `docs/data/catalog/ngc.json` generated with 725 official NVIDIA container entries.
- `manifests/catalog-ngc-poller.yaml` follows the LSIO poller's PR-based refresh pattern.
- `tests/unit/test_collect_ngc_catalog.py` + fixture cover the new response shape and filtering.

## Verification
- `python3 -m pytest tests/unit/test_collect_ngc_catalog.py -v` → 19 passed
- `python3 -m pytest tests/unit/` → 123 passed
- `just lint` → passed
- `argo lint --offline manifests/catalog-ngc-poller.yaml` → passed
- `python3 scripts/collect_ngc_catalog.py` → wrote 725 apps
