### PR TITLE
fix(console): replace migration image with FSDK runner

### DIFF
--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -142,6 +142,7 @@ correctly answers no. The Console reaches wds1 as a registered cluster.
 | New pod stuck ContainerCreating on upgrade | strategy reverted to RollingUpdate with RWO PVC; keep Recreate |
 | MCP bridge initialization times out | rendered kubeconfig Secret is absent or not mounted; verify `/app/.kube/config` uses the projected ServiceAccount token and CA paths |
 | ArgoCD reports a duplicate-env ComparisonError | `NO_LOCAL_AGENT` was added to `extraEnv`; remove it because chart 0.3.34 emits it |
+| PVC migration hook is ImagePullBackOff on `bitnami/kubectl:latest` | retain the narrowly scoped `kubestellar-console-pvc-migration-image` admission policy; chart 0.3.34 hardcodes the image and offers no values override |
 | `/api/health` returns "Missing authorization" | expected — auth is enforced; sign in or use a token |
 | Anonymous full access | dev-mode without OAuth config — acceptable ONLY via port-forward, never exposed |
 

--- a/manifests/kubestellar-console-image-policy.yaml
+++ b/manifests/kubestellar-console-image-policy.yaml
@@ -1,0 +1,56 @@
+# Console 0.3.34 hardcodes Docker Hub's bitnami/kubectl:latest in its
+# pre-upgrade PVC migration hook. Replace only that exact upstream image with
+# the pinned, shell-enabled FSDK cluster-ops image before the Job is admitted.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: kubestellar-console-pvc-migration-image
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: Never
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - batch
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - jobs
+  matchConditions:
+    - name: console-migration-job
+      expression: >-
+        request.namespace == "kubestellar-console" &&
+        object.metadata.name == "kubestellar-console-pvc-migration"
+    - name: expected-upstream-container
+      expression: >-
+        object.spec.template.spec.containers.size() == 1 &&
+        object.spec.template.spec.containers[0].name == "migrate-pvcs" &&
+        object.spec.template.spec.containers[0].image == "bitnami/kubectl:latest"
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          [
+            JSONPatch{
+              op: "replace",
+              path: "/spec/template/spec/containers/0/image",
+              value: "ghcr.io/projectbluefin/lab-runner@sha256:fe097bb3b85a126b9a16093fbc498b4b6fb7b24e0f74162ad3d91a402dcfa940"
+            }
+          ]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: kubestellar-console-pvc-migration-image
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  policyName: kubestellar-console-pvc-migration-image


### PR DESCRIPTION
Replaces Console 0.3.34's hardcoded bitnami/kubectl:latest PVC migration image with the signed, digest-pinned ghcr.io/projectbluefin/lab-runner image through a narrowly scoped Kubernetes MutatingAdmissionPolicy. The upstream chart has no image override; the current hook is blocked by Docker Hub 429 responses and violates lab image policy. Validated with server-side dry-run, just lint, git diff --check, and cosign verification.