### PR TITLE
fix(prometheus): roll out scrape config

### DIFF
--- a/docs/skills/kubestellar/SKILL.md
+++ b/docs/skills/kubestellar/SKILL.md
@@ -171,6 +171,7 @@ instance.
 | Parent app stuck "waiting for healthy state of Application/kubestellar" | KubeFlex mutated `PostCreateHook.spec.templates`; retain the scoped ignore and `RespectIgnoreDifferences=true` in the core Application |
 | Prometheus cAdvisor targets stay `unknown` and the pod restarts | check for `OOMKilled`; WAL replay plus the controller and cAdvisor scrape set needs the committed 512 MiB request and 2 GiB limit, not the original demo sizing |
 | Prometheus reaches its memory limit after NFD labels appear | never `labelmap` all `__meta_kubernetes_node_label_*` values onto cAdvisor series; map only `__meta_kubernetes_node_name` to `node`, or NFD's 100+ labels multiply across every container metric |
+| Prometheus ConfigMap is Synced but scrape behavior does not change | bump `lab.projectbluefin.io/config-version` on the Deployment pod template with every scrape-config change; Prometheus has no config reloader sidecar |
 | `clusteradm get token` forbidden | workflow ran as `argo` SA; needs `serviceAccountName: kubestellar-bootstrap` |
 | Workflow pod rejected "failed quota: argo-quota" | missing resources requests/limits on the template |
 | Downsynced namespace exists but is empty | objectSelectors don't match the inner objects' labels |

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -237,7 +237,7 @@ spec:
       labels:
         app: prometheus-lightweight
       annotations:
-        lab.projectbluefin.io/config-version: kubestellar-controller-metrics-v1
+        lab.projectbluefin.io/config-version: bounded-cadvisor-node-labels-v2
     spec:
       serviceAccountName: prometheus-lightweight
       containers:


### PR DESCRIPTION
## Summary
- bump the Prometheus pod-template config version
- force a clean ArgoCD rollout with the bounded cAdvisor node-label mapping

## Validation
- `just lint`
- `git diff --check`