### PR TITLE
fix(qa): pass init explicitly to nested image tests

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -165,7 +165,7 @@ spec:
           --volume /workspace:/workspace:ro \
           --volume /tmp/results:/tmp/results \
           --volume /etc/resolv.conf:/etc/resolv.conf:ro \
-          "${IMAGE}" >/dev/null
+          "${IMAGE}" /sbin/init >/dev/null
 
         ready=false
         for _ in $(seq 1 60); do

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -150,6 +150,11 @@ Key rules:
 
 #### Container-only QA runner: publish digest-pinned results
 
+When starting the nested target with Podman, pass `/sbin/init` explicitly after the
+image reference. Some bootc OCI images have an empty image `Cmd`; relying on
+`--systemd=always` alone then makes crun fail with `cannot find `` in $PATH` before
+systemd starts.
+
 `run-container-tests` runs inside a privileged `quay.io/podman/stable:latest` container, which does not include `git` or `skopeo`. When publishing BDD evidence back to the lab repo:
 
 1. Install tooling if it is missing: `command -v skopeo >/dev/null || dnf install -y skopeo` and `command -v git >/dev/null || dnf install -y git-core`.

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -70,6 +70,7 @@ def test_container_runner_uses_a_nested_systemd_target_with_bounded_resources():
     assert "podman run --detach --systemd=always" in content
     assert "--network host" in content
     assert "--volume /etc/resolv.conf:/etc/resolv.conf:ro" in content
+    assert '"${IMAGE}" /sbin/init' in content
     assert "systemctl is-active dbus systemd-logind" in content
     assert "bluefin-test:x:1000:1000" in content
     assert "bluefin-test ALL=(ALL) NOPASSWD: ALL" in content


### PR DESCRIPTION
## Summary

Pass `/sbin/init` explicitly when `run-container-tests` starts a nested bootc OCI image. Some images have an empty image `Cmd`; relying on `--systemd=always` alone makes crun fail with `cannot find `` in $PATH` before systemd starts.

Also records the workflow lesson and adds a regression assertion.

## Verification

- YAML parses successfully.
- Targeted workflow tests reach the new assertion; the existing test file still has three unrelated baseline failures (two stale paths and one pre-existing content assertion).
- `git diff --check` passes.

Assisted-by: GPT-5 via pi