### PR TITLE
fix(console): set NO_LOCAL_AGENT=true to suppress desktop agent installation prompt

### DIFF
--- a/argocd/kubestellar-console-app.yaml
+++ b/argocd/kubestellar-console-app.yaml
@@ -45,7 +45,7 @@ spec:
         enabledDashboards: "dashboard,clusters,workloads,pods,services,nodes,events,gitops,helm,security,storage"
         extraEnv:
           - name: NO_LOCAL_AGENT
-            value: "false"
+            value: "true"
           - name: ENABLE_DEMO_DASHBOARDS
             value: "false"
           - name: SHOW_DEMO_TO_LOCAL_CTA

--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -41,7 +41,7 @@ Lab-specific values (do not regress these):
   storage/backup ADR (Velero, user-data-only).
 - `service.type: ClusterIP`, `ingress.enabled: false`.
 - `enabledDashboards: "dashboard,clusters,workloads,pods,services,nodes,events,gitops,helm,security,storage"` — restricts sidebar views to real cluster resources only.
-- `extraEnv`: `NO_LOCAL_AGENT: "false"`, `ENABLE_DEMO_DASHBOARDS: "false"`, `SHOW_DEMO_TO_LOCAL_CTA: "false"`, `DISABLE_DYNAMIC_CARDS: "true"` — disables demo mode fallback data so the Console connects directly to the in-cluster K8s API and reflects 100% real cluster status.
+- `extraEnv`: `NO_LOCAL_AGENT: "true"`, `ENABLE_DEMO_DASHBOARDS: "false"`, `SHOW_DEMO_TO_LOCAL_CTA: "false"`, `DISABLE_DYNAMIC_CARDS: "true"` — suppresses local desktop agent prompts (users connect via port-forward/LAN without needing desktop agent software installed on their machine) and disables demo fallback data so the Console connects directly to the in-cluster K8s API (`https://10.43.0.1:443`).
 
 ## Exposure and auth policy (locked, ADR-0003)
 


### PR DESCRIPTION
Sets `NO_LOCAL_AGENT=true` in KubeStellar Console's Application `extraEnv` so the UI stops prompting users to install the `kc-agent` desktop software on their workstations. The in-cluster console pod continues to connect directly to the in-cluster Kubernetes API (`https://10.43.0.1:443`) and render 100% real cluster metrics.