### PR TITLE
fix(pr-poller): build and QA Dakota PRs against an immutable SHA-tagged artifact

### DIFF
--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -9,7 +9,8 @@ metadata:
       the NVIDIA variant in parallel using the shared Buildbarn frontend.
       BuildStream driver pods use node-local persistent cache directories on ghost/exo-0.
       Triggered by push to dakota:testing via the dakota-commit-poller CronWorkflow.
-      On success, exports to local Zot (:30500) as dakota:testing and dakota-nvidia:testing.
+      On success, exports to local Zot (:30500) as dakota:<image-tag> and
+      dakota-nvidia:<image-tag> (default "testing").
       NVIDIA builds run with continueOn (non-blocking) as the lab does not have GPU
       hardware to test NVIDIA runtime execution.
       Uses bst-build PriorityClass.
@@ -33,6 +34,8 @@ spec:
         value: "testing"
       - name: commit-sha
         value: ""
+      - name: image-tag
+        value: "testing"
       - name: registry
         value: "192.168.1.102:30500"
       - name: build-mode
@@ -56,6 +59,8 @@ spec:
             value: "{{workflow.parameters.ref}}"
           - name: commit-sha
             value: "{{workflow.parameters.commit-sha}}"
+          - name: image-tag
+            value: "{{workflow.parameters.image-tag}}"
           - name: repo
             value: "{{workflow.parameters.repo}}"
           - name: registry
@@ -87,6 +92,8 @@ spec:
                   value: "{{inputs.parameters.ref}}"
                 - name: commit-sha
                   value: "{{inputs.parameters.commit-sha}}"
+                - name: image-tag
+                  value: "{{inputs.parameters.image-tag}}"
                 - name: repo
                   value: "{{inputs.parameters.repo}}"
                 - name: registry
@@ -108,6 +115,8 @@ spec:
                   value: "{{inputs.parameters.ref}}"
                 - name: commit-sha
                   value: "{{inputs.parameters.commit-sha}}"
+                - name: image-tag
+                  value: "{{inputs.parameters.image-tag}}"
                 - name: repo
                   value: "{{inputs.parameters.repo}}"
                 - name: registry
@@ -149,6 +158,7 @@ spec:
           - name: tag
           - name: ref
           - name: commit-sha
+          - name: image-tag
           - name: repo
           - name: registry
           - name: mode
@@ -170,6 +180,8 @@ spec:
                   value: "{{inputs.parameters.ref}}"
                 - name: commit-sha
                   value: "{{inputs.parameters.commit-sha}}"
+                - name: image-tag
+                  value: "{{inputs.parameters.image-tag}}"
                 - name: repo
                   value: "{{inputs.parameters.repo}}"
                 - name: registry
@@ -187,6 +199,8 @@ spec:
                   value: "{{inputs.parameters.ref}}"
                 - name: commit-sha
                   value: "{{inputs.parameters.commit-sha}}"
+                - name: image-tag
+                  value: "{{inputs.parameters.image-tag}}"
                 - name: repo
                   value: "{{inputs.parameters.repo}}"
                 - name: registry
@@ -211,6 +225,7 @@ spec:
         parameters:
           - name: ref
           - name: commit-sha
+          - name: image-tag
           - name: repo
           - name: registry
       volumes:
@@ -249,6 +264,7 @@ spec:
           set -euo pipefail
           ELEMENT=oci/bluefin.bst
           REGISTRY="{{inputs.parameters.registry}}"
+          IMAGE_TAG="{{inputs.parameters.image-tag}}"
           rm -rf /src
           git clone --depth=1 "{{inputs.parameters.repo}}" /src
           cd /src
@@ -286,13 +302,13 @@ spec:
           rm -rf "${EXPORT_DIR}" && mkdir -p "${EXPORT_DIR}"
           bst --config /tmp/buildstream-local.conf --no-interactive artifact checkout "${ELEMENT}" --directory "${EXPORT_DIR}"
           if command -v skopeo >/dev/null 2>&1; then
-            skopeo copy --dest-tls-verify=false "oci:${EXPORT_DIR}" "docker://${REGISTRY}/dakota:testing"
+            skopeo copy --dest-tls-verify=false "oci:${EXPORT_DIR}" "docker://${REGISTRY}/dakota:${IMAGE_TAG}"
           else
             IMAGE_ID=$(podman pull "oci:${EXPORT_DIR}" | tail -1)
-            podman tag "${IMAGE_ID}" "${REGISTRY}/dakota:testing"
-            podman push "${REGISTRY}/dakota:testing" --tls-verify=false
+            podman tag "${IMAGE_ID}" "${REGISTRY}/dakota:${IMAGE_TAG}"
+            podman push "${REGISTRY}/dakota:${IMAGE_TAG}" --tls-verify=false
           fi
