### PR TITLE
feat(metrics): persist build telemetry

### DIFF
--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -33,6 +33,27 @@ spec:
         value: "re"
 
   entrypoint: build
+  metrics:
+    prometheus:
+      - name: lab_build_workflow_completed_total
+        help: Completed lab build workflows by pipeline and status.
+        labels:
+          - key: pipeline
+            value: bluefin-server
+          - key: status
+            value: "{{workflow.status}}"
+        counter:
+          value: "1"
+      - name: lab_build_workflow_duration_seconds
+        help: Lab build workflow duration in seconds by pipeline and status.
+        labels:
+          - key: pipeline
+            value: bluefin-server
+          - key: status
+            value: "{{workflow.status}}"
+        histogram:
+          buckets: [300, 900, 1800, 3600, 7200, 14400, 28800, 43200, 86400]
+          value: "{{workflow.duration}}"
 
   templates:
 

--- a/argo/workflow-templates/bst-qa-pipeline.yaml
+++ b/argo/workflow-templates/bst-qa-pipeline.yaml
@@ -33,6 +33,27 @@ spec:
         value: "grpc://frontend.buildbarn.svc.cluster.local:8980"
 
   entrypoint: build
+  metrics:
+    prometheus:
+      - name: lab_build_workflow_completed_total
+        help: Completed lab build workflows by pipeline and status.
+        labels:
+          - key: pipeline
+            value: bst-qa
+          - key: status
+            value: "{{workflow.status}}"
+        counter:
+          value: "1"
+      - name: lab_build_workflow_duration_seconds
+        help: Lab build workflow duration in seconds by pipeline and status.
+        labels:
+          - key: pipeline
+            value: bst-qa
+          - key: status
+            value: "{{workflow.status}}"
+        histogram:
+          buckets: [300, 900, 1800, 3600, 7200, 14400, 28800, 43200, 86400]
+          value: "{{workflow.duration}}"
 
   templates:
 

--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -42,6 +42,27 @@ spec:
         value: "re"
 
   entrypoint: build
+  metrics:
+    prometheus:
+      - name: lab_build_workflow_completed_total
+        help: Completed lab build workflows by pipeline and status.
+        labels:
+          - key: pipeline
+            value: cosmic
+          - key: status
+            value: "{{workflow.status}}"
+        counter:
+          value: "1"
+      - name: lab_build_workflow_duration_seconds
+        help: Lab build workflow duration in seconds by pipeline and status.
+        labels:
+          - key: pipeline
+            value: cosmic
+          - key: status
+            value: "{{workflow.status}}"
+        histogram:
+          buckets: [300, 900, 1800, 3600, 7200, 14400, 28800, 43200, 86400]
+          value: "{{workflow.duration}}"
 
   templates:
 

--- a/docs/adr/0005-storage-and-backup.md
+++ b/docs/adr/0005-storage-and-backup.md
@@ -21,6 +21,7 @@ Stateful workloads today are:
 | `zot-local` registry (`local-registry/registry`) | `hostPath` on `/var/mnt/ghost-data/zot-local` | User data: locally built/pushed images — migrate to `local-path` PVC before Velero backup |
 | `zot-cache` pull-through cache | `hostPath` on `/var/mnt/ghost-data/zot-cache` | Reproducible: exclude |
 | BuildBarn CAS/AC shards (`buildbarn/storage`) | `local-path` PVCs per StatefulSet replica | Reproducible but expensive to rebuild: include |
+| Lightweight Prometheus (`kube-system/prometheus-lightweight`) | 50Gi `local-path` PVC with 30d/45GB TSDB retention | Operational history: exclude; not a source of truth |
 | BuildBarn worker node cache | `hostPath` on `/var/lib/buildbarn/worker` | Reproducible: exclude |
 | ARC runner work volumes | `local-path` PVCs created per runner pod | Ephemeral CI state: exclude |
 

--- a/docs/ops/architecture.md
+++ b/docs/ops/architecture.md
@@ -134,6 +134,15 @@ this cluster today. `manifests/local-path-config.yaml` explicitly maps `ghost`
 and `exo-0` to their own data mounts and has no default mapping. Never
 provision workload storage on a root filesystem.
 
