### PR TITLE
fix(kubestellar): ignore controller-owned hook drift

### DIFF
--- a/argocd/kubestellar-app.yaml
+++ b/argocd/kubestellar-app.yaml
@@ -36,10 +36,18 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kubestellar
+  # KubeFlex expands the hook templates after creation. Treat that
+  # controller-owned field as runtime state so the app-of-apps wave can settle.
+  ignoreDifferences:
+    - group: tenancy.kflex.kubestellar.org
+      kind: PostCreateHook
+      jsonPointers:
+        - /spec/templates
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - RespectIgnoreDifferences=true
       - ServerSideApply=true

--- a/docs/skills/kubestellar/SKILL.md
+++ b/docs/skills/kubestellar/SKILL.md
@@ -73,6 +73,12 @@ Hence: `kubeflex-operator.installPostgreSQL: false` in the core app and a
 separate `kubestellar-postgres` Application whose Helm release name MUST be
 `postgres` (the operator waits for pod `postgres-postgresql-0`).
 
+**Critical gotcha — PostCreateHook drift**: KubeFlex expands
+`PostCreateHook.spec.templates` after creation. The core Application must ignore
+that controller-owned field and set `RespectIgnoreDifferences=true`; otherwise
+the core remains OutOfSync and the app-of-apps sync wave never advances to
+Console.
+
 Verify:
 
 ```bash
@@ -162,6 +168,7 @@ instance.
 | Symptom | Cause / fix |
 |---|---|
 | App sync stuck "waiting for healthy state of kubeflex-controller-manager" | postgres deadlock — see install section; check `kubestellar-postgres` app is Synced/Healthy |
+| Parent app stuck "waiting for healthy state of Application/kubestellar" | KubeFlex mutated `PostCreateHook.spec.templates`; retain the scoped ignore and `RespectIgnoreDifferences=true` in the core Application |
 | `clusteradm get token` forbidden | workflow ran as `argo` SA; needs `serviceAccountName: kubestellar-bootstrap` |
 | Workflow pod rejected "failed quota: argo-quota" | missing resources requests/limits on the template |
 | Downsynced namespace exists but is empty | objectSelectors don't match the inner objects' labels |


### PR DESCRIPTION
## Summary

- ignore KubeFlex-managed `PostCreateHook.spec.templates` drift in the core Application
- preserve the ignored runtime field during sync with `RespectIgnoreDifferences=true`
- document the app-of-apps deadlock and recovery pattern

## Root cause

KubeFlex expands `PostCreateHook.spec.templates` after creation. ArgoCD treated that controller-owned mutation as permanent drift, so `kubestellar` stayed OutOfSync and the parent sync wave never advanced to update Console.

## Validation

- `just lint`
- `git diff --check`
- Context7 verification against current Argo CD `ignoreDifferences` and `RespectIgnoreDifferences` guidance