### PR TITLE
fix(argo): wait for RBAC RoleBinding propagation in ephemeral namespace

### DIFF
--- a/argo/workflow-templates/bluefin-service-catalog-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-service-catalog-pipeline.yaml
@@ -106,6 +106,13 @@ spec:
           NS="{{inputs.parameters.namespace}}"
           LANE="{{inputs.parameters.lane}}"
           CONTENT="${LANE}-ready"
+
+          # Wait for RBAC RoleBinding propagation in newly created namespace
+          for i in $(seq 1 10); do
+            if kubectl get pods -n "${NS}" >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+
           kubectl apply -n "${NS}" -f - <<EOF
           apiVersion: v1
           kind: PersistentVolumeClaim

--- a/argo/workflow-templates/service-catalog-pipeline.yaml
+++ b/argo/workflow-templates/service-catalog-pipeline.yaml
@@ -112,6 +112,12 @@ spec:
           LANE="{{inputs.parameters.lane}}"
           BRANCH="{{inputs.parameters.branch}}"
 
+          # Wait for RBAC RoleBinding propagation in newly created namespace
+          for i in $(seq 1 10); do
+            if kubectl get pods -n "${NS}" >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+
           dnf install -y --quiet git kubernetes-client 2>&1 | tail -4
 
           REPO_DIR=$(mktemp -d)


### PR DESCRIPTION
Adds a short retry loop in deploy steps to wait for RBAC RoleBinding propagation in newly created ephemeral namespaces before invoking `kubectl apply`.