+### Metrics storage
+
+The backend-only `prometheus-lightweight` Deployment stores up to 30 days or
+45GB of time series on a 50Gi `local-path` PVC. The size gap reserves space for
+WAL and compaction. It scrapes node and cAdvisor metrics, the Argo workflow
+controller, both Zot registries, BuildBarn, and KubeStellar controllers.
+Prometheus has ClusterIP access only; KubeStellar Console remains the private
+operator UI, and Grafana is intentionally absent.
+
 ---
 
 ## Compute Model

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -100,6 +100,11 @@ The workflow authoring guidance is split by topic:
 - **Queue Starvation / `activeDeadlineSeconds` Trap**: Leaving a workflow's `activeDeadlineSeconds` at default (or unspecified) when it queues under a template-level semaphore or resource limit. The workflow-level deadline starts ticking upon *submission/creation*, not *execution/scheduling*. If a workflow queues for longer than the global default deadline (e.g., 2h), it gets instantly canceled with `DeadlineExceeded` as soon as it begins running. Always set a generous workflow-level deadline (e.g., 4h/14400s) on queueable templates and dynamic API submission specs.
 - **Secret leakage via shell tracing**: Never use `set -x`/`set -eux` in a script that invokes authenticated APIs or expands secret-bearing variables. Argo retains command output in workflow logs. Disable tracing for the whole script or bracket only non-secret diagnostics with explicit `set +x`/`set -x` boundaries, then inspect logs for credentials before publishing evidence.
 - **PR approval gate bypass**: Routine labels such as `automerge` or `chore/deps` are not maintainer approval. PR-batch templates must stop before build/QA when `pr/needs-review` remains or live GitHub review data lacks a verified maintainer approval.
+- **Custom metric cardinality**: Never label workflow metrics with workflow
+  names, UIDs, commit SHAs, refs, image digests, or build elements. Use only
+  constant pipeline identifiers and bounded states. Workflow-level completion
+  metrics are safe only when the workflow status truthfully represents the
+  publish result; non-blocking or transitional DAG branches must be fixed first.
 
 ## Verification
 
@@ -127,3 +132,5 @@ Before marking any WorkflowTemplate change done:
 - [ ] Image pollers update digest state only after QA pipeline success (failed runs must retry on next poll)
 - [ ] After removing `suspend: true` from a CronWorkflow and syncing, live `spec.suspend` confirmed via `kubectl get -o jsonpath` — not assumed from ArgoCD's `Synced` status alone
 - [ ] After any disk wipe/registry migration/Zot cleanup, every affected containerDisk tag manually force-rebuilt rather than assuming a digest-comparison poller will self-heal
+- [ ] Custom metrics share identical help text and histogram buckets across
+      templates, and labels are limited to low-cardinality constants/states

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -47,6 +47,45 @@ metadata:
    PVC provisioning fails on an unconfigured node instead of falling back to
    that node's root disk.
 
+## Lightweight Prometheus backend
+
+`manifests/prometheus-lightweight.yaml` is the lab's backend-only metrics
+service. Keep it as a single `ClusterIP` deployment: do not add an ingress,
+Grafana, Prometheus Operator, or another cluster dashboard.
+
+- Storage is a `local-path` RWO PVC. The Deployment uses `Recreate` so two pods
+  never contend for the node-local volume.
+- The PVC is 50Gi; Prometheus keeps at most 30 days or 45GB, whichever limit is
+  reached first. The remaining space is headroom for WAL and compaction.
+- Required scrape jobs are `kubernetes-nodes`, `kubernetes-cadvisor`,
+  `argo-workflow-controller`, `zot`, `buildbarn`, and the existing
+  `kubestellar-*` controller jobs.
+- Zot metrics require `extensions.metrics` in both `zot-cache-config` and
+  `zot-local-config`; both expose `/metrics` on their existing HTTP port.
+- Argo custom build metrics use only constant `pipeline` and bounded `status`
+  labels. Never label metrics with workflow name, UID, commit SHA, image digest,
+  ref, or element.
+- `cosmic-build-pipeline`, `bluefin-server-build-pipeline`, and
+  `bst-qa-pipeline` emit completion and duration metrics. Dakota stays omitted
+  until its DAG refactor makes overall workflow status match the publish result;
+  its current non-blocking branches would record false successes.
+
+After changing scrape configuration, bump
+`lab.projectbluefin.io/config-version` on the Prometheus pod template because
+there is no config-reloader sidecar. Verify through the Kubernetes API:
+
+```bash
+kubectl get pvc -n kube-system prometheus-lightweight-data
+kubectl get pods -n kube-system -l app=prometheus-lightweight
+kubectl port-forward -n kube-system svc/prometheus 9090:9090
+curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' |
+  jq -r '.data.activeTargets[] | [.labels.job, .health, .lastError] | @tsv'
+```
+
+The custom series are exposed as
+`argo_workflows_lab_build_workflow_completed_total` and
+`argo_workflows_lab_build_workflow_duration_seconds`.
+
 ## Deep-dive topics
 
 - [BuildStream distributed builds and Buildbarn](buildstream.md)
