### PR TITLE
fix(argo): make BST poller retries safe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -255,6 +255,12 @@ run-bst-build ref="testing" repo="https://github.com/projectbluefin/dakota.git":
       -p build-mode=re \
       -n {{ argo_ns }} --watch
 
+# Re-run the Dakota poller for the current testing SHA without bypassing BST admission.
+force-dakota-poll:
+    argo submit --from cronworkflow/dakota-commit-poller \
+      -p force=true \
+      -n {{ argo_ns }} --watch
+
 # Compatibility alias for older docs/callers.
 run-dakota-validate ref="testing" repo="https://github.com/projectbluefin/dakota.git":
     just run-bst-build {{ ref }} {{ repo }}

--- a/argo/workflow-templates/bst-commit-poller.yaml
+++ b/argo/workflow-templates/bst-commit-poller.yaml
@@ -26,6 +26,8 @@ spec:
       - name: repo
       - name: branch
       - name: state-key
+      - name: force
+        value: "false"
       - name: registry
         value: "192.168.1.102:30500"
 
@@ -60,6 +62,8 @@ spec:
               parameters:
                 - name: sha
                   value: "{{tasks.check-sha.outputs.parameters.sha}}"
+                - name: expected-sha
+                  value: "{{tasks.check-sha.outputs.parameters.stored-sha}}"
 
     - name: poll-cosmic
       dag:
@@ -89,6 +93,8 @@ spec:
               parameters:
                 - name: sha
                   value: "{{tasks.check-sha.outputs.parameters.sha}}"
+                - name: expected-sha
+                  value: "{{tasks.check-sha.outputs.parameters.stored-sha}}"
 
     - name: check-sha
       outputs:
@@ -99,6 +105,9 @@ spec:
           - name: sha
             valueFrom:
               path: /tmp/sha
+          - name: stored-sha
+            valueFrom:
+              path: /tmp/stored-sha
       script:
         image: ghcr.io/projectbluefin/lab-runner:latest
         command: [bash]
@@ -121,6 +130,12 @@ spec:
           REPO="{{workflow.parameters.repo}}"
           BRANCH="{{workflow.parameters.branch}}"
           KEY="{{workflow.parameters.state-key}}"
