### PR TITLE
fix(console): preserve generated JWT secret

### DIFF
--- a/argocd/kubestellar-console-app.yaml
+++ b/argocd/kubestellar-console-app.yaml
@@ -84,10 +84,19 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kubestellar-console
+  # ArgoCD renders Helm without cluster access, so the chart's lookup cannot
+  # preserve its generated JWT and randAlphaNum changes on every comparison.
+  ignoreDifferences:
+    - kind: Secret
+      name: kubestellar-console
+      namespace: kubestellar-console
+      jsonPointers:
+        - /data/jwt-secret
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - RespectIgnoreDifferences=true
       - ServerSideApply=true

--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -143,6 +143,7 @@ correctly answers no. The Console reaches wds1 as a registered cluster.
 | MCP bridge initialization times out | rendered kubeconfig Secret is absent or not mounted; verify `/app/.kube/config` uses the projected ServiceAccount token and CA paths |
 | ArgoCD reports a duplicate-env ComparisonError | `NO_LOCAL_AGENT` was added to `extraEnv`; remove it because chart 0.3.34 emits it |
 | PVC migration hook is ImagePullBackOff on `bitnami/kubectl:latest` | retain the narrowly scoped `kubestellar-console-pvc-migration-image` admission policy; chart 0.3.34 hardcodes the image and offers no values override |
+| Console continuously syncs and reruns the PVC migration hook | retain the scoped JWT Secret ignore and `RespectIgnoreDifferences=true`; ArgoCD cannot use the chart's live `lookup`, so its random fallback otherwise changes every render |
 | `/api/health` returns "Missing authorization" | expected — auth is enforced; sign in or use a token |
 | Anonymous full access | dev-mode without OAuth config — acceptable ONLY via port-forward, never exposed |
 


### PR DESCRIPTION
Stops Console's perpetual ArgoCD sync loop by ignoring only data.jwt-secret on the chart-managed Secret and enabling RespectIgnoreDifferences. ArgoCD Helm rendering cannot execute the chart's live lookup, so randAlphaNum otherwise changes every comparison and reruns the PVC migration hook indefinitely. Validated with just lint, git diff --check, server-side Application dry-run, and current Argo CD documentation.