### PR TITLE
fix(argo): add serviceAccountName homelab-runner to bluefin-service-catalog-pipeline

### DIFF
--- a/argo/workflow-templates/bluefin-service-catalog-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-service-catalog-pipeline.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   entrypoint: pipeline
   onExit: cleanup
+  serviceAccountName: homelab-runner
   arguments:
     parameters:
       - name: lane


### PR DESCRIPTION
Sets `serviceAccountName: homelab-runner` in `bluefin-service-catalog-pipeline.yaml` so the template pod has permissions to create ephemeral namespaces.