### PR TITLE
feat(argo): publish Dakota testing images to GHCR

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -285,6 +285,11 @@ run-dakota-container-qa image-tag="testing" variant="dakota":
       -p variant={{ variant }} \
       -n {{ argo_ns }} --watch
 
+# Publish dakota:testing and dakota-nvidia:testing from Zot to GHCR.
+run-dakota-publish:
+    argo submit --from workflowtemplate/dakota-publish-pipeline \
+      -n {{ argo_ns }} --watch
+
 # Run the in-cluster BuildStream build pipeline for bluefin-server
 # Usage: just run-bluefin-server-build
 run-bluefin-server-build ref="main" repo="https://github.com/projectbluefin/server.git":

--- a/argo/workflow-templates/dakota-publish-pipeline.yaml
+++ b/argo/workflow-templates/dakota-publish-pipeline.yaml
@@ -1,0 +1,193 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: dakota-publish-pipeline
+  namespace: argo
+  annotations:
+    description: |
+      Publishes the local Zot dakota:testing and dakota-nvidia:testing images
+      to GHCR by source digest, verifies each destination digest, and copies
+      OCI referrers when present. Requires the ghcr-publish-auth Secret.
+    bluefin.io/ghcr-publish-auth-secret-type: kubernetes.io/dockerconfigjson
+  labels:
+    app.kubernetes.io/component: image-publisher
+    app.kubernetes.io/part-of: dakota-test-suite
+spec:
+  serviceAccountName: argo
+  activeDeadlineSeconds: 14400
+  entrypoint: publish-all
+  podGC:
+    strategy: OnWorkflowCompletion
+  ttlStrategy:
+    secondsAfterSuccess: 86400
+    secondsAfterFailure: 604800
+
+  templates:
+    - name: publish-all
+      synchronization:
+        semaphores:
+          - configMapKeyRef:
+              name: workflow-semaphores
+              key: dakota-publish
+      dag:
+        tasks:
+          - name: publish-dakota
+            template: publish-lane
+            arguments:
+              parameters:
+                - name: image
+                  value: dakota
+
+          - name: publish-dakota-nvidia
+            template: publish-lane
+            arguments:
+              parameters:
+                - name: image
+                  value: dakota-nvidia
+
+          - name: verify-lane-results
+            depends: >-
+              (publish-dakota.Succeeded || publish-dakota.Failed || publish-dakota.Errored) &&
+              (publish-dakota-nvidia.Succeeded || publish-dakota-nvidia.Failed || publish-dakota-nvidia.Errored)
+            template: verify-lane-results
+            arguments:
+              parameters:
+                - name: dakota-status
+                  value: "{{tasks.publish-dakota.status}}"
+                - name: dakota-nvidia-status
+                  value: "{{tasks.publish-dakota-nvidia.status}}"
+
+    - name: publish-lane
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: "2"
+        retryPolicy: Always
+        backoff:
+          duration: "30s"
+          factor: "2"
+          maxDuration: "2m"
+      inputs:
+        parameters:
+          - name: image
+      volumes:
+        - name: ghcr-auth
+          secret:
+            secretName: ghcr-publish-auth
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        volumeMounts:
+          - name: ghcr-auth
+            mountPath: /auth
+            readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        env:
+          - name: IMAGE
+            value: "{{inputs.parameters.image}}"
+          - name: SOURCE_REGISTRY
+            value: "192.168.1.102:30500"
+          - name: DESTINATION_REGISTRY
+            value: "ghcr.io/projectbluefin"
+          - name: IMAGE_TAG
+            value: testing
+        source: |
+          set -euo pipefail
+
+          AUTH_FILE=/auth/config.json
+          SOURCE_REF="${SOURCE_REGISTRY}/${IMAGE}:${IMAGE_TAG}"
+          DESTINATION_REF="${DESTINATION_REGISTRY}/${IMAGE}:${IMAGE_TAG}"
+
+          SOURCE_DIGEST=$(skopeo inspect \
+            --tls-verify=false \
+            --format '{{.Digest}}' \
+            "docker://${SOURCE_REF}")
+          if ! printf '%s\n' "${SOURCE_DIGEST}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "ERROR: invalid source digest for ${SOURCE_REF}: ${SOURCE_DIGEST}" >&2
+            exit 1
+          fi
+
+          echo "Publishing ${SOURCE_REF}@${SOURCE_DIGEST} to ${DESTINATION_REF}" >&2
+          skopeo copy \
+            --all \
+            --src-tls-verify=false \
+            --dest-authfile "${AUTH_FILE}" \
+            "docker://${SOURCE_REGISTRY}/${IMAGE}@${SOURCE_DIGEST}" \
+            "docker://${DESTINATION_REF}"
+
+          SOURCE_DIGEST_REF="${SOURCE_REGISTRY}/${IMAGE}@${SOURCE_DIGEST}"
+          if command -v oras >/dev/null 2>&1; then
+            if DISCOVERY=$(oras discover \
+              --plain-http \
+              --format json \
+              --depth 1 \
+              "${SOURCE_DIGEST_REF}" 2>/dev/null); then
+              REFERRER_COUNT=$(printf '%s' "${DISCOVERY}" | jq '(.referrers // []) | length')
+              if [ "${REFERRER_COUNT}" -eq 0 ]; then
+                echo "OCI referrers: none present for ${SOURCE_DIGEST_REF}; image publication continues" >&2
+              else
+                echo "OCI referrers: found ${REFERRER_COUNT}; copying recursively" >&2
+                oras cp \
+                  --recursive \
+                  --from-plain-http \
+                  --to-registry-config "${AUTH_FILE}" \
+                  --no-tty \
+                  "${SOURCE_DIGEST_REF}" \
+                  "${DESTINATION_REF}"
+              fi
+            else
+              echo "OCI referrers: discovery unavailable for ${SOURCE_DIGEST_REF}; image publication continues" >&2
+            fi
+          else
+            echo "OCI referrers: ORAS unavailable; image publication continues" >&2
+          fi
+
+          DESTINATION_DIGEST=$(skopeo inspect \
+            --authfile "${AUTH_FILE}" \
+            --format '{{.Digest}}' \
+            "docker://${DESTINATION_REF}")
+          if [ "${DESTINATION_DIGEST}" != "${SOURCE_DIGEST}" ]; then
+            echo "ERROR: digest mismatch for ${DESTINATION_REF}: source=${SOURCE_DIGEST} destination=${DESTINATION_DIGEST}" >&2
+            exit 1
+          fi
+
+          echo "Published ${DESTINATION_REF}@${DESTINATION_DIGEST}" >&2
+
+    - name: verify-lane-results
+      inputs:
+        parameters:
+          - name: dakota-status
+          - name: dakota-nvidia-status
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 25m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        env:
+          - name: DAKOTA_STATUS
+            value: "{{inputs.parameters.dakota-status}}"
+          - name: DAKOTA_NVIDIA_STATUS
+            value: "{{inputs.parameters.dakota-nvidia-status}}"
+        source: |
+          set -euo pipefail
+
+          echo "dakota:testing publication: ${DAKOTA_STATUS}"
+          echo "dakota-nvidia:testing publication: ${DAKOTA_NVIDIA_STATUS}"
+
+          if [ "${DAKOTA_STATUS}" != Succeeded ] || [ "${DAKOTA_NVIDIA_STATUS}" != Succeeded ]; then
+            echo "ERROR: one or more Dakota publication lanes failed" >&2
+            exit 1
+          fi

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -249,6 +249,32 @@ remains in GitHub Actions; Kubernetes sends only `repository_dispatch` payloads.
 Each repository's `lab-check.yml` must exist on its default branch. The app
 installation must grant `checks: write`.
 
