### PR TITLE
docs(pr-review): document lab-authoritative Dakota merge gate

### DIFF
--- a/docs/skills/dakota-pr-review/SKILL.md
+++ b/docs/skills/dakota-pr-review/SKILL.md
@@ -28,33 +28,42 @@ metadata:
 
 ## Core Process
 
-1. Treat Dakota PRs as lab-backed changes, not just code-review items.
-2. Before dispatch, confirm the PR has verified maintainer approval. `pr/needs-review`, `automerge`, and `chore/deps` labels do not substitute for an approval review; stop at the human gate when approval is absent.
-3. Let the PR poller dispatch `dakota-pr-batch-pipeline` for open Dakota PRs labeled `test-on-lab`; if it does not, trigger the workflow manually against the PR number or branch.
-4. Track the workflow in Argo and keep the run linked to the PR.
-5. Report the outcome as pass/fail with blockers, not a vague “looks fine.”
-6. Return to maintainers with a short summary and the next action.
+Dakota PR review is a lab-backed admission process. GitHub Actions status is advisory when the repository's known CI/merge-queue path is broken; the lab result is the merge gate for this workflow.
 
-## Maintainer Policy
+1. Confirm the PR number, target branch, head SHA, and that it is still open and mergeable.
+2. Do not treat `pr/needs-review`, `automerge`, or `chore/deps` labels as approval. Verify maintainer approval when the repository policy requires it.
+3. Build the exact PR head SHA with `dakota-build-pipeline` in distributed (`re`) mode. Use the live WorkflowTemplate parameters; do not guess them.
+4. Test the resulting image with `dakota-container-qa-pipeline` (image smoke checks) and, when the image supports it, `dakota-qa-pipeline`/`run-container-tests` for the full containerized BDD/GUI suites.
+5. Keep each build serialized by the `bst-build` semaphore. Never start competing Dakota BST builds; queue them and process one PR at a time.
+6. Capture Argo workflow names, exact SHAs, build mode, test result, and failure logs. A pass must be tied to the same commit that will be merged.
+7. If build and E2E pass, recheck the PR head and mergeability, then merge directly. Do not use GitHub merge queue for this process: queue promotion has historically evaluated the wrong/stale commit when GHA is failing.
+8. If lab validation fails, do not merge. Classify infrastructure failures separately from source/test failures and rerun only after the blocker is fixed.
 
-- Maintainers own merge and hold decisions; operators do not merge.
-- A Dakota PR should stay in review until a fresh lab run is attached and the result is understood.
-- If the workflow is missing, failing, or inconclusive, hold the PR and request a rerun or follow-up.
-- Merge only when the evidence is green and no unresolved blocker remains.
+## Merge Policy
+
+- The lab is authoritative for this operator flow when Dakota GHA checks are known to fail for unrelated CI or merge-queue reasons.
+- Direct merge is allowed only after the exact PR SHA has a successful distributed build and successful required lab E2E/smoke coverage.
+- Merge the current head only; if the PR changes after testing, discard the evidence and rerun.
+- Do not merge a PR with an unresolved source/test failure, a stale result, or an infrastructure run that never reached the test phase.
+- Keep one active Dakota build at a time; QA workflows may run concurrently only when they do not contend for the BST build semaphore.
 
 ## Operator Flow
 
-1. Confirm the PR number, target branch, and commit SHA.
-2. Check whether the PR poller already dispatched `dakota-pr-batch-pipeline`; if not, trigger it manually.
-3. Watch the workflow to completion and capture the relevant logs or artifacts.
-4. Report back with the PR, workflow link, outcome, and any blocker or next step.
-5. If the PR needs changes, leave the review open and hand the exact failure back to the author or maintainer.
+1. List open Dakota PRs and group them by base branch; process oldest/queue-ready first.
+2. For each PR, inspect the current head SHA and changed paths, then dispatch the distributed build from the exact branch/ref.
+3. Wait for `dakota-build-pipeline` to complete. A parent workflow marked successful with failed child nodes is not a clean pass; inspect the node summary and logs.
+4. Run `dakota-container-qa-pipeline` against the built local registry image. Run the full `dakota-qa-pipeline` suites when the PR needs GUI/BDD coverage.
+5. Record pass/fail evidence and stop on infrastructure failures such as BuildBarn storage/DNS or worker loss; recover the lab before retrying.
+6. On a clean pass, re-read the PR head SHA, confirm it remains mergeable, and merge directly rather than entering merge queue.
+7. After merge, verify the merge commit and watch the next build/publish workflow; do not report success merely because the merge API accepted the operation.
 
-## Common Rationalizations
+## Known Lab Lessons
 
-- "The PR is fine; I don't need a lab run." — Dakota changes still need fresh evidence before a maintainer decision.
-- "The poller can be skipped if I am already looking at the PR." — The cluster-backed review lane is the point of the workflow; skipping it leaves the evidence gap unresolved.
-- "I can just merge and fix later." — The workflow exists to keep review and evidence linked; merging without a fresh run is a regression risk.
+- The `dakota-pr-import-poller` historically watched `test-on-lab`, while the active Dakota queue uses `clanker-queue`; inspect the live poller/template before assuming labels will dispatch work.
+- A Dakota image may have an empty OCI `Cmd`. `run-container-tests` must pass `/sbin/init` explicitly after the image reference or crun fails before systemd starts.
+- BuildBarn storage/worker DNS or disappearance errors are infrastructure failures, not PR failures. Confirm storage StatefulSet pods, frontends, scheduler, workers, and the `bst-build` semaphore before retrying.
+- A successful Argo parent can hide failed child build nodes. Read the node summary and logs.
+- GitHub merge queue is not the merge path for this operator flow when GHA is failing; direct merge follows fresh lab evidence and an exact-SHA recheck.
 
 ## Red Flags
 
@@ -67,8 +76,9 @@ metadata:
 
 ## Verification
 
-- [ ] Maintainer approval and required lifecycle labels were verified before dispatch
-- [ ] The PR has a fresh Dakota workflow run attached
+- [ ] PR head SHA, base branch, mergeability, and approval state were verified
+- [ ] Distributed `dakota-build-pipeline` passed for the exact PR SHA
+- [ ] Dakota smoke/E2E workflow passed for the resulting image
+- [ ] BuildBarn and Argo child nodes were checked; no hidden failed nodes remain
 - [ ] Workflow logs were checked for secret redaction before linking them
-- [ ] The operator report includes the workflow link and outcome
-- [ ] Maintainer decision is based on the evidence, not a guess
+- [ ] If merged, the merge was direct (not merge queue) and the post-merge workflow was checked


### PR DESCRIPTION
## Summary

Document the repeatable Dakota PR review process:

- Build the exact PR SHA with distributed BuildBarn execution
- Run image smoke and full containerized E2E coverage
- Keep Dakota BST builds serialized
- Treat known unrelated GHA failures as advisory
- Merge directly after fresh lab evidence instead of using merge queue
- Record BuildBarn and Argo recovery lessons

## Verification

- `git diff --check` passes
- Documentation reviewed locally

Assisted-by: GPT-5 via pi