### PR TITLE
fix(prometheus): size backend for live lab metrics

### DIFF
--- a/docs/skills/kubestellar/SKILL.md
+++ b/docs/skills/kubestellar/SKILL.md
@@ -169,6 +169,7 @@ instance.
 |---|---|
 | App sync stuck "waiting for healthy state of kubeflex-controller-manager" | postgres deadlock — see install section; check `kubestellar-postgres` app is Synced/Healthy |
 | Parent app stuck "waiting for healthy state of Application/kubestellar" | KubeFlex mutated `PostCreateHook.spec.templates`; retain the scoped ignore and `RespectIgnoreDifferences=true` in the core Application |
+| Prometheus cAdvisor targets stay `unknown` and the pod restarts | check for `OOMKilled`; the controller and cAdvisor scrape set needs the committed 1 GiB limit, not the original 256 MiB demo sizing |
 | `clusteradm get token` forbidden | workflow ran as `argo` SA; needs `serviceAccountName: kubestellar-bootstrap` |
 | Workflow pod rejected "failed quota: argo-quota" | missing resources requests/limits on the template |
 | Downsynced namespace exists but is empty | objectSelectors don't match the inner objects' labels |

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -250,10 +250,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 100Mi
+              memory: 256Mi
             limits:
               cpu: 200m
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /etc/prometheus


### PR DESCRIPTION
Raises the existing lightweight Prometheus request to 256 MiB and limit to 1 GiB. The real two-node cAdvisor plus five KubeStellar controller scrape set OOM-kills the old 256 MiB demo-sized container during WAL replay, leaving targets unknown and the acceptance gate unable to query data. Both nodes have ample memory headroom. Validated with just lint and git diff --check.