### PR TITLE
feat(buildstream): add chunkah OCI transform

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -289,6 +289,11 @@ run-bluefin-server-build ref="main" repo="https://github.com/projectbluefin/serv
 
 # ── Validation ───────────────────────────────────────────────────────────────
 
+# Validate the reusable BuildStream OCI rechunk transform.
+test-rechunk:
+    bash -n scripts/rechunk_bst_image.sh
+    python -m pytest -q tests/unit/test_rechunk_bst_image.py
+
 # Apply bootstrap WorkflowTemplates to the cluster (run once during initial setup)
 apply-bootstrap:
     kubectl apply -f argo/bootstrap/ -n {{ argo_ns }}

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -91,6 +91,37 @@ The 2026-07-22 Dakota investigation established the following decision tree:
    is reliable. Low utilization during a failed action is expected and is not a
    reason to add workers or jobs.
 
+## Rechunking a Dakota BuildStream OCI export
+
+`scripts/rechunk_bst_image.sh` is the reusable layout-to-layout transform for
+Dakota BST exports:
+
+```bash
+FAKECAP_RESTORE=/src/files/fakecap/fakecap-restore \
+  scripts/rechunk_bst_image.sh \
+  /workspace/export \
+  /workspace/rechunked \
+  /src/files/fakecap-manifest.tsv > /workspace/rechunk-metrics.json
+```
+
+The script uses the existing privileged builder tools (`podman`, `skopeo`,
+`jq`, overlayfs, and Dakota's compiled `fakecap-restore`); it installs nothing.
+It pins chunkah v0.6.0, physically restores the manifest xattrs, emits at most
+128 compressed layers, prunes `/sysroot/`, preserves `containers.bootc`, and
+removes `ostree.commit` plus `ostree.final-diffid`. Stdout is one JSON object
+with input/output digests, compressed bytes, layer count, duration, and tool
+version. Logs go to stderr.
+
+In Argo, keep build/export, rechunk, publish, and metrics persistence as
+artifact-connected DAG tasks. Pass the Dakota manifest/helper paths into this
+script; do not duplicate the transform inline in Workflow YAML.
+
+Sources:
+
+- [chunkah v0.6.0 usage and bootc compatibility](https://github.com/coreos/chunkah/blob/v0.6.0/README.md)
+- [Project Bluefin chunkah action](https://github.com/projectbluefin/actions/blob/main/bootc-build/chunka/action.yml)
+- [Dakota fakecap convention](https://github.com/projectbluefin/dakota/blob/main/Justfile)
+
 ## BST build scheduling: avoid preemption
 
 BST build pods use the `bst-build` PriorityClass. Long distributed builds lose all
@@ -405,4 +436,3 @@ When `buildbarn-config` changes, also bump the `buildbarn-config-revision` pod-t
 - `manifests/buildbarn-scheduler.yaml`
 - `manifests/buildbarn-storage.yaml`
 - `manifests/buildbarn-worker.yaml`
-

--- a/scripts/rechunk_bst_image.sh
+++ b/scripts/rechunk_bst_image.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHUNKAH_VERSION="v0.6.0"
+CHUNKAH_REF="${CHUNKAH_REF:-quay.io/coreos/chunkah:${CHUNKAH_VERSION}@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708}"
+MAX_LAYERS=128
+
+usage() {
+    echo "usage: $0 SOURCE_OCI OUTPUT_OCI FAKECAP_MANIFEST" >&2
+    exit 2
+}
+
+fail() {
+    echo "rechunk_bst_image: $*" >&2
+    exit 1
+}
+
+[[ $# -eq 3 ]] || usage
+
+SOURCE=$1
+OUTPUT=$2
+MANIFEST=$3
+PODMAN=${PODMAN:-podman}
+SKOPEO=${SKOPEO:-skopeo}
+JQ=${JQ:-jq}
+
+for command in "$PODMAN" "$SKOPEO" "$JQ" mount umount; do
+    command -v "$command" >/dev/null || fail "required command not found: $command"
+done
+
+[[ -f "$SOURCE/oci-layout" && -f "$SOURCE/index.json" ]] ||
+    fail "source is not an OCI layout: $SOURCE"
+[[ -f "$MANIFEST" ]] || fail "fakecap manifest not found: $MANIFEST"
+[[ ! -e "$OUTPUT" ]] || fail "output already exists: $OUTPUT"
+
+SOURCE=$(cd "$(dirname "$SOURCE")" && pwd -P)/$(basename "$SOURCE")
+OUTPUT_PARENT=$(cd "$(dirname "$OUTPUT")" && pwd -P)
+OUTPUT_NAME=$(basename "$OUTPUT")
+MANIFEST=$(cd "$(dirname "$MANIFEST")" && pwd -P)/$(basename "$MANIFEST")
+FAKECAP_RESTORE=${FAKECAP_RESTORE:-"$(dirname "$MANIFEST")/fakecap/fakecap-restore"}
+[[ -x "$FAKECAP_RESTORE" ]] ||
+    fail "fakecap restore helper is not executable: $FAKECAP_RESTORE"
+
+ROOT=()
+if [[ $(id -u) -ne 0 ]]; then
+    command -v sudo >/dev/null || fail "root privileges are required"
+    ROOT=(sudo)
+fi
+
+WORK_ROOT=${RECHUNK_WORKDIR:-"${OUTPUT_PARENT}/.rechunk-${OUTPUT_NAME}"}
+[[ ! -e "$WORK_ROOT" ]] || fail "work directory already exists: $WORK_ROOT"
+UPPER="${WORK_ROOT}/upper"
+OVERLAY_WORK="${WORK_ROOT}/work"
+MERGED="${WORK_ROOT}/rootfs"
+MOUNTED=false
+SUCCESS=false
+SOURCE_IMAGE=
+
+cleanup() {
+    if [[ "$MOUNTED" == true ]]; then
+        "${ROOT[@]}" umount "$MERGED" 2>/dev/null || true
+    fi
+    if [[ -n "$SOURCE_IMAGE" ]]; then
+        "${ROOT[@]}" "$PODMAN" image unmount "$SOURCE_IMAGE" >/dev/null 2>&1 || true
+    fi
+    "${ROOT[@]}" rm -rf "$WORK_ROOT"
+    if [[ "$SUCCESS" != true ]]; then
+        "${ROOT[@]}" rm -rf "$OUTPUT"
+    fi
+}
+trap cleanup EXIT
+
+STARTED_AT=$(date +%s)
+INPUT_DIGEST=$("$SKOPEO" inspect --format '{{.Digest}}' "oci:${SOURCE}")
+SOURCE_INSPECT=$("$SKOPEO" inspect "oci:${SOURCE}")
+SOURCE_BOOTC=$("$JQ" -er '.Labels["containers.bootc"]' <<<"$SOURCE_INSPECT") ||
+    fail "source OCI layout is missing containers.bootc"
+
+SOURCE_IMAGE=$("${ROOT[@]}" "$PODMAN" pull -q "oci:${SOURCE}" | tail -n 1)
+[[ -n "$SOURCE_IMAGE" ]] || fail "podman did not return an image ID"
+SOURCE_CONFIG=$("${ROOT[@]}" "$PODMAN" inspect "$SOURCE_IMAGE")
+LOWER=$("${ROOT[@]}" "$PODMAN" image mount "$SOURCE_IMAGE")
+[[ -d "$LOWER" ]] || fail "podman did not mount the source image"
+
+"${ROOT[@]}" mkdir -p "$UPPER" "$OVERLAY_WORK" "$MERGED"
+"${ROOT[@]}" mount -t overlay overlay \
+    -o "lowerdir=${LOWER},upperdir=${UPPER},workdir=${OVERLAY_WORK}" "$MERGED"
+MOUNTED=true
+
+echo "==> Applying fakecap xattrs" >&2
+"${ROOT[@]}" "$FAKECAP_RESTORE" "$MANIFEST" "$MERGED"
+
+for attempt in 1 2 3; do
+    if "${ROOT[@]}" "$PODMAN" pull "$CHUNKAH_REF" >/dev/null; then
+        break
+    fi
+    [[ $attempt -lt 3 ]] || fail "unable to pull ${CHUNKAH_REF}"
+    sleep 10
+done
+
+echo "==> Rechunking OCI layout with chunkah ${CHUNKAH_VERSION}" >&2
+"${ROOT[@]}" "$PODMAN" run --rm \
+    --pull never \
+    --security-opt label=type:unconfined_t \
+    -v "${MERGED}:/chunkah:ro" \
+    -v "${OUTPUT_PARENT}:/output:rw" \
+    -e "CHUNKAH_ROOTFS=/chunkah" \
+    -e "CHUNKAH_CONFIG_STR=${SOURCE_CONFIG}" \
+    "$CHUNKAH_REF" build \
+    --compressed \
+    --max-layers "$MAX_LAYERS" \
+    --prune /sysroot/ \
+    --label ostree.commit- \
+    --label ostree.final-diffid- \
+    --output "oci:/output/${OUTPUT_NAME}"
+
+[[ -f "$OUTPUT/oci-layout" && -f "$OUTPUT/index.json" ]] ||
+    fail "chunkah did not produce an OCI layout"
+
+OUTPUT_DIGEST=$("$SKOPEO" inspect --format '{{.Digest}}' "oci:${OUTPUT}")
+OUTPUT_INSPECT=$("$SKOPEO" inspect "oci:${OUTPUT}")
+OUTPUT_BOOTC=$("$JQ" -er '.Labels["containers.bootc"]' <<<"$OUTPUT_INSPECT") ||
+    fail "output OCI layout is missing containers.bootc"
+[[ "$OUTPUT_BOOTC" == "$SOURCE_BOOTC" ]] ||
+    fail "containers.bootc changed during rechunk"
+
+# shellcheck disable=SC2016 # jq variables, not shell variables
+if "$JQ" -e '
+    (.Labels // {}) as $labels
+    | ($labels | has("ostree.commit")) or ($labels | has("ostree.final-diffid"))
+' >/dev/null <<<"$OUTPUT_INSPECT"; then
+    fail "output retained stale ostree labels"
+fi
+
+OUTPUT_MANIFEST=$("$SKOPEO" inspect --raw "oci:${OUTPUT}")
+LAYER_COUNT=$("$JQ" -er '.layers | length' <<<"$OUTPUT_MANIFEST")
+COMPRESSED_SIZE=$("$JQ" -er '[.layers[].size] | add // 0' <<<"$OUTPUT_MANIFEST")
+(( LAYER_COUNT <= MAX_LAYERS )) ||
+    fail "output has ${LAYER_COUNT} layers; maximum is ${MAX_LAYERS}"
+
+DURATION=$(( $(date +%s) - STARTED_AT ))
+SUCCESS=true
+# shellcheck disable=SC2016 # jq variables, not shell variables
+"$JQ" -n \
+    --arg input_digest "$INPUT_DIGEST" \
+    --arg output_digest "$OUTPUT_DIGEST" \
+    --arg tool_version "chunkah ${CHUNKAH_VERSION}" \
+    --argjson compressed_size_bytes "$COMPRESSED_SIZE" \
+    --argjson layer_count "$LAYER_COUNT" \
+    --argjson duration_seconds "$DURATION" \
+    '{
+        input_digest: $input_digest,
+        output_digest: $output_digest,
+        compressed_size_bytes: $compressed_size_bytes,
+        layer_count: $layer_count,
+        duration_seconds: $duration_seconds,
+        tool_version: $tool_version
+    }'

--- a/tests/unit/test_rechunk_bst_image.py
+++ b/tests/unit/test_rechunk_bst_image.py
@@ -1,0 +1,173 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/rechunk_bst_image.sh"
+WORK_BASE = ROOT / "tests/.rechunk-test-work"
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def rechunk_case():
+    work = WORK_BASE / str(os.getpid())
+    shutil.rmtree(work, ignore_errors=True)
+    (work / "bin").mkdir(parents=True)
+    source = work / "source"
+    source.mkdir()
+    (source / "oci-layout").write_text('{"imageLayoutVersion":"1.0.0"}\n')
+    (source / "index.json").write_text('{"schemaVersion":2,"manifests":[]}\n')
+    manifest = work / "files/fakecap-manifest.tsv"
+    manifest.parent.mkdir()
+    manifest.write_text("/usr/bin/example\tbluefin/example.bst\tweekly\n")
+    fakecap = manifest.parent / "fakecap/fakecap-restore"
+    fakecap.parent.mkdir()
+    log = work / "commands.log"
+
+    write_executable(
+        work / "bin/sudo",
+        'echo "sudo $*" >> "$MOCK_LOG"\nexec "$@"\n',
+    )
+    write_executable(
+        work / "bin/mount",
+        'echo "mount $*" >> "$MOCK_LOG"\n',
+    )
+    write_executable(
+        work / "bin/umount",
+        'echo "umount $*" >> "$MOCK_LOG"\n',
+    )
+    write_executable(
+        fakecap,
+        'echo "fakecap $*" >> "$MOCK_LOG"\n',
+    )
+    write_executable(
+        work / "bin/podman",
+        r'''
+echo "podman $*" >> "$MOCK_LOG"
+case "${1:-} ${2:-}" in
+    "pull -q") echo "sha256:source-image" ;;
+    "inspect sha256:source-image")
+        printf '[{"Config":{"Labels":{"containers.bootc":"1","ostree.commit":"old"}}}]\n'
+        ;;
+    "image mount")
+        mkdir -p "$MOCK_LOWER"
+        echo "$MOCK_LOWER"
+        ;;
+    "run --rm")
+        mkdir -p "$MOCK_OUTPUT"
+        printf '{"imageLayoutVersion":"1.0.0"}\n' > "$MOCK_OUTPUT/oci-layout"
+        printf '{"schemaVersion":2,"manifests":[]}\n' > "$MOCK_OUTPUT/index.json"
+        ;;
+esac
+''',
+    )
+    write_executable(
+        work / "bin/skopeo",
+        r'''
+echo "skopeo $*" >> "$MOCK_LOG"
+ref="${*: -1}"
+if [[ "$*" == *"--raw"* ]]; then
+    printf '%s\n' "$MOCK_OUTPUT_MANIFEST"
+elif [[ "$*" == *"--format"* ]]; then
+    if [[ "$ref" == *"/source" ]]; then echo "sha256:input"; else echo "sha256:output"; fi
+elif [[ "$ref" == *"/source" ]]; then
+    printf '{"Labels":{"containers.bootc":"1","ostree.commit":"old","ostree.final-diffid":"old"}}\n'
+else
+    printf '%s\n' "$MOCK_OUTPUT_INSPECT"
+fi
+''',
+    )
+
+    env = os.environ | {
+        "PATH": f"{work / 'bin'}:{os.environ['PATH']}",
+        "MOCK_LOG": str(log),
+        "MOCK_LOWER": str(work / "lower"),
+        "MOCK_OUTPUT": str(work / "output"),
+        "MOCK_OUTPUT_MANIFEST": '{"layers":[{"size":40},{"size":50}]}',
+        "MOCK_OUTPUT_INSPECT": '{"Labels":{"containers.bootc":"1"}}',
+        "FAKECAP_RESTORE": str(fakecap),
+        "RECHUNK_WORKDIR": str(work / "overlay"),
+    }
+
+    try:
+        yield work, source, manifest, log, env
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+        if WORK_BASE.exists() and not any(WORK_BASE.iterdir()):
+            WORK_BASE.rmdir()
+
+
+def run_rechunk(case, **env_overrides):
+    work, source, manifest, _, env = case
+    return subprocess.run(
+        [SCRIPT, source, work / "output", manifest],
+        cwd=ROOT,
+        env=env | env_overrides,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_rechunks_layout_and_emits_metrics(rechunk_case):
+    result = run_rechunk(rechunk_case)
+
+    assert result.returncode == 0, result.stderr
+    metrics = json.loads(result.stdout)
+    assert metrics["input_digest"] == "sha256:input"
+    assert metrics["output_digest"] == "sha256:output"
+    assert metrics["compressed_size_bytes"] == 90
+    assert metrics["layer_count"] == 2
+    assert metrics["tool_version"] == "chunkah v0.6.0"
+    assert isinstance(metrics["duration_seconds"], int)
+
+    commands = rechunk_case[3].read_text(encoding="utf-8")
+    assert "fakecap-manifest.tsv" in commands
+    assert "quay.io/coreos/chunkah:v0.6.0@sha256:" in commands
+    assert "--compressed --max-layers 128 --prune /sysroot/" in commands
+    assert "--label ostree.commit- --label ostree.final-diffid-" in commands
+    assert "--output oci:/output/output" in commands
+    assert "CHUNKAH_CONFIG_STR=" in commands
+    assert not (rechunk_case[0] / "overlay").exists()
+
+
+def test_rejects_more_than_128_layers(rechunk_case):
+    layers = {"layers": [{"size": 1}] * 129}
+    result = run_rechunk(
+        rechunk_case,
+        MOCK_OUTPUT_MANIFEST=json.dumps(layers, separators=(",", ":")),
+    )
+
+    assert result.returncode == 1
+    assert "maximum is 128" in result.stderr
+    assert not (rechunk_case[0] / "output").exists()
+
+
+@pytest.mark.parametrize(
+    ("labels", "message"),
+    [
+        ({"Labels": {}}, "missing containers.bootc"),
+        (
+            {"Labels": {"containers.bootc": "1", "ostree.commit": "stale"}},
+            "retained stale ostree labels",
+        ),
+    ],
+)
+def test_rejects_invalid_output_labels(rechunk_case, labels, message):
+    result = run_rechunk(
+        rechunk_case,
+        MOCK_OUTPUT_INSPECT=json.dumps(labels, separators=(",", ":")),
+    )
+
+    assert result.returncode == 1
+    assert message in result.stderr
+    assert not (rechunk_case[0] / "output").exists()


### PR DESCRIPTION
## Summary
- add a reusable OCI-layout-to-OCI-layout Dakota rechunk helper pinned to chunkah v0.6.0
- restore fakecap manifest xattrs, preserve `containers.bootc`, prune `/sysroot/`, remove stale ostree labels, and cap output at 128 compressed layers
- emit JSON metrics for digests, compressed bytes, layer count, duration, and tool version
- add mocked focused tests, a `just test-rechunk` entrypoint, and BuildStream skill documentation

## Validation
- `shellcheck scripts/rechunk_bst_image.sh`
- `just test-rechunk`
- `python -m pytest -q tests/unit/` (131 passed)
- `just lint`

## Remaining integration
This PR intentionally does not perform the unfinished Dakota DAG refactor. Follow-up integration must split build/export, rechunk, publish, and metrics persistence into artifact-connected tasks and invoke this script with Dakota's `files/fakecap-manifest.tsv` and compiled `fakecap-restore` path.