@@ -118,6 +157,10 @@ Do not guess flags, chart schema, or MCP method names. The K8sGPT MCP server exp
 - [ ] The build progresses past source fetches into artifact pulls/builds.
 - [ ] Workflow reaches `Succeeded`, or if it fails, the failure is a real build
       error (not `pod deleted`).
+- [ ] Prometheus PVC is `Bound` on `local-path` and survives a rollout restart.
+- [ ] Required Prometheus targets report `health: up`; no target exposes a
+      user-facing dashboard.
+- [ ] Build workflow metric labels remain limited to `pipeline` and `status`.
 
 ## Key references
 

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -57,6 +57,25 @@ data:
       evaluation_interval: 15s
 
     scrape_configs:
+      - job_name: 'kubernetes-nodes'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        authorization:
+          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics
+
       - job_name: 'kubernetes-cadvisor'
         scheme: https
         tls_config:
@@ -100,6 +119,44 @@ data:
             target_label: __address__
           - source_labels: [__meta_kubernetes_pod_label_app]
             target_label: app
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: node
+
+      - job_name: 'argo-workflow-controller'
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: ['argo']
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: workflow-controller
+          - source_labels: [__meta_kubernetes_pod_container_port_name]
+            action: keep
+            regex: metrics
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: node
+
+      - job_name: 'zot'
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names: ['local-registry']
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            action: keep
+            regex: registry|zot-cache
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            target_label: service
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
           - source_labels: [__meta_kubernetes_pod_node_name]
             target_label: node
 
@@ -218,6 +275,21 @@ data:
           - source_labels: [__meta_kubernetes_pod_name]
             target_label: instance
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-lightweight-data
+  namespace: kube-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 50Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -229,6 +301,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: prometheus-lightweight
@@ -237,16 +311,23 @@ spec:
       labels:
         app: prometheus-lightweight
       annotations:
-        lab.projectbluefin.io/config-version: bounded-cadvisor-node-labels-v2
+        lab.projectbluefin.io/config-version: persistent-build-metrics-v1
     spec:
       serviceAccountName: prometheus-lightweight
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: prometheus
           image: quay.io/prometheus/prometheus:v2.53.0
           args:
             - --config.file=/etc/prometheus/prometheus.yml
             - --storage.tsdb.path=/prometheus
-            - --storage.tsdb.retention.time=2h
+            - --storage.tsdb.retention.time=30d
+            - --storage.tsdb.retention.size=45GB
           ports:
             - containerPort: 9090
               name: web
