### PR TITLE
fix(console): wire live node telemetry

### DIFF
--- a/argo/workflow-templates/kubestellar-platform-verify.yaml
+++ b/argo/workflow-templates/kubestellar-platform-verify.yaml
@@ -115,7 +115,7 @@ spec:
             sleep 5
           done
 
-          for app_name in kubestellar-applications kubestellar-postgres \
+          for app_name in node-feature-discovery kubestellar-applications kubestellar-postgres \
             kubestellar kubestellar-console; do
             application=$(kubectl get application -n argocd "$app_name" -o json)
             if ! jq -e '
@@ -182,6 +182,45 @@ spec:
             echo "FAIL: Console did not initialize its in-cluster Kubernetes client" >&2
             exit 1
           fi
+
+          console_role=$(kubectl get clusterrole \
+            kubestellar-console-lab-surfaces -o json)
+          if ! jq -e '
+            any(.rules[];
+              (.apiGroups | index("metrics.k8s.io")) != null and
+              (.resources | index("nodes")) != null and
+              (.resources | index("pods")) != null and
+              (.verbs | index("list")) != null)
+          ' <<<"$console_role" >/dev/null; then
+            echo "FAIL: Console cannot read metrics.k8s.io node and pod usage" >&2
+            exit 1
+          fi
+
+          resource_metrics=$(kubectl get --raw \
+            '/apis/metrics.k8s.io/v1beta1/nodes')
+          jq -e '
+            (.items | length) > 0 and
+            all(.items[];
+              .usage.cpu != null and .usage.cpu != "0" and
+              .usage.memory != null and .usage.memory != "0")
+          ' <<<"$resource_metrics" >/dev/null
+
+          nfd_workers=$(kubectl get daemonset -n node-feature-discovery \
+            -l role=worker -o json)
+          jq -e '
+            (.items | length) == 1 and
+            .items[0].status.desiredNumberScheduled > 0 and
+            .items[0].status.numberReady == .items[0].status.desiredNumberScheduled
+          ' <<<"$nfd_workers" >/dev/null
+
+          nodes=$(kubectl get nodes -o json)
+          jq -e '
+            (.items | length) > 0 and
+            all(.items[];
+              [.metadata.labels | keys[] |
+                select(startswith("feature.node.kubernetes.io/"))] |
+              length > 0)
+          ' <<<"$nodes" >/dev/null
           echo "OK ArgoCD ownership, Console health, dashboards, and live cluster wiring"
 
     - name: verify-query-surfaces

--- a/docs/skills/console-dashboard/SKILL.md
+++ b/docs/skills/console-dashboard/SKILL.md
@@ -37,9 +37,12 @@ turn cloud or external multi-cluster possibilities into lab requirements.
 2. Verify dashboard IDs and Helm values against that exact upstream tag.
 3. Configure supported built-ins through `enabledDashboards`; expose additional
    cluster data through precise read-only Kubernetes API permissions.
-4. Keep demo data and dynamic cards disabled, and make all desired-state
+4. For node hardware and utilization surfaces, verify the dependency chain:
+   metrics-server API → Console `metrics.k8s.io` RBAC, plus Node Feature
+   Discovery workers → `feature.node.kubernetes.io/*` labels on every node.
+5. Keep demo data and dynamic cards disabled, and make all desired-state
    changes through Git for ArgoCD reconciliation.
-5. Run `just lint`, client-side Kubernetes YAML/RBAC checks, and
+6. Run `just lint`, client-side Kubernetes YAML/RBAC checks, and
    `git diff --check`.
 
 ## Deployment
@@ -142,6 +145,8 @@ correctly answers no. The Console reaches wds1 as a registered cluster.
 | New pod stuck ContainerCreating on upgrade | strategy reverted to RollingUpdate with RWO PVC; keep Recreate |
 | Console shows sample data instead of ghost | remove chart `kubeconfig` values and verify `/health` reports `in_cluster: true`; clear the browser's stale `kc-demo-mode`/auth state once after rollout |
 | Browser reloads `/login` while APIs return `token signature is invalid` | the chart-generated JWT changed while the browser retained stale auth. Clear local-storage keys `token`, `auth_token`, `kc_token`, `kc-auth-token`, `kc-has-session`, and `kc-demo-mode`, plus the `kc_auth` and `kc_ux_ctx` cookies for the Console origin. The v0.3.34 logout request cannot recover because stale auth fails before its CSRF-protected cookie cleanup runs. |
+| CPU and memory monitors show zero although `kubectl top nodes` works | metrics-server is healthy, but the Console ServiceAccount cannot list `nodes` and `pods` in `metrics.k8s.io`; retain that scoped read permission in `kubestellar-console-lab-surfaces` |
+| Hardware inventory has no PCI, storage, CPU, or kernel features | the cluster lacks Node Feature Discovery labels; keep the pinned `node-feature-discovery` ArgoCD Application healthy and require ready workers plus `feature.node.kubernetes.io/*` labels in acceptance |
 | ArgoCD reports a duplicate-env ComparisonError | `NO_LOCAL_AGENT` was added to `extraEnv`; remove it because chart 0.3.34 emits it |
 | PVC migration hook is ImagePullBackOff on `bitnami/kubectl:latest` | retain the narrowly scoped `kubestellar-console-pvc-migration-image` admission policy; chart 0.3.34 hardcodes the image and offers no values override |
 | Console continuously syncs and reruns the PVC migration hook | retain the scoped JWT Secret ignore and `RespectIgnoreDifferences=true`; ArgoCD cannot use the chart's live `lookup`, so its random fallback otherwise changes every render |