+### `dakota-publish-pipeline`
+
+Publishes `192.168.1.102:30500/dakota:testing` and
+`192.168.1.102:30500/dakota-nvidia:testing` to the matching
+`ghcr.io/projectbluefin/*:testing` tags. Each lane resolves and copies the Zot
+image by digest, then fails unless GHCR reports the same digest. The lanes run
+independently; a final result task reports both statuses and fails the workflow
+if either lane fails.
+
+The workflow requires a Secret named `ghcr-publish-auth` in namespace `argo`.
+It is an operator-managed `kubernetes.io/dockerconfigjson` Secret with the
+standard `.dockerconfigjson` key and GHCR package write access. The Secret is
+not stored in git. Scripts consume the mounted auth file directly and never
+enable shell tracing.
+
+ORAS discovery is attempted for each source digest. Referrers are copied
+recursively when present. No referrers, an unsupported discovery API, or a
+missing ORAS binary is logged explicitly and does not invalidate the image
+copy; a failed copy of discovered referrers fails that lane.
+
+Manual run:
+
+```bash
+just run-dakota-publish
+```
+
 ---
 
 ## Catalog installs
@@ -292,6 +318,7 @@ Lives in `manifests/`, applied via the `testing-lab-infra` ArgoCD app:
 |---|---|---|---|
 | `nightly-smoke` | 02:00 UTC | `bluefin-qa-pipeline` (latest) | Catch upstream regressions |
 | `nightly-smoke-lts` | 02:30 UTC | `bluefin-qa-pipeline` (lts)    | Same, for LTS branch; first fire builds the missing golden disk |