+          FORCE="{{workflow.parameters.force}}"
+
+          if [[ "${FORCE}" != "true" && "${FORCE}" != "false" ]]; then
+            echo "force must be true or false" >&2
+            exit 1
+          fi
 
           REMOTE=$(
             curl -sf \
@@ -137,10 +152,11 @@ spec:
 
           STORED=$(kubectl get configmap image-polling-digests \
             -n argo -o jsonpath="{.data.${KEY}}" 2>/dev/null || true)
+          printf '%s' "${STORED}" > /tmp/stored-sha
           echo "Remote SHA: ${REMOTE}" >&2
           echo "Stored SHA: ${STORED:-<none>}" >&2
 
-          if [[ "${REMOTE}" == "${STORED}" ]]; then
+          if [[ "${FORCE}" == "false" && "${REMOTE}" == "${STORED}" ]]; then
             echo "false" > /tmp/changed
             exit 0
           fi
@@ -157,13 +173,18 @@ spec:
             exit 0
           fi
 
-          echo "Commit changed and BST queue has capacity (${ACTIVE}/2 admitted)" >&2
+          if [[ "${FORCE}" == "true" ]]; then
+            echo "Forced rebuild requested; BST queue has capacity (${ACTIVE}/2 admitted)" >&2
+          else
+            echo "Commit changed and BST queue has capacity (${ACTIVE}/2 admitted)" >&2
+          fi
           echo "true" > /tmp/changed
 
     - name: update-sha
       inputs:
         parameters:
           - name: sha
+          - name: expected-sha
       script:
         image: cgr.dev/chainguard/kubectl:latest-dev
         command: [bash]
@@ -178,6 +199,18 @@ spec:
           set -euo pipefail
           KEY="{{workflow.parameters.state-key}}"
           SHA="{{inputs.parameters.sha}}"
+          EXPECTED="{{inputs.parameters.expected-sha}}"
+          STORED=$(kubectl get configmap image-polling-digests \
+            -n argo -o jsonpath="{.data.${KEY}}" 2>/dev/null || true)
+
+          if [[ "${STORED}" != "${EXPECTED}" ]]; then
+            echo "State changed since admission (expected '${EXPECTED}', found '${STORED}'); skipping stale write." >&2
+            exit 0
+          fi
+
+          echo "Persisting successful SHA for ${KEY}: ${SHA}" >&2
           kubectl patch configmap image-polling-digests \
             -n argo --type merge \
-            -p "{\"data\":{\"${KEY}\":\"${SHA}\"}}"
+            -p "{\"data\":{\"${KEY}\":\"${SHA}\"}}" 2>/dev/null \
+            || kubectl create configmap image-polling-digests \
+                 -n argo --from-literal="${KEY}=${SHA}"

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -196,8 +196,15 @@ validation path succeed.
 The Dakota and Cosmic commit CronWorkflows share one implementation. It compares
 the source SHA, defers when two BST workflows are already admitted, invokes the
 repository-specific build template, and writes the SHA only after that build
-succeeds. The schedules are staggered behind the PR poller to avoid simultaneous
-admission bursts.
+succeeds. Failed builds therefore remain eligible on the next poll. The schedules
+are staggered behind the PR poller to avoid simultaneous admission bursts.
+
+The CronWorkflows pass `force=false`. For recovery after an out-of-band artifact
+loss, `just force-dakota-poll` submits the Dakota CronWorkflow with `force=true`.
+Force bypasses only the stored-SHA equality check: queue admission and the
+`bst-build` semaphore still apply. A retried or resumed older workflow builds its
+captured SHA, but skips the final state write if another successful workflow
+advanced the stored SHA while it was running.
 
 **Current contract:** `image-poller` must not update `image-polling-digests`
 until `run-pipeline.Succeeded`. If the digest is written before QA passes, the

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -91,6 +91,7 @@ The workflow authoring guidance is split by topic:
 - Any pod containing `initContainers` (like `git-sync` in `run-gnome-tests.yaml`) that lacks explicit `resources.requests` and `resources.limits` blocks — the `argo-quota` admission controller evaluates all containers in a pod (including init containers), and will reject the entire pod if any container lacks resource definitions.
 - `orphan-pod-gc` memory capped too low (128Mi) — large pod inventories can OOM the cleanup step (`exit code 137`) and silently skip GC.
 - An image poller that writes the new digest to `image-polling-digests` before the downstream QA pipeline succeeds — failures under cluster pressure then drop work permanently (digest is marked seen, no retry on next poll). Persist digest only after `run-pipeline.Succeeded`.
+- A success-only poller that blindly writes its captured SHA after a retry or resume — an older workflow can overwrite state advanced by a newer successful run. Capture the stored value during admission and compare it again before the final write.
 - Aurora/Bazzite digest pollers running full GNOME suite sets (`smoke,common,developer,software,system`) even though these variants are KDE-focused — this creates 5x VM pressure per trigger and overloads scheduling. Keep Aurora/Bazzite pollers on `suites: system`.
 - K8sGPT finding no-endpoint Services for `argocd-applicationset-controller`, `argocd-dex-server`, `argocd-notifications-controller-metrics`, or `kubevirt/virt-exportproxy` — these are documented control-plane exceptions in this cluster shape.
 - Commit message not in Conventional Commits format — the pre-commit hook rejects any commit not matching `<type>(<scope>): <description>`. Valid types: `feat fix ci chore docs refactor test build perf revert`
@@ -125,5 +126,6 @@ Before marking any WorkflowTemplate change done:
 - [ ] All local OCI registry references use `:30500` (NodePort), not `:5000` (container-internal)
 - [ ] `grep -rn 'image:' argo/ manifests/` shows only allowlisted registries: `ghcr.io`, `quay.io`, `registry.fedoraproject.org`, `registry.access.redhat.com`, `registry.k8s.io`, `<lab-ip>`, `localhost`
 - [ ] Image pollers update digest state only after QA pipeline success (failed runs must retry on next poll)
+- [ ] Poller state writers depend on the downstream task's `.Succeeded` result and reject stale writes when the stored value changed after admission
 - [ ] After removing `suspend: true` from a CronWorkflow and syncing, live `spec.suspend` confirmed via `kubectl get -o jsonpath` — not assumed from ArgoCD's `Synced` status alone
 - [ ] After any disk wipe/registry migration/Zot cleanup, every affected containerDisk tag manually force-rebuilt rather than assuming a digest-comparison poller will self-heal

--- a/manifests/cosmic-commit-poller.yaml
+++ b/manifests/cosmic-commit-poller.yaml
@@ -29,5 +29,7 @@ spec:
           value: main
         - name: state-key
           value: sha-cosmic-main
+        - name: force
+          value: "false"
     workflowTemplateRef:
       name: bst-commit-poller

--- a/manifests/dakota-commit-poller.yaml
+++ b/manifests/dakota-commit-poller.yaml
@@ -29,5 +29,7 @@ spec:
           value: testing
         - name: state-key
           value: sha-dakota-testing
+        - name: force
+          value: "false"
     workflowTemplateRef:
       name: bst-commit-poller

--- a/tests/unit/test_bst_poller_admission.py
+++ b/tests/unit/test_bst_poller_admission.py
@@ -16,10 +16,17 @@ def test_shared_bst_pollers_are_enabled_and_staggered():
 
     assert template["metadata"]["name"] == "bst-commit-poller"
     assert {"poll-dakota", "poll-cosmic", "check-sha", "update-sha"} <= templates.keys()
+    parameters = {
+        item["name"]: item.get("value")
+        for item in template["spec"]["arguments"]["parameters"]
+    }
+    assert parameters["force"] == "false"
 
     source = templates["check-sha"]["script"]["source"]
     assert "bluefin.io/bst-workload=true" in source
     assert "ACTIVE > 2" in source
+    assert '"${FORCE}" == "false" && "${REMOTE}" == "${STORED}"' in source
+    assert "Forced rebuild requested; BST queue has capacity" in source
     assert "kubectl patch configmap" not in source
 
     for name, schedule, entrypoint in (
@@ -33,6 +40,41 @@ def test_shared_bst_pollers_are_enabled_and_staggered():
         assert cron["spec"]["workflowSpec"]["entrypoint"] == entrypoint
         assert cron["spec"]["workflowSpec"]["workflowTemplateRef"]["name"] == "bst-commit-poller"
         assert cron["spec"]["workflowMetadata"]["labels"]["bluefin.io/bst-workload"] == "true"
+        arguments = {
+            item["name"]: item["value"]
+            for item in cron["spec"]["workflowSpec"]["arguments"]["parameters"]
+        }
+        assert arguments["force"] == "false"
+
+
+def test_bst_poller_persists_only_successful_non_stale_builds():
+    template = load("argo/workflow-templates/bst-commit-poller.yaml")
+    templates = {item["name"]: item for item in template["spec"]["templates"]}
+
+    for entrypoint in ("poll-dakota", "poll-cosmic"):
+        tasks = {
+            item["name"]: item
+            for item in templates[entrypoint]["dag"]["tasks"]
+        }
+        assert tasks["update-sha"]["depends"] == "run-build.Succeeded"
+        update_arguments = {
+            item["name"]: item["value"]
+            for item in tasks["update-sha"]["arguments"]["parameters"]
+        }
+        assert update_arguments["expected-sha"] == (
+            "{{tasks.check-sha.outputs.parameters.stored-sha}}"
+        )
+
+    update_source = templates["update-sha"]["script"]["source"]
+    assert "State changed since admission" in update_source
+    assert update_source.index('if [[ "${STORED}" != "${EXPECTED}" ]]') < (
+        update_source.index("kubectl patch configmap")
+    )
+
+    justfile = (ROOT / "Justfile").read_text(encoding="utf-8")
+    assert "force-dakota-poll:" in justfile
+    assert "--from cronworkflow/dakota-commit-poller" in justfile
+    assert "-p force=true" in justfile
 
 
 def test_pr_poller_bounds_bst_queue_and_legacy_poller_is_removed():


### PR DESCRIPTION
## Summary
- add explicit non-force defaults for Dakota/Cosmic CronWorkflows and a forced Dakota manual entrypoint
- bypass SHA equality only when forced while retaining BST admission and the build semaphore
- preserve success-only state writes and prevent stale retried/resumed workflows from overwriting newer successful state

## Behavioral contract
- normal polls skip an already-successful SHA
- failed builds do not update state and remain eligible next poll
- `force=true` rebuilds the current SHA but still defers at the BST admission ceiling and waits on `bst-build`
- state is written only after `run-build.Succeeded`; stale completions skip their write
- no observed/in-progress state is added

## Validation
- `pytest -q tests/unit/test_bst_poller_admission.py tests/unit/test_workflow_defaults.py` (16 passed)
- `argo lint --offline argo/workflow-templates/ manifests/dakota-commit-poller.yaml manifests/cosmic-commit-poller.yaml`
- `just lint`