@@ -267,7 +348,8 @@ spec:
           configMap:
             name: prometheus-lightweight-config
         - name: storage
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: prometheus-lightweight-data
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -42,6 +42,12 @@ data:
       },
       "log": { "level": "info" },
       "extensions": {
+        "metrics": {
+          "enable": true,
+          "prometheus": {
+            "path": "/metrics"
+          }
+        },
         "sync": {
           "enable": true,
           "registries": [

--- a/manifests/zot-writable.yaml
+++ b/manifests/zot-writable.yaml
@@ -25,7 +25,15 @@ data:
         "address": "0.0.0.0",
         "port": "5000"
       },
-      "log": { "level": "debug" }
+      "log": { "level": "debug" },
+      "extensions": {
+        "metrics": {
+          "enable": true,
+          "prometheus": {
+            "path": "/metrics"
+          }
+        }
+      }
     }
 ---
 apiVersion: apps/v1

--- a/tests/unit/test_build_metrics.py
+++ b/tests/unit/test_build_metrics.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_documents(path):
+    return list(yaml.safe_load_all((ROOT / path).read_text(encoding="utf-8")))
+
+
+def test_prometheus_uses_bounded_local_path_storage_and_retention():
+    documents = load_documents("manifests/prometheus-lightweight.yaml")
+    pvc = next(doc for doc in documents if doc["kind"] == "PersistentVolumeClaim")
+    deployment = next(doc for doc in documents if doc["kind"] == "Deployment")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert pvc["spec"]["storageClassName"] == "local-path"
+    assert pvc["spec"]["accessModes"] == ["ReadWriteOnce"]
+    assert pvc["spec"]["resources"]["requests"]["storage"] == "50Gi"
+    assert deployment["spec"]["strategy"]["type"] == "Recreate"
+    assert "--storage.tsdb.retention.time=30d" in container["args"]
+    assert "--storage.tsdb.retention.size=45GB" in container["args"]
+    assert deployment["spec"]["template"]["spec"]["volumes"][1] == {
+        "name": "storage",
+        "persistentVolumeClaim": {"claimName": "prometheus-lightweight-data"},
+    }
+
+
+def test_prometheus_scrapes_required_build_and_node_targets():
+    config_map = next(
+        doc
+        for doc in load_documents("manifests/prometheus-lightweight.yaml")
+        if doc["kind"] == "ConfigMap"
+    )
+    config = yaml.safe_load(config_map["data"]["prometheus.yml"])
+    jobs = {job["job_name"]: job for job in config["scrape_configs"]}
+
+    assert {
+        "kubernetes-nodes",
+        "kubernetes-cadvisor",
+        "argo-workflow-controller",
+        "zot",
+        "buildbarn",
+    }.issubset(jobs)
+    assert jobs["zot"]["metrics_path"] == "/metrics"
+    assert jobs["zot"]["kubernetes_sd_configs"][0]["namespaces"]["names"] == [
+        "local-registry"
+    ]
+    assert jobs["argo-workflow-controller"]["kubernetes_sd_configs"][0][
+        "namespaces"
+    ]["names"] == ["argo"]
+
+
+def test_zot_metrics_are_enabled_on_both_registries():
+    for path in ("manifests/zot-cache.yaml", "manifests/zot-writable.yaml"):
+        config_map = next(doc for doc in load_documents(path) if doc["kind"] == "ConfigMap")
+        config = json.loads(config_map["data"]["config.json"])
+
+        assert config["extensions"]["metrics"] == {
+            "enable": True,
+            "prometheus": {"path": "/metrics"},
+        }
+
+
+def test_safe_build_workflows_emit_only_low_cardinality_metrics():
+    pipelines = {
+        "cosmic-build-pipeline.yaml": "cosmic",
+        "bluefin-server-build-pipeline.yaml": "bluefin-server",
+        "bst-qa-pipeline.yaml": "bst-qa",
+    }
+
+    for filename, pipeline in pipelines.items():
+        workflow = yaml.safe_load(
+            (ROOT / "argo/workflow-templates" / filename).read_text(encoding="utf-8")
+        )
+        metrics = workflow["spec"]["metrics"]["prometheus"]
+
+        assert {metric["name"] for metric in metrics} == {
+            "lab_build_workflow_completed_total",
+            "lab_build_workflow_duration_seconds",
+        }
+        for metric in metrics:
+            assert metric["labels"] == [
+                {"key": "pipeline", "value": pipeline},
+                {"key": "status", "value": "{{workflow.status}}"},
+            ]
+
+    dakota = yaml.safe_load(
+        (ROOT / "argo/workflow-templates/dakota-build-pipeline.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert "metrics" not in dakota["spec"]


### PR DESCRIPTION
## Summary
- persist lightweight Prometheus on a 50Gi local-path PVC with 30d/45GB retention
- scrape node/cAdvisor, Argo workflow-controller, Zot, existing BuildBarn, and KubeStellar metrics while remaining backend-only
- emit low-cardinality completion/duration metrics from safe build templates and document operations

## Validation
- `pytest -q tests/unit/test_build_metrics.py tests/unit/test_workflow_defaults.py` (17 passed)
- `promtool check config` using Prometheus v2.53.0
- `just lint`

## Deferred
- Dakota custom workflow metrics remain omitted until its DAG refactor makes overall workflow status accurately represent publish success; current non-blocking branches can report false success.