### PR TITLE
docs(skills): fleet session write-back — NGC public API and catalog rebuild coupling

### DIFF
--- a/docs/skills/astro-dashboard-pages/SKILL.md
+++ b/docs/skills/astro-dashboard-pages/SKILL.md
@@ -134,6 +134,8 @@ Read the published JSON contract at prerender time, join any linked result JSON 
 89. For containerDisk or OCI image inventory pages, query the local Zot registry at build time with short timeouts and fall back to a static catalog definition when the registry is unreachable. Label sizes as compressed OCI layer sizes, not unpacked raw disk sizes, and show availability per tag explicitly.
 90. Load page-specific chart code as a plain-global script (no ESM imports) in `src/scripts/`, reference it from the Astro page via `import chartSrc from '../scripts/x.js?url'`, and emit it with `<script is:inline src={chartSrc} defer data-cfasync="false">` alongside the echarts CDN tag carrying the same attributes. Never use a bare `<script type="module">` for chart boot code: Cloudflare Rocket Loader rewrites module script types on the live site and the charts silently die. An Astro `<script>` with any attribute is treated as `is:inline` and ships raw — an ESM `import` statement inside it will not be bundled and will throw at runtime. Reference implementations: `src/pages/builds.astro` and `src/components/TestsCharts.astro`.
 
+91. The `/catalog` page embeds all `docs/data/catalog/*.json` provider indexes into the HTML payload at build time (`src/lib/catalog-page.ts` readdir + inline JSON script tag). Adding or refreshing a provider index file does NOT update the live page by itself — a Pages rebuild (`npm run build`, commit `docs/`) must land in the same or a follow-up PR, or the live catalog silently lags the data (this bit the NGC index in #361 and was fixed by rebuild PR #362). Verify with `grep -o '"provider":"<name>"' docs/catalog/index.html | wc -l`.
+
 ## Verification
 
 - [ ] Page prerender loads repo-tracked JSON at build time with repo-root paths

--- a/docs/skills/registry-catalog/SKILL.md
+++ b/docs/skills/registry-catalog/SKILL.md
@@ -63,7 +63,15 @@ For linuxserver.io it is the `application_setup` README anchor.
 
 - **linuxserver.io** is the reference rich-API tier. The poller uses
   `https://api.linuxserver.io/api/v1/images?include_config=true`.
-- Future providers (NGC, AMD, DockerHub) reuse the same index schema but may
+- **NGC (NVIDIA)** is live (`scripts/collect_ngc_catalog.py`,
+  `manifests/catalog-ngc-poller.yaml`, `docs/data/catalog/ngc.json`).
+  Use the PUBLIC unauthenticated search endpoint
+  `https://api.ngc.nvidia.com/v2/search/catalog/resources/CONTAINER`
+  (paginated `q={"query":"*","pageSize":N,"page":M}`); the per-org
+  containers endpoint (`/v2/orgs/nvidia/containers`) returns 401 without
+  an API key — do not use it. Filter results to `orgName == "nvidia"` to
+  keep only official images; image refs are `nvcr.io/<resourceId>`.
+- Future providers (AMD, DockerHub) reuse the same index schema but may
   leave many fields `null`/`false`. They only need to populate `name`,
   `description`, `image_ref`, and `config_pointer`.
 


### PR DESCRIPTION
End-of-session skill write-back per meta-skill-improvement loop:

- **registry-catalog**: NGC provider adapter is live (#358/#361). Documents the working public unauthenticated search endpoint (`/v2/search/catalog/resources/CONTAINER`), warns that the per-org containers endpoint returns 401 unauthenticated (this caused a false blocker during implementation), and records the `orgName == nvidia` curation rule.
- **astro-dashboard-pages**: the `/catalog` page embeds `docs/data/catalog/*.json` at build time, so index changes need a Pages rebuild in the same or a follow-up PR (bit us in #361, fixed by #362). Adds a grep verification recipe.