### PR TITLE
fix(argo): bind homelab-runner-workspace-role in ephemeral test namespaces

### DIFF
--- a/argo/workflow-templates/bluefin-service-catalog-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-service-catalog-pipeline.yaml
@@ -69,6 +69,22 @@ spec:
             labels:
               app.kubernetes.io/part-of: bluefin-test-suite
               bluefin.io/lane: service-catalog
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: homelab-runner-workspace-binding
+            namespace: "{{inputs.parameters.namespace}}"
+            labels:
+              app.kubernetes.io/part-of: bluefin-test-suite
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: homelab-runner-workspace-role
+          subjects:
+            - kind: ServiceAccount
+              name: homelab-runner
+              namespace: argo
 
     - name: deploy-fixture
       inputs:

--- a/argo/workflow-templates/service-catalog-pipeline.yaml
+++ b/argo/workflow-templates/service-catalog-pipeline.yaml
@@ -72,6 +72,22 @@ spec:
             labels:
               app.kubernetes.io/part-of: bluefin-test-suite
               bluefin.io/lane: "svc-{{inputs.parameters.lane}}"
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: homelab-runner-workspace-binding
+            namespace: "{{inputs.parameters.namespace}}"
+            labels:
+              app.kubernetes.io/part-of: bluefin-test-suite
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: homelab-runner-workspace-role
+          subjects:
+            - kind: ServiceAccount
+              name: homelab-runner
+              namespace: argo
 
     - name: deploy-workload
       inputs:


### PR DESCRIPTION
Injects a RoleBinding for `homelab-runner-workspace-role` into the ephemeral namespace manifest created by `service-catalog-pipeline` and `bluefin-service-catalog-pipeline` so `homelab-runner` has permissions to deploy workload fixtures and PVCs inside its own ephemeral test namespaces.