### PR TITLE
feat(argo): cap run-container-tests concurrency with ghost-container-qa semaphore

### DIFF
--- a/argo/bluefin-test-matrix.yaml
+++ b/argo/bluefin-test-matrix.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   entrypoint: matrix
   serviceAccountName: argo
+  # Generous ceiling because the run-container-tests template now queues behind a
+  # cross-workflow semaphore; the workflow-level deadline must outlive queue wait
+  # plus the 1h per-suite test pod deadline.
+  activeDeadlineSeconds: 14400
   ttlStrategy:
     secondsAfterCompletion: 3600
     secondsAfterSuccess: 3600

--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -15,7 +15,10 @@ metadata:
 spec:
   serviceAccountName: argo
   parallelism: 2
-  activeDeadlineSeconds: 3600
+  # Generous ceiling because the run-container-tests template now queues behind a
+  # cross-workflow semaphore; the workflow-level deadline must outlive queue wait
+  # plus the 1h per-suite test pod deadline.
+  activeDeadlineSeconds: 14400
   entrypoint: pipeline
   arguments:
     parameters:

--- a/argo/workflow-templates/cosmic-qa-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-qa-pipeline.yaml
@@ -12,7 +12,10 @@ metadata:
     app.kubernetes.io/part-of: bluefin-test-suite
 spec:
   serviceAccountName: argo
-  activeDeadlineSeconds: 3600
+  # Generous ceiling because the run-container-tests template now queues behind a
+  # cross-workflow semaphore; the workflow-level deadline must outlive queue wait
+  # plus the 1h per-suite test pod deadline.
+  activeDeadlineSeconds: 14400
   entrypoint: pipeline
   arguments:
     parameters:

--- a/argo/workflow-templates/dakota-qa-pipeline.yaml
+++ b/argo/workflow-templates/dakota-qa-pipeline.yaml
@@ -15,7 +15,10 @@ metadata:
 spec:
   serviceAccountName: argo
   parallelism: 2
-  activeDeadlineSeconds: 3600
+  # Generous ceiling because the run-container-tests template now queues behind a
+  # cross-workflow semaphore; the workflow-level deadline must outlive queue wait
+  # plus the 1h per-suite test pod deadline.
+  activeDeadlineSeconds: 14400
   entrypoint: pipeline
   arguments:
     parameters:

--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -20,6 +20,14 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/control-plane: "true"
     activeDeadlineSeconds: 3600
+    # Cross-workflow backpressure: this template is referenced by every
+    # container-only QA pipeline, so a template-level semaphore caps total
+    # concurrent runs on ghost without touching VM scheduling policy.
+    synchronization:
+      semaphores:
+      - configMapKeyRef:
+          name: workflow-semaphores
+          key: ghost-container-qa
     inputs:
       parameters:
       - name: image

--- a/manifests/workflow-semaphores.yaml
+++ b/manifests/workflow-semaphores.yaml
@@ -10,6 +10,12 @@
 #                        stampeding the cache or starving lab validation.
 #   migration-containerdisk-build — Serializes the migration workflow while it
 #                        refreshes and consumes its temporary VM source disk.
+#   ghost-container-qa — Cross-workflow capacity limit for the control-plane
+#                        container QA runner (run-container-tests). Each pod
+#                        requests 4Gi on ghost; cap concurrent runs to keep
+#                        total requested memory below the 95% pressure threshold.
+#                        VMs are still scheduled natively and must not use this
+#                        semaphore (see docs/skills/argo-workflows/patterns.md).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,3 +26,4 @@ metadata:
 data:
   bst-build: "1"
   migration-containerdisk-build: "1"
+  ghost-container-qa: "8"


### PR DESCRIPTION
Adds a cross-workflow template-level semaphore for the control-plane container QA runner so Dakota PR lanes no longer saturate ghost memory requests. VM scheduling policy is untouched.

- Adds `ghost-container-qa: "8"` to `manifests/workflow-semaphores.yaml`
- Binds `run-container-tests` to the semaphore at template scope (covers all callers via templateRef)
- Raises `activeDeadlineSeconds` to 14400s on all callers so queued workflows don't DeadlineExceeded

Validation: `just lint`, `pytest tests/unit/test_container_only_qa_workflows.py`.