-          echo "=== DAKOTA PUBLISHED: ${REGISTRY}/dakota:testing ==="
+          echo "=== DAKOTA PUBLISHED: ${REGISTRY}/dakota:${IMAGE_TAG} ==="
 
     - name: bst-build-re
       affinity:
@@ -325,6 +341,7 @@ spec:
           - name: tag
           - name: ref
           - name: commit-sha
+          - name: image-tag
           - name: repo
           - name: registry
           - name: mode
@@ -390,6 +407,7 @@ spec:
           BST_CONF=/tmp/buildstream-cluster.conf
           ELEMENT="{{inputs.parameters.element}}"
           TAG="{{inputs.parameters.tag}}"
+          IMAGE_TAG="{{inputs.parameters.image-tag}}"
           REF="{{inputs.parameters.ref}}"
           REPO="{{inputs.parameters.repo}}"
           mkdir -p "${XDG_CACHE_HOME}"
@@ -525,11 +543,11 @@ spec:
 
           echo "=== Pushing to local Zot ==="
           if command -v skopeo >/dev/null 2>&1; then
-            skopeo copy --dest-tls-verify=false "oci:${EXPORT_DIR}" "docker://{{inputs.parameters.registry}}/${TAG}:testing"
+            skopeo copy --dest-tls-verify=false "oci:${EXPORT_DIR}" "docker://{{inputs.parameters.registry}}/${TAG}:${IMAGE_TAG}"
           else
             IMAGE_ID=$(podman pull "oci:${EXPORT_DIR}" | tail -1)
-            podman push "${IMAGE_ID}" "docker://{{inputs.parameters.registry}}/${TAG}:testing" --tls-verify=false
+            podman push "${IMAGE_ID}" "docker://{{inputs.parameters.registry}}/${TAG}:${IMAGE_TAG}" --tls-verify=false
             podman rmi "${IMAGE_ID}" 2>/dev/null || true
           fi
 
-          echo "=== Build complete: {{inputs.parameters.registry}}/${TAG}:testing ==="
+          echo "=== Build complete: {{inputs.parameters.registry}}/${TAG}:${IMAGE_TAG} ==="

--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -111,12 +111,8 @@ spec:
 
            # Route to matching WorkflowTemplate + derive per-repo params
            case "$REPO" in
-            */dakota)       TMPL="dakota-qa-pipeline"
-                            EXTRA_PARAMS="
-               - name: testsuite-branch
-                 value: ${TESTSUITE_BRANCH}
-               - name: testsuite-repo
-                 value: ${TESTSUITE_REPO}" ;;
+            */dakota)       TMPL="dakota-build-qa"
+                            EXTRA_PARAMS="" ;;
             */knuckle)      TMPL="knuckle-qa-pipeline"
                             EXTRA_PARAMS="" ;;
             */bazzite)      TMPL="bluefin-qa-pipeline"
@@ -186,7 +182,70 @@ spec:
                  value: ${TESTSUITE_REPO}" ;;
            esac
 
-           kubectl create -f - <<EOF
+           if [[ "$TMPL" == "dakota-build-qa" ]]; then
+             kubectl create -f - <<EOF
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+           generateName: "${REPO_SLUG}-${PR_NUM}-${TITLE_SLUG}-"
+           namespace: argo
+           labels:
+             bluefin.io/trigger: pr-auto
+             bluefin.io/pr-number: "${PR_NUM}"
+             bluefin.io/pr-sha: "${SHA12}"
+          spec:
+           serviceAccountName: argo
+           activeDeadlineSeconds: 90000
+           entrypoint: pr-pipeline
+           arguments:
+             parameters:
+               - name: image
+                 value: "192.168.1.102:30500/dakota"
+               - name: image-tag
+                 value: "${SHA}"
+               - name: suites
+                 value: "smoke,common,developer,software,system"
+               - name: variant
+                 value: "dakota"
+               - name: branch
+                 value: "${BRANCH}"
+               - name: testsuite-branch
+                 value: "${TESTSUITE_BRANCH}"
+               - name: testsuite-repo
+                 value: "${TESTSUITE_REPO}"
+           templates:
+             - name: pr-pipeline
+               dag:
+                 tasks:
+                   - name: build
+                     templateRef:
+                       name: dakota-build-pipeline
+                       template: build
+                     arguments:
+                       parameters:
+                         - name: ref
+                           value: "testing"
+                         - name: commit-sha
+                           value: "${SHA}"
+                         - name: repo
+                           value: "https://github.com/${REPO}.git"
+                         - name: registry
+                           value: "192.168.1.102:30500"
+                         - name: image-tag
+                           value: "${SHA}"
+                         - name: build-mode
+                           value: "re"
+                         - name: lock-key
+                           value: "bst-build"
+                   - name: qa
+                     depends: "build.Succeeded"
+                     templateRef:
+                       name: dakota-qa-pipeline
+                       template: pipeline
+          EOF
+             echo "PR #${PR_NUM} ${REPO}: dispatched dakota build+qa pipeline for ${SHA12}" >&2
+           else
+             kubectl create -f - <<EOF
           apiVersion: argoproj.io/v1alpha1
           kind: Workflow
           metadata:
