### PR TITLE
fix(console): use live in-cluster data

### DIFF
--- a/argo/workflow-templates/kubestellar-platform-verify.yaml
+++ b/argo/workflow-templates/kubestellar-platform-verify.yaml
@@ -145,34 +145,21 @@ spec:
             exit 1
           fi
 
-          secret_volume=$(jq -r '
-            first(.spec.template.spec.volumes[]? |
-              select(.secret.secretName == "kubestellar-console-kubeconfig") |
-              .name) // empty
-          ' <<<"$deployment")
-          [ -n "$secret_volume" ] || {
-            echo "FAIL: Console Deployment does not mount the kubeconfig Secret" >&2
-            exit 1
-          }
-          mount_path=$(jq -r --arg volume "$secret_volume" '
-            first(.spec.template.spec.containers[]?.volumeMounts[]? |
-              select(.name == $volume) | .mountPath) // empty
-          ' <<<"$deployment")
           kubeconfig_path=$(jq -r '
             first(.spec.template.spec.containers[]?.env[]? |
               select(.name == "KUBECONFIG") | .value) // empty
           ' <<<"$deployment")
-          [ -n "$mount_path" ] &&
-            [[ "$kubeconfig_path" == "$mount_path/"* ]] || {
-              echo "FAIL: Console KUBECONFIG does not point into its Secret mount" >&2
-              exit 1
-            }
+          [ -z "$kubeconfig_path" ] || {
+            echo "FAIL: Console KUBECONFIG disables in-cluster data mode" >&2
+            exit 1
+          }
 
           health=$(kubectl get --raw \
             '/api/v1/namespaces/kubestellar-console/services/http:kubestellar-console:8080/proxy/health')
           jq -e '
             .status == "ok" and
             .project == "kubestellar" and
+            .in_cluster == true and
             .no_local_agent == true and
             (.enabled_dashboards | index("cluster-admin")) != null and
             (.enabled_dashboards | index("deploy")) != null and
@@ -191,17 +178,11 @@ spec:
             -o jsonpath='{.status.startTime}')
           console_logs=$(kubectl logs -n kubestellar-console "$console_pod" \
             --since-time="$pod_started")
-          bridge_state=$(grep -E \
-            'MCP bridge (started successfully|not available)' \
-            <<<"$console_logs" | tail -1 || true)
-          if [[ "$bridge_state" != *'MCP bridge started successfully'* ]] ||
-             grep -q 'bridge ListClusters failed.*ops client not available' \
-               <<<"$console_logs"; then
-            echo "FAIL: Console MCP bridge is unavailable" >&2
-            printf '%s\n' "$bridge_state" >&2
+          if ! grep -q 'Using in-cluster config' <<<"$console_logs"; then
+            echo "FAIL: Console did not initialize its in-cluster Kubernetes client" >&2
             exit 1
           fi
-          echo "OK ArgoCD ownership, Console health, dashboards, and MCP wiring"
+          echo "OK ArgoCD ownership, Console health, dashboards, and live cluster wiring"
 
     - name: verify-query-surfaces
       serviceAccountName: kubestellar-observability

--- a/argocd/kubestellar-console-app.yaml
+++ b/argocd/kubestellar-console-app.yaml
@@ -50,34 +50,7 @@ spec:
           enabled: false
         clusterName: ghost
         consoleProject: kubestellar
-        kubeconfig:
-          existingSecretKey: config
-          content: |
-            apiVersion: v1
-            kind: Config
-            clusters:
-              - name: ghost
-                cluster:
-                  server: https://kubernetes.default.svc
-                  certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            contexts:
-              - name: ghost
-                context:
-                  cluster: ghost
-                  user: ghost
-            current-context: ghost
-            users:
-              - name: ghost
-                user:
-                  tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
         enabledDashboards: "dashboard,clusters,cluster-admin,deploy,compute,workloads,deployments,pods,services,nodes,events,gitops,helm,operators,security,storage,network"
-        extraEnv:
-          - name: ENABLE_DEMO_DASHBOARDS
-            value: "false"
-          - name: SHOW_DEMO_TO_LOCAL_CTA
-            value: "false"
-          - name: DISABLE_DYNAMIC_CARDS
-            value: "true"
         auth:
           allowedGitHubLogins: castrojo
           adminGitHubLogins: castrojo

--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -67,7 +67,10 @@ Lab-specific values (do not regress these):
 - `selfUpgrade.enabled: false` and `rbac.resourceQuotasReadOnly: true` — keep
   declarative upgrades and quota changes in Git instead of creating Console
   mutations that ArgoCD immediately reverts.
-- `extraEnv`: `ENABLE_DEMO_DASHBOARDS: "false"`, `SHOW_DEMO_TO_LOCAL_CTA: "false"`, `DISABLE_DYNAMIC_CARDS: "true"` — disables demo fallback data and dynamic cards. Chart 0.3.34 already emits `NO_LOCAL_AGENT`; adding it here creates a duplicate environment variable and an ArgoCD ComparisonError.
+- Do not configure `kubeconfig.content` for the single-cluster install. Chart
+  0.3.34 sets `KUBECONFIG` when it is present, which makes `/health` report
+  `in_cluster: false` and routes cards to local-agent/demo fallbacks instead of
+  the pod ServiceAccount-backed API.
 
 ## Exposure and auth policy (locked, ADR-0003)
 
@@ -140,7 +143,7 @@ correctly answers no. The Console reaches wds1 as a registered cluster.
 |---|---|
 | Pod Pending, backups PVC Pending | backup re-enabled: its PVC is RWX-hardcoded; keep `backup.enabled: false` |
 | New pod stuck ContainerCreating on upgrade | strategy reverted to RollingUpdate with RWO PVC; keep Recreate |
-| MCP bridge initialization times out | rendered kubeconfig Secret is absent or not mounted; verify `/app/.kube/config` uses the projected ServiceAccount token and CA paths |
+| Console shows sample data instead of ghost | remove chart `kubeconfig` values and verify `/health` reports `in_cluster: true`; clear the browser's stale `kc-demo-mode`/auth state once after rollout |
 | ArgoCD reports a duplicate-env ComparisonError | `NO_LOCAL_AGENT` was added to `extraEnv`; remove it because chart 0.3.34 emits it |
 | PVC migration hook is ImagePullBackOff on `bitnami/kubectl:latest` | retain the narrowly scoped `kubestellar-console-pvc-migration-image` admission policy; chart 0.3.34 hardcodes the image and offers no values override |
 | Console continuously syncs and reruns the PVC migration hook | retain the scoped JWT Secret ignore and `RespectIgnoreDifferences=true`; ArgoCD cannot use the chart's live `lookup`, so its random fallback otherwise changes every render |


### PR DESCRIPTION
Removes the chart kubeconfig that set KUBECONFIG and made Console 0.3.34 report in_cluster=false. That binary-mode classification routed cards to demo/local-agent fallbacks despite valid cluster credentials. The single ghost cluster now uses the pod ServiceAccount, and the acceptance workflow requires in_cluster=true plus the in-cluster client startup log. Also removes three no-op demo environment variables that do not exist in the pinned Console source. Validated with just lint, git diff --check, chart rendering, live RBAC checks, and upstream source tracing.