### PR TITLE
fix(pr-poller): wire immutable Dakota artifact into QA templateRef

### DIFF
--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -229,8 +229,6 @@ spec:
                            value: "${SHA}"
                          - name: repo
                            value: "https://github.com/${REPO}.git"
-                         - name: registry
-                           value: "192.168.1.102:30500"
                          - name: image-tag
                            value: "${SHA}"
                          - name: build-mode
@@ -242,6 +240,22 @@ spec:
                      templateRef:
                        name: dakota-qa-pipeline
                        template: pipeline
+                     arguments:
+                       parameters:
+                         - name: image
+                           value: "{{workflow.parameters.image}}"
+                         - name: image-tag
+                           value: "{{workflow.parameters.image-tag}}"
+                         - name: suites
+                           value: "{{workflow.parameters.suites}}"
+                         - name: variant
+                           value: "{{workflow.parameters.variant}}"
+                         - name: branch
+                           value: "{{workflow.parameters.branch}}"
+                         - name: testsuite-branch
+                           value: "{{workflow.parameters.testsuite-branch}}"
+                         - name: testsuite-repo
+                           value: "{{workflow.parameters.testsuite-repo}}"
           EOF
              echo "PR #${PR_NUM} ${REPO}: dispatched dakota build+qa pipeline for ${SHA12}" >&2
            else


### PR DESCRIPTION
Fixes the Dakota build+QA workflow dispatched by the PR poller so the QA task receives the SHA-tagged local registry image and testsuite source parameters explicitly, instead of falling back to `dakota-qa-pipeline` defaults.

Changes:
- Pass `image`, `image-tag`, `suites`, `variant`, `branch`, `testsuite-branch`, and `testsuite-repo` at the `qa` task's `templateRef`.
- Remove the `registry` parameter from the `build` task; `dakota-build-pipeline` already defaults it to the local Zot registry.

Validated with `just lint` and the relevant unit tests.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>