@@ -210,7 +269,8 @@ spec:
                - name: pr-number
                  value: "${PR_NUM}"${EXTRA_PARAMS}
           EOF
-           echo "PR #${PR_NUM} ${REPO}: dispatched ${TMPL}" >&2
+             echo "PR #${PR_NUM} ${REPO}: dispatched ${TMPL}" >&2
+           fi
            (( DISPATCHED++ )) || true
           }
 

--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -130,6 +130,15 @@ spec:
         IMG_SLUG="${VARIANT}-${IMAGE_TAG}"
 
         # Resolve the digest of the target OCI image for digest-pinned QA evidence.
+        # Local Zot and other insecure registries need explicit TLS verification off.
+        SKOPEO_TLS_ARGS=()
+        PODMAN_PULL_TLS_ARGS=()
+        case "${IMAGE%%/*}" in
+          192.168.1.102:*|localhost:*|127.0.0.1:*)
+            SKOPEO_TLS_ARGS=(--tls-verify=false)
+            PODMAN_PULL_TLS_ARGS=(--tls-verify=false)
+            ;;
+        esac
         if ! command -v skopeo >/dev/null 2>&1; then
           echo "skopeo not found; installing for digest resolution..." >&2
           dnf install -y skopeo >/dev/null 2>&1 || true
@@ -140,7 +149,7 @@ spec:
           if [[ -n "${GITHUB_TOKEN:-}" ]]; then
             SKOPEO_ARGS+=(--creds "_token:${GITHUB_TOKEN}")
           fi
-          DIGEST=$(skopeo inspect "${SKOPEO_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE}" 2>/dev/null || true)
+          DIGEST=$(skopeo inspect "${SKOPEO_TLS_ARGS[@]}" "${SKOPEO_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE}" 2>/dev/null || true)
         fi
         if [[ -z "${DIGEST:-}" ]]; then
           echo "Warning: could not resolve digest for ${IMAGE}; result will still be published but may fall back to tag-based matching." >&2
@@ -163,6 +172,9 @@ spec:
           exit 1
         }
         mkdir -p /tmp/results
+        if [[ "${#PODMAN_PULL_TLS_ARGS[@]}" -gt 0 ]]; then
+          podman pull "${PODMAN_PULL_TLS_ARGS[@]}" "${IMAGE}" >/dev/null
+        fi
         podman run --detach --systemd=always --network host --privileged \
           --cgroupns=host \
           --security-opt seccomp=unconfined \

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -51,8 +51,11 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
 
 ### dakota-build-pipeline
 - **Purpose:** The actual BuildStream compile step for Dakota — builds
-  `oci/bluefin.bst` and pushes the default image to the local Zot registry. NVIDIA
-  variants are intentionally disabled for clean distributed builds.
+  `oci/bluefin.bst` and pushes the image to the local Zot registry under the tag
+  given by `image-tag` (default `testing`). NVIDIA variants are built
+  non-blocking and pushed with the same tag.
+- **Parameters:** `repo`, `ref`, `commit-sha`, `image-tag` (default `testing`),
+  `registry`, `build-mode`, `lock-key`.
 - **Distribution:** `build-mode=re` is mandatory. A fresh USB4 `up` observation
   and a Ready BuildBarn worker are required on both `ghost` and `exo-0` before
   admission. Cache-only, Ethernet-backed, automatic fallback, runner-local
@@ -70,6 +73,9 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
   GitHub SHA for `dakota:testing` and passes that exact commit into the local
   BuildStream run, so the lab build checks out the same source revision that
   GitHub is building instead of drifting to a later branch tip.
+- **PR path:** `pr-poller` dispatches a combined build+QA workflow for Dakota PRs
+  that builds the exact PR head SHA and tags the resulting image with that SHA
+  before running the container QA suites against it.
 
 **Distributed-gate rule:** A Dakota PR build is valid only when a fresh
 `build-mode=re` run completes for the exact PR head SHA and its pushed registry


### PR DESCRIPTION
Dakota PR workflows previously inherited dakota-qa-pipeline defaults and tested ghcr.io/projectbluefin/dakota:testing, which is not built from the PR SHA.

Changes:
- pr-poller now dispatches a combined build+QA workflow for Dakota PRs that builds the exact PR head SHA, publishes it to the local Zot registry tagged with the full commit SHA, and then runs dakota-qa-pipeline against that immutable tag.
- dakota-build-pipeline gains an image-tag parameter (default testing) so the commit-poller path is unchanged while PR builds can publish SHA tags without clobbering :testing.
- run-container-tests disables TLS verification for the local insecure registry so it can pull the SHA-tagged Dakota image.

Validated with just lint.