### PR TITLE
fix(console): simplify migration admission patch

### DIFF
--- a/manifests/kubestellar-console-image-policy.yaml
+++ b/manifests/kubestellar-console-image-policy.yaml
@@ -2,7 +2,7 @@
 # pre-upgrade PVC migration hook. Replace only that exact upstream image with
 # the pinned, shell-enabled FSDK cluster-ops image before the Job is admitted.
 # The upstream security context assumes Bitnami's uid 1001, so also select an
-# explicit non-root uid and writable HOME for the FSDK image.
+# explicit non-root uid for the FSDK image.
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
@@ -48,16 +48,6 @@ spec:
               op: "add",
               path: "/spec/template/spec/containers/0/securityContext/runAsUser",
               value: 65532
-            },
-            JSONPatch{
-              op: "add",
-              path: "/spec/template/spec/containers/0/env",
-              value: [
-                Object.spec.template.spec.containers.env{
-                  name: "HOME",
-                  value: "/tmp"
-                }
-              ]
             }
           ]
 ---


### PR DESCRIPTION
Removes the unnecessary CEL env-list mutation that causes the k3s API server to reset matching Job admission requests. The FSDK runner was verified to run kubectl as uid 65532 without HOME, so the policy retains only the signed image replacement and explicit non-root uid. Validated with exact local container execution, server-side policy dry-run, just lint, and git diff --check.