### PR TITLE
fix(prometheus): bound cAdvisor node labels

### DIFF
--- a/argo/workflow-templates/kubestellar-platform-verify.yaml
+++ b/argo/workflow-templates/kubestellar-platform-verify.yaml
@@ -115,6 +115,17 @@ spec:
             sleep 5
           done
 
+          cadvisor_nodes=$(prom_query \
+            'count(count by (node) (container_cpu_usage_seconds_total{job="kubernetes-cadvisor"}))')
+          expected_nodes=$(kubectl get nodes -o json | jq '.items | length')
+          actual_nodes=$(jq -r '.data.result[0].value[1] // "0"' \
+            <<<"$cadvisor_nodes")
+          if [ "$actual_nodes" -ne "$expected_nodes" ]; then
+            echo "FAIL: cAdvisor reports $actual_nodes node(s), expected $expected_nodes" >&2
+            exit 1
+          fi
+          echo "OK cAdvisor exposes one bounded node label for all $actual_nodes nodes"
+
           for app_name in node-feature-discovery kubestellar-applications kubestellar-postgres \
             kubestellar kubestellar-console; do
             application=$(kubectl get application -n argocd "$app_name" -o json)

--- a/docs/skills/kubestellar/SKILL.md
+++ b/docs/skills/kubestellar/SKILL.md
@@ -170,6 +170,7 @@ instance.
 | App sync stuck "waiting for healthy state of kubeflex-controller-manager" | postgres deadlock — see install section; check `kubestellar-postgres` app is Synced/Healthy |
 | Parent app stuck "waiting for healthy state of Application/kubestellar" | KubeFlex mutated `PostCreateHook.spec.templates`; retain the scoped ignore and `RespectIgnoreDifferences=true` in the core Application |
 | Prometheus cAdvisor targets stay `unknown` and the pod restarts | check for `OOMKilled`; WAL replay plus the controller and cAdvisor scrape set needs the committed 512 MiB request and 2 GiB limit, not the original demo sizing |
+| Prometheus reaches its memory limit after NFD labels appear | never `labelmap` all `__meta_kubernetes_node_label_*` values onto cAdvisor series; map only `__meta_kubernetes_node_name` to `node`, or NFD's 100+ labels multiply across every container metric |
 | `clusteradm get token` forbidden | workflow ran as `argo` SA; needs `serviceAccountName: kubestellar-bootstrap` |
 | Workflow pod rejected "failed quota: argo-quota" | missing resources requests/limits on the template |
 | Downsynced namespace exists but is empty | objectSelectors don't match the inner objects' labels |

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -67,8 +67,11 @@ data:
         kubernetes_sd_configs:
           - role: node
         relabel_configs:
-          - action: labelmap
-            regex: __meta_kubernetes_node_label_(.+)
+          # Keep one bounded identity label. Copying every node label onto every
+          # cAdvisor series multiplies NFD's 100+ hardware labels across tens of
+          # thousands of container series and exhausts Prometheus memory.
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node
           - target_label: __address__
             replacement: kubernetes.default.svc:443
           - source_labels: [__meta_kubernetes_node_name]


### PR DESCRIPTION
## Summary
- retain one stable `node` label on cAdvisor metrics instead of copying every NFD hardware label
- prevent NFD label cardinality from exhausting the Prometheus heap
- verify cAdvisor still reports every cluster node

## Root cause
NFD adds 115+ labels per node. The old wildcard `labelmap` copied all of them onto roughly 25k cAdvisor series, pushing Prometheus to its 2 GiB limit despite only ~48k active series.

## Validation
- `just lint`
- `git diff --check`
- `promtool check config`