@@ -171,6 +176,8 @@ correctly answers no. The Console reaches wds1 as a registered cluster.
 - [ ] Required CRDs have only `get`, `list`, and `watch` access
 - [ ] No unsupported card JSON/ConfigMap manifests remain
 - [ ] Browser requests do not loop on `401 token signature is invalid`
+- [ ] `metrics.k8s.io/v1beta1/nodes` returns non-zero CPU and memory usage
+- [ ] Every node has NFD `feature.node.kubernetes.io/*` labels
 - [ ] `just lint` and `git diff --check` pass
 
 ## Sources
@@ -182,6 +189,8 @@ correctly answers no. The Console reaches wds1 as a registered cluster.
 - Context7 `/kubestellar/kubestellar` documents the WDS → ITS → WEC model but
   has no Console library entry; verify Console behavior against the pinned
   upstream tag instead.
+- Context7 `/kubernetes-sigs/node-feature-discovery` documents the CPU, kernel,
+  memory, network, PCI, storage, system, and USB feature sources used by NFD.
 
 ## Upgrade
 

--- a/docs/skills/kubestellar/SKILL.md
+++ b/docs/skills/kubestellar/SKILL.md
@@ -169,7 +169,7 @@ instance.
 |---|---|
 | App sync stuck "waiting for healthy state of kubeflex-controller-manager" | postgres deadlock — see install section; check `kubestellar-postgres` app is Synced/Healthy |
 | Parent app stuck "waiting for healthy state of Application/kubestellar" | KubeFlex mutated `PostCreateHook.spec.templates`; retain the scoped ignore and `RespectIgnoreDifferences=true` in the core Application |
-| Prometheus cAdvisor targets stay `unknown` and the pod restarts | check for `OOMKilled`; the controller and cAdvisor scrape set needs the committed 1 GiB limit, not the original 256 MiB demo sizing |
+| Prometheus cAdvisor targets stay `unknown` and the pod restarts | check for `OOMKilled`; WAL replay plus the controller and cAdvisor scrape set needs the committed 512 MiB request and 2 GiB limit, not the original demo sizing |
 | `clusteradm get token` forbidden | workflow ran as `argo` SA; needs `serviceAccountName: kubestellar-bootstrap` |
 | Workflow pod rejected "failed quota: argo-quota" | missing resources requests/limits on the template |
 | Downsynced namespace exists but is empty | objectSelectors don't match the inner objects' labels |

--- a/manifests/kubestellar-console-crd-read.yaml
+++ b/manifests/kubestellar-console-crd-read.yaml
@@ -13,6 +13,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: lab
 rules:
+  - apiGroups: [metrics.k8s.io]
+    resources:
+      - nodes
+      - pods
+    verbs: [get, list, watch]
   - apiGroups: [argoproj.io]
     resources:
       - applications

--- a/manifests/kubestellar-observability-rbac.yaml
+++ b/manifests/kubestellar-observability-rbac.yaml
@@ -20,9 +20,20 @@ rules:
       - services/proxy
       - pods
       - pods/log
+      - nodes
+    verbs: [get, list]
+  - apiGroups: [metrics.k8s.io]
+    resources:
+      - nodes
+      - pods
     verbs: [get, list]
   - apiGroups: [apps]
-    resources: [deployments]
+    resources:
+      - deployments
+      - daemonsets
+    verbs: [get, list]
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [clusterroles]
     verbs: [get]
   - apiGroups: [argoproj.io]
     resources: [applications]

--- a/manifests/node-feature-discovery-app.yaml
+++ b/manifests/node-feature-discovery-app.yaml
@@ -1,0 +1,56 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: node-feature-discovery
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    chart: node-feature-discovery
+    targetRevision: 0.19.0
+    helm:
+      releaseName: node-feature-discovery
+      valuesObject:
+        master:
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 512Mi
+        worker:
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+        gc:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+        topologyUpdater:
+          enable: false
+        prometheus:
+          enable: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: node-feature-discovery
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -249,11 +249,11 @@ spec:
               name: web
           resources:
             requests:
-              cpu: 50m
-              memory: 256Mi
+              cpu: 100m
+              memory: 512Mi
             limits:
-              cpu: 200m
-              memory: 1Gi
+              cpu: 500m
+              memory: 2Gi
           volumeMounts:
             - name: config
               mountPath: /etc/prometheus


### PR DESCRIPTION
## Summary
- grant KubeStellar Console read access to live node and pod resource metrics
- install pinned Node Feature Discovery through ArgoCD for hardware labels on every node
- increase Prometheus headroom and extend the platform acceptance workflow

## Root cause
`metrics-server` was already healthy, but the Console ServiceAccount could not list `metrics.k8s.io` resources, so usage cards rendered zero. The nodes also lacked NFD hardware labels.

## Validation
- `just lint`
- `git diff --check`
- rendered node-feature-discovery chart 0.19.0 with committed values