### PR TITLE
docs(skills): document persistent RWO rollouts

### DIFF
--- a/docs/skills/gitops-argocd/SKILL.md
+++ b/docs/skills/gitops-argocd/SKILL.md
@@ -8,6 +8,7 @@ description: >
 metadata:
   context7-sources:
     - /argoproj/argo-cd
+    - /kubernetes/website
     - /websites/argo-cd_readthedocs_io_en_stable
 ---
 
@@ -125,6 +126,12 @@ names to track resources. Always use a fixed `name:`.
 **Dynamic ConfigMap Key Avoidance:** When a ConfigMap tracks dynamic, runtime-managed state (such as image digests or the last-seen kernel version), do **not** declare placeholder keys (e.g., `kernel-stable: ""`) in the Git manifest's `data:` block. Under Server-Side Apply, defining a field in Git forces ArgoCD to continuously reconcile and overwrite that specific field, resetting it to the placeholder and triggering infinite polling or build loops. To prevent this, omit the dynamic keys entirely from the Git manifest. Server-Side Apply will bootstrap the empty ConfigMap object and leave dynamically added keys untouched at runtime.
 
 **Exception — intentional runtime-state ConfigMap contract:** If the Git manifest must define an explicit set of runtime keys (for example, to document a lifecycle-state contract with known empty marker keys), scope an `ignoreDifferences` rule to that one ConfigMap and ignore `/data`, then enable `RespectIgnoreDifferences=true` on the Application. This keeps the key contract in git without ArgoCD patching live runtime values back to placeholders.
+
+**Singleton local-path PVC rollout:** When a GitOps-managed singleton Deployment
+moves from `emptyDir` to a `local-path` `ReadWriteOnce` PVC, set its strategy to
+`Recreate`. Leave placement to `WaitForFirstConsumer` and the scheduler; do not
+add a hostname selector. Size application retention below PVC capacity so WAL,
+compaction, or other temporary files cannot fill the volume.
 
 **Subdirectories and namespaces:** `testing-lab-infra` runs with
 `directory.recurse: true` (live-patched 2026-07-25; the Application object is


### PR DESCRIPTION
## Summary
- capture the GitOps-safe rollout pattern for moving singleton Deployments from `emptyDir` to local-path RWO PVCs
- record `Recreate`, scheduler placement, and retention headroom requirements
- cite the Kubernetes Context7 source used to verify the pattern

Follow-up learning write-back from #401.