+| `nightly-dakota-publish` | 21:00 UTC | `dakota-publish-pipeline` | Copy both Dakota testing lanes from Zot to GHCR by digest |
 | `orphan-vm-cleanup` | every 2h | inline | GC stale per-run hostDisks in bluefin, flatcar, and knuckle namespaces |
 
 ---

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -30,6 +30,7 @@
 | Check exo-0 kernel canary status (7.1 target) | `kubectl get node exo-0 -o jsonpath='{.status.nodeInfo.kernelVersion}{"\n"}'` |
 | Submit Dakota BST build pipeline (default variant only) | `just run-bst-build [ref=testing]` |
 | Run Dakota containerized smoke QA (no VM, works for composefs-oci) | `just run-dakota-container-qa [image-tag=testing] [variant=dakota]` |
+| Publish both Dakota testing lanes from Zot to GHCR | `just run-dakota-publish` |
 | Trigger the Dakota PR batch workflow | `argo submit -n argo --from workflowtemplate/dakota-pr-batch-pipeline -p pr-numbers=<number> --wait` |
 | Tail the most recent workflow's logs | `just logs` |
 | List workflows / VMs | `just list-workflows` · `just list-vms` |
@@ -66,6 +67,8 @@ Run `just logs` first. Then match a row. **Bluefin and Dakota image-poll QA are 
 | `No GITHUB_TOKEN or missing results.json - skipping publication` | `kubectl get secret -n argo github-token` — secret must exist; then inspect `just logs` for the failing suite before rerunning. |
 | `results.json not found` or summary reports `Execution failed` | `just logs | grep -n "results.json not found\|Execution failed"` → identify the failing `run-container-tests` lane, then rerun after fixing the image or suite issue. |
 | Expected image-poll rerun never starts after a new publish | `kubectl get configmap image-polling-digests -n argo -o yaml` — compare the stored digest with the workflow log; stale state means the previous run already claimed that digest. |
