### PR TITLE
docs(dakota): align PR review documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ lab/
 | 4 — Atomic OS contract | `system` | Nightly, every image build |
 | 5 — Flatcar substrate | `flatcar` | Dedicated workflow |
 | — Migration validation | `migration` | On rechunk → chunkah switches |
-| — Dakota BST | `dakota` | Every Dakota PR |
+| — Dakota BST | `dakota` | Every Dakota PR; see [Dakota PR review](docs/skills/dakota-pr-review/SKILL.md) for exact-SHA build, E2E, repair, and direct-merge policy |
 
 ---
 
@@ -355,7 +355,7 @@ See [/docs/skills/test-authoring/dogtail-patterns.md](/docs/skills/test-authorin
 
 - [Project Bluefin](https://projectbluefin.io) — primary subject under test; this lab validates every image publish
 - [ublue-os/bluefin](https://github.com/ublue-os/bluefin) — upstream Bluefin image builds
-- [Project Dakota](https://github.com/projectbluefin/dakota) — BST-built Bluefin variant; Dakota PRs trigger `dakota-qa-pipeline`
+- [Project Dakota](https://github.com/projectbluefin/dakota) — BST-built Bluefin variant; Dakota PRs use the lab-authoritative [Dakota PR review process](docs/skills/dakota-pr-review/SKILL.md) and `dakota-qa-pipeline`
 - [projectbluefin/testsuite](https://github.com/projectbluefin/testsuite) — shared behave suites and container QA inputs
 - [projectbluefin/actions](https://github.com/projectbluefin/actions) — shared GitHub Actions workflows around the release pipeline
 - [bootc](https://containers.github.io/bootc/) — image-based Linux standard

--- a/docs/ops/lab-operations.md
+++ b/docs/ops/lab-operations.md
@@ -59,11 +59,13 @@ fallback. A successful local build/push or container E2E is diagnostic evidence
 only and does not satisfy this gate. Do not increase jobs, workers, or semaphore
 capacity while the full SDK input root or runner remains unhealthy.
 
-For the current Dakota incident, inspect runner logs for `rustc -vV`,
-`Permission denied`, invalid `TMPDIR`, and CAS materialization errors. Confirm
-the live ConfigMaps and pods match the checked-in manifests; a GitOps/config
-drift can leave the cluster running an obsolete virtual/FUSE or
-`setTmpdirEnvironmentVariable` configuration even when the repository is fixed.
+For Dakota distributed-build failures, inspect runner logs for `rustc -vV`,
+`Permission denied`, invalid `TMPDIR`, CAS materialization errors, BuildBarn
+storage DNS failures, and disappeared workers. Confirm the live ConfigMaps and
+pods match the checked-in manifests; GitOps/config drift can leave the cluster
+running an obsolete virtual/FUSE or `setTmpdirEnvironmentVariable` configuration
+even when the repository is fixed. Treat storage/DNS/worker failures as lab
+blockers and recover them before judging a PR.
 
 ---
 

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -254,16 +254,23 @@ accessCredentials rather than baking them into disk images.
 
 ---
 
-## 6.5. Dakota PR batch workflow
+## 6.5. Dakota PR review and repair loop
 
-Use the Dakota PR batch workflow when you want to validate a Dakota PR branch
-without switching to the full container-only QA lane. It sits alongside the
-existing Dakota entry points:
-- `just run-bst-build` — the BuildStream artifact build lane.
-- `just run-dakota-qa` — the full Dakota container-only QA lane.
-- `just run-dakota-container-qa` — containerized QA that runs image-level smoke checks directly inside the OCI image. Use this for `dakota:testing` while the VM path is blocked; NVIDIA builds are disabled (Dakota's composefs-oci backend declares systemd-boot but ships no UKI, so `bootc install to-disk` fails).
+Use the [Dakota PR review skill](../skills/dakota-pr-review/SKILL.md) for the
+repeatable pre-merge path. Do not rely on the older batch workflow as the merge
+gate when Dakota GHA or merge queue is unhealthy.
 
-Trigger it with:
+For each open PR:
+
+1. Confirm the current head SHA and mergeability.
+2. Submit `dakota-build-pipeline` with that exact SHA and `build-mode=re`.
+3. Run `dakota-container-qa-pipeline` against the built local registry image,
+   then `dakota-qa-pipeline` for required BDD/GUI coverage.
+4. If a scoped PR defect is found, fix it on the PR branch, push the new SHA,
+   rebuild, and rerun E2E. Old evidence is invalid after a push.
+5. Merge directly only after the fresh lab build and E2E pass; do not enter merge queue.
+
+The older batch workflow remains useful for validation-only runs:
 
 ```bash
 argo submit -n argo --from workflowtemplate/dakota-pr-batch-pipeline \

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -47,6 +47,7 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
 - **DAG:** `validate-suites` → parallel `test-lane` items (`smoke`, `common`, `developer`,
   `software`, `system`) through `run-container-tests`.
 - **Just recipe:** `run-dakota-qa`.
+- **PR review:** use the [Dakota PR review skill](../skills/dakota-pr-review/SKILL.md). Build the exact PR SHA first, then run smoke and required E2E suites against the resulting image. If lab validation identifies a scoped PR defect, repair the PR branch, rebuild from its new SHA, rerun E2E, and merge directly only after a fresh pass; do not use merge queue when Dakota GHA is known-broken.
 
 ### dakota-build-pipeline
 - **Purpose:** The actual BuildStream compile step for Dakota — builds
@@ -70,14 +71,12 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
   BuildStream run, so the lab build checks out the same source revision that
   GitHub is building instead of drifting to a later branch tip.
 
-**Current distributed-gate status (2026-07-22):** Dakota's five full distributed
-  benchmark attempts all failed; the latest failures reached remote execution but
-  exposed runner temporary-directory/Rust execution errors, and subsequent direct
-  isolation identified full SDK input-root CAS materialization stalls and shard
-  inconsistency. The local BuildStream fallback and independent Dakota container E2E
-  are useful diagnostics only and do not satisfy the distributed gate. No green
-  distributed image publication or registry-digest validation may be claimed until
-  a fresh `build-mode=re` run completes and its pushed image is verified.
+**Distributed-gate rule:** A Dakota PR build is valid only when a fresh
+`build-mode=re` run completes for the exact PR head SHA and its pushed registry
+image is verified. Local, cache-only, or fallback builds are diagnostic evidence
+and do not satisfy the distributed gate. Inspect failed child nodes even when the
+Argo parent phase is successful; classify BuildBarn storage/DNS/worker failures as
+infrastructure blockers and repair the lab before retrying.
 
 ### cosmic-build-pipeline
 - **Purpose:** BuildStream compile pipeline for the default COSMIC image

--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -96,7 +96,7 @@ correctly answers no. The Console reaches wds1 as a registered cluster.
 - **Missions** (`kc-mission-v1`): step sequences with `yaml` (one-click
   apply) and `command` blocks; custom missions are shareable via built-in
   PR flow. The "add your second PC" onboarding flow is committed as
-  [`missions/add-your-second-pc.json`](../../missions/add-your-second-pc.json).
+  [`missions/add-your-second-pc.json`](../../../missions/add-your-second-pc.json).
   The Console v0.3.34 does not read custom missions from a ConfigMap/CRD yet;
   import it via **Missions > Local Files > Import**. See
   `node-lifecycle/SKILL.md` for the agent-executable version.

--- a/docs/skills/dakota-pr-review/SKILL.md
+++ b/docs/skills/dakota-pr-review/SKILL.md
@@ -57,6 +57,20 @@ Dakota PR review is a lab-backed admission process. GitHub Actions status is adv
 6. On a clean pass, re-read the PR head SHA, confirm it remains mergeable, and merge directly rather than entering merge queue.
 7. After merge, verify the merge commit and watch the next build/publish workflow; do not report success merely because the merge API accepted the operation.
 
+## Repair Loop
+
+When lab validation exposes a fixable issue in the PR itself, repair the PR instead of merely reporting failure:
+
+1. Confirm the failure is caused by the PR and is within its stated scope; do not absorb unrelated cleanup.
+2. Check out the PR branch, make the smallest source fix, and add or update a regression test when practical.
+3. Run the lightest local checks first, then push the fix to the PR branch with a clear commit message. Never force-push or rewrite contributor history.
+4. Re-read the PR head SHA after the push and rerun the distributed build from that new SHA.
+5. Run the image smoke and required E2E suites against the rebuilt image. Old lab evidence is invalid after a PR change.
+6. If the repaired PR passes, merge the PR directly using the fresh head SHA; if it fails, leave it open with the exact source/test blocker.
+7. Record the repair, test workflow names, and merge result in the operator handoff; do not post duplicate status comments when the PR UI already shows the state.
+
+A repair is appropriate for a localized build recipe, element, workflow, or test defect that the PR is clearly responsible for. Stop and ask for human direction for design changes, security-sensitive changes, cross-repo API changes, or fixes that expand the PR's purpose.
+
 ## Known Lab Lessons
 
 - The `dakota-pr-import-poller` historically watched `test-on-lab`, while the active Dakota queue uses `clanker-queue`; inspect the live poller/template before assuming labels will dispatch work.
@@ -81,4 +95,5 @@ Dakota PR review is a lab-backed admission process. GitHub Actions status is adv
 - [ ] Dakota smoke/E2E workflow passed for the resulting image
 - [ ] BuildBarn and Argo child nodes were checked; no hidden failed nodes remain
 - [ ] Workflow logs were checked for secret redaction before linking them
+- [ ] If the PR was repaired, the fix was pushed to the PR branch and tested from its new head SHA
 - [ ] If merged, the merge was direct (not merge queue) and the post-merge workflow was checked

--- a/docs/skills/node-lifecycle/SKILL.md
+++ b/docs/skills/node-lifecycle/SKILL.md
@@ -123,7 +123,7 @@ memory/ADR). Cross-WEC grid joins via Tailscale CAS mesh.
 The Console hosts this as a guided mission ("Add your second PC") wrapping
 the same steps: token display, agent config, verification queries. The
 mission source lives at
-[`missions/add-your-second-pc.json`](../../missions/add-your-second-pc.json)
+[`missions/add-your-second-pc.json`](../../../missions/add-your-second-pc.json)
 in `kc-mission-v1` format. Because the Console v0.3.34 cannot yet load
 custom missions from an in-cluster ConfigMap or CRD, import it via
 **Missions > Local Files > Import**. Keep the mission and this skill in sync


### PR DESCRIPTION
## Summary

Align the lab documentation with the Dakota PR review skill:

- Link the exact-SHA distributed build/E2E/repair/direct-merge process from README and operator references
- Replace stale distributed-build incident status with timeless gate and recovery rules
- Update the operator cheatsheet for repair-and-rerun handling
- Fix two broken skill links found by documentation validation

## Verification

- `python3 scripts/validate-docs.py` passes (warnings only)
- `git diff --check` passes

Assisted-by: GPT-5 via pi