### PR TITLE
fix(console): disable demo mode fallback to reflect real cluster status

### DIFF
--- a/argocd/kubestellar-console-app.yaml
+++ b/argocd/kubestellar-console-app.yaml
@@ -42,6 +42,10 @@ spec:
           type: ClusterIP
         ingress:
           enabled: false
+        env:
+          NO_LOCAL_AGENT: "false"
+          ENABLE_DEMO_DASHBOARDS: "false"
+          SHOW_DEMO_TO_LOCAL_CTA: "false"
         auth:
           allowedGitHubLogins: castrojo
           adminGitHubLogins: castrojo


### PR DESCRIPTION
Disables demo mode fallback in KubeStellar Console (`NO_LOCAL_AGENT=false`, `ENABLE_DEMO_DASHBOARDS=false`, `SHOW_DEMO_TO_LOCAL_CTA=false`) so the console renders 100% real live cluster status instead of fallback example data.