+| Dakota GHCR publish fails before copying | Confirm the operator-managed contract without printing its data: `kubectl get secret ghcr-publish-auth -n argo -o jsonpath='{.type}{"\n"}'` must report `kubernetes.io/dockerconfigjson`; then inspect the lane status with `argo get -n argo @latest`. |
+| Dakota GHCR publish reports a digest mismatch | Compare source and destination with authenticated operator tooling; never print or decode `ghcr-publish-auth`. A lane is successful only when Zot and GHCR report the same digest. |
 | VMI `NotFound` 1 second after VM creation | Same as above — KubeVirt refused to start VM due to missing accessCredentials secret; VM status will be `Stopped` |
 | `TypeError: ... requireResult` | Fix the step per [`/docs/skills/test-authoring/dogtail-patterns.md`](/docs/skills/test-authoring/dogtail-patterns.md) §6.2 (`findChildren(...)` / `retry=False`) |
 | `Application "gnome-shell" is running` step fails | Replace it with `* GNOME Shell is accessible via AT-SPI` |

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -10,6 +10,7 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
   - [bluefin-qa-pipeline](#bluefin-qa-pipeline)
   - [dakota-qa-pipeline](#dakota-qa-pipeline)
   - [dakota-build-pipeline](#dakota-build-pipeline)
+  - [dakota-publish-pipeline](#dakota-publish-pipeline)
   - [cosmic-build-pipeline](#cosmic-build-pipeline)
   - [bluefin-server-build-pipeline](#bluefin-server-build-pipeline)
   - [bst-qa-pipeline](#bst-qa-pipeline)
@@ -84,6 +85,25 @@ image is verified. Local, cache-only, or fallback builds are diagnostic evidence
 and do not satisfy the distributed gate. Inspect failed child nodes even when the
 Argo parent phase is successful; classify BuildBarn storage/DNS/worker failures as
 infrastructure blockers and repair the lab before retrying.
+
+### dakota-publish-pipeline
+- **Purpose:** Publish the local Zot `dakota:testing` and
+  `dakota-nvidia:testing` images to the corresponding
+  `ghcr.io/projectbluefin` packages without changing their digests.
+- **Source:** `192.168.1.102:30500` (the cluster-reachable Zot NodePort).
+- **Authentication:** operator-managed `ghcr-publish-auth` Secret, type
+  `kubernetes.io/dockerconfigjson`, mounted as an auth file. It is never
+  committed or printed.
+- **DAG:** two independent publication lanes followed by a terminal result
+  check that fails the workflow if either lane did not succeed.
+- **Integrity:** source is copied by digest and the destination digest must
+  match. Each lane has two bounded retries.
+- **OCI evidence:** ORAS discovers and recursively copies referrers when
+  present. Explicit absence or unavailable discovery is non-fatal; failure to
+  copy discovered referrers fails the lane.
+- **Concurrency:** the `dakota-publish` semaphore allows one publication
+  workflow while preserving parallel lane execution inside it.
+- **Just recipe:** `run-dakota-publish`.
 
 ### cosmic-build-pipeline
 - **Purpose:** BuildStream compile pipeline for the default COSMIC image
@@ -219,6 +239,7 @@ the next cycle.
 | `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin-lts` |
 | `nightly-dakota` | — | `dakota-qa-pipeline` | Tests pre-built images only — does not build/warm cache. Currently `suspend: true`. |
 | `nightly-knuckle` | 03:30 | `knuckle-qa-pipeline` | `branch=main`, `namespace=knuckle-test`, `suite=smoke`, `tests-branch=main` |
+| `nightly-dakota-publish` | 21:00 | `dakota-publish-pipeline` | Digest-preserving Zot-to-GHCR publication for both Dakota testing lanes. |
 
 ## Priority Classes
 

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -9,6 +9,7 @@ metadata:
   context7-sources:
     - /argoproj/argo-workflows
     - /kubernetes/website
+    - /oras-project/oras
     - /websites/github_en_rest
 ---
 

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -223,6 +223,44 @@ Verified against Context7 `/argoproj/argo-workflows` CronWorkflow spec docs.
 
 CronWorkflows also cannot be invoked via `workflowTemplateRef` — if you need a CronWorkflow to be submittable manually, extract its logic into a WorkflowTemplate and have the CronWorkflow reference it with `workflowTemplateRef`.
 
+### 17a. Authenticated digest-preserving registry publication
+
+For a scheduled Zot-to-GHCR publisher, keep the reusable logic in a
+WorkflowTemplate and point the CronWorkflow at it. Mount an operator-managed
+`kubernetes.io/dockerconfigjson` Secret as an auth file; do not expose registry
+credentials through parameters, command arguments, stdout, or shell tracing.
+
+Resolve the source tag to a digest, copy `source@digest`, and inspect the
+destination tag with the same auth file. A lane succeeds only when the
+destination digest exactly matches the source digest. Put a semaphore on the
+entrypoint DAG so separate publication workflows serialize while independent
+image lanes within one workflow can still run in parallel.
+
+Use terminal-status dependencies for the result task:
+
+```yaml
+depends: >-
+  (lane-a.Succeeded || lane-a.Failed || lane-a.Errored) &&
+  (lane-b.Succeeded || lane-b.Failed || lane-b.Errored)
+```
+
+Pass each `{{tasks.<lane>.status}}` to the result task and fail it unless every
+lane succeeded. Bound each lane with `retryStrategy.limit` and backoff.
+
+After the image copy, use `oras discover` against the source digest. If
+referrers exist, recursively copy them with the destination registry auth file.
+Log explicit `none present` or `discovery unavailable` states as non-fatal;
+failure to copy referrers that were discovered is a lane failure. Verify the
+destination digest after this optional evidence step.
+
+```bash
+# Source: Context7 /oras-project/oras
+oras discover --plain-http --format json --depth 1 "${SOURCE}@${DIGEST}"
+oras cp --recursive --from-plain-http \
+  --to-registry-config /auth/config.json --no-tty \
+  "${SOURCE}@${DIGEST}" "${DESTINATION}:testing"
+```
+
 ### 18. `when` condition trap — never reference a Skipped task's outputs
 
 **Verified against Context7 `/argoproj/argo-workflows` enhanced-depends-logic docs:**

--- a/manifests/nightly-dakota-publish.yaml
+++ b/manifests/nightly-dakota-publish.yaml
@@ -1,0 +1,31 @@
+# CronWorkflow: publish both local Dakota testing lanes to GHCR at 21:00 UTC.
+# The reusable WorkflowTemplate remains available for manual publication.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: nightly-dakota-publish
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: dakota-test-suite
+spec:
+  suspend: false
+  schedules:
+    - "0 21 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  workflowMetadata:
+    labels:
+      app.kubernetes.io/part-of: dakota-test-suite
+      bluefin.io/trigger: nightly
+      bluefin.io/lane: ghcr-publish
+  workflowSpec:
+    serviceAccountName: argo
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterSuccess: 86400
+      secondsAfterFailure: 604800
+    workflowTemplateRef:
+      name: dakota-publish-pipeline
+

--- a/manifests/workflow-semaphores.yaml
+++ b/manifests/workflow-semaphores.yaml
@@ -16,6 +16,8 @@
 #                        total requested memory below the 95% pressure threshold.
 #                        VMs are still scheduled natively and must not use this
 #                        semaphore (see docs/skills/argo-workflows/patterns.md).
+#   dakota-publish      — Serializes Zot-to-GHCR Dakota publication workflows
+#                        while both image lanes run independently inside one slot.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -27,3 +29,4 @@ data:
   bst-build: "1"
   migration-containerdisk-build: "1"
   ghost-container-qa: "8"
+  dakota-publish: "1"

--- a/tests/unit/test_dakota_publish_workflow.py
+++ b/tests/unit/test_dakota_publish_workflow.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PIPELINE_PATH = ROOT / "argo/workflow-templates/dakota-publish-pipeline.yaml"
+CRON_PATH = ROOT / "manifests/nightly-dakota-publish.yaml"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def template_named(workflow, name):
+    return next(template for template in workflow["spec"]["templates"] if template["name"] == name)
+
+
+def test_publish_pipeline_has_two_independent_gated_lanes():
+    workflow = load_yaml(PIPELINE_PATH)
+    pipeline = template_named(workflow, "publish-all")
+    tasks = {task["name"]: task for task in pipeline["dag"]["tasks"]}
+
+    assert workflow["metadata"]["name"] == "dakota-publish-pipeline"
+    assert workflow["spec"]["activeDeadlineSeconds"] == 14400
+    assert pipeline["synchronization"]["semaphores"][0]["configMapKeyRef"] == {
+        "name": "workflow-semaphores",
+        "key": "dakota-publish",
+    }
+    assert tasks["publish-dakota"]["arguments"]["parameters"][0]["value"] == "dakota"
+    assert (
+        tasks["publish-dakota-nvidia"]["arguments"]["parameters"][0]["value"]
+        == "dakota-nvidia"
+    )
+    assert "publish-dakota.Failed" in tasks["verify-lane-results"]["depends"]
+    assert "publish-dakota-nvidia.Failed" in tasks["verify-lane-results"]["depends"]
+
+
+def test_publish_lane_preserves_and_verifies_digest_without_logging_credentials():
+    workflow = load_yaml(PIPELINE_PATH)
+    lane = template_named(workflow, "publish-lane")
+    source = lane["script"]["source"]
+    secret = lane["volumes"][0]["secret"]
+
+    assert lane["retryStrategy"]["limit"] == "2"
+    assert lane["retryStrategy"]["retryPolicy"] == "Always"
+    assert lane["retryStrategy"]["backoff"]["maxDuration"] == "2m"
+    assert secret["secretName"] == "ghcr-publish-auth"
+    assert secret["items"][0]["key"] == ".dockerconfigjson"
+    assert (
+        workflow["metadata"]["annotations"][
+            "bluefin.io/ghcr-publish-auth-secret-type"
+        ]
+        == "kubernetes.io/dockerconfigjson"
+    )
+    assert "192.168.1.102:30500" in str(lane["script"]["env"])
+    assert '"docker://${SOURCE_REGISTRY}/${IMAGE}@${SOURCE_DIGEST}"' in source
+    assert 'if [ "${DESTINATION_DIGEST}" != "${SOURCE_DIGEST}" ]' in source
+    assert "set -x" not in source
+    assert "set -eux" not in source
+
+
+def test_publish_lane_handles_oci_referrers_explicitly():
+    source = template_named(load_yaml(PIPELINE_PATH), "publish-lane")["script"]["source"]
+
+    assert "oras discover" in source
+    assert "oras cp" in source
+    assert "--recursive" in source
+    assert "OCI referrers: none present" in source
+    assert "OCI referrers: discovery unavailable" in source
+    assert "OCI referrers: ORAS unavailable" in source
+
+
+def test_nightly_publish_schedule_and_manual_entrypoint():
+    cron = load_yaml(CRON_PATH)
+    justfile = (ROOT / "Justfile").read_text(encoding="utf-8")
+
+    assert cron["metadata"]["name"] == "nightly-dakota-publish"
+    assert cron["spec"]["schedules"] == ["0 21 * * *"]
+    assert cron["spec"]["timezone"] == "UTC"
+    assert cron["spec"]["concurrencyPolicy"] == "Forbid"
+    assert (
+        cron["spec"]["workflowSpec"]["workflowTemplateRef"]["name"]
+        == "dakota-publish-pipeline"
+    )
+    assert "run-dakota-publish:" in justfile
+    assert "--from workflowtemplate/dakota-publish-pipeline" in justfile
+
+
+def test_publish_secret_is_a_contract_not_a_committed_secret():
+    committed_secrets = []
+    for path in (ROOT / "manifests").glob("*.yaml"):
+        manifests = yaml.safe_load_all(path.read_text(encoding="utf-8"))
+        for manifest in manifests:
+            if isinstance(manifest, dict) and manifest.get("kind") == "Secret":
+                if manifest.get("metadata", {}).get("name") == "ghcr-publish-auth":
+                    committed_secrets.append(path.name)
+
+    assert not committed_secrets


### PR DESCRIPTION
## Summary
- publish `dakota:testing` and `dakota-nvidia:testing` from Zot to GHCR by digest
- verify destination digests, copy OCI referrers when present, and aggregate independent lane results
- add the 21:00 UTC CronWorkflow, semaphore, manual `just` entrypoint, docs, and focused tests

## Secret contract
Requires the operator-managed `ghcr-publish-auth` Secret (`kubernetes.io/dockerconfigjson`) in `argo`. This PR does not create or expose it.

## Validation
- `python -m pytest tests/unit/test_dakota_publish_workflow.py -q` (5 passed)
- `argo lint --offline argo/workflow-templates/ manifests/nightly-dakota-publish.yaml`
- embedded workflow scripts: `bash -n`
- `just lint`