### PR TITLE
fix(prometheus): clear rolling update on Recreate

### DIFF
--- a/docs/skills/gitops-argocd/SKILL.md
+++ b/docs/skills/gitops-argocd/SKILL.md
@@ -129,8 +129,10 @@ names to track resources. Always use a fixed `name:`.
 
 **Singleton local-path PVC rollout:** When a GitOps-managed singleton Deployment
 moves from `emptyDir` to a `local-path` `ReadWriteOnce` PVC, set its strategy to
-`Recreate`. Leave placement to `WaitForFirstConsumer` and the scheduler; do not
-add a hostname selector. Size application retention below PVC capacity so WAL,
+`Recreate` and explicitly set `rollingUpdate: null`; Server-Side Apply otherwise
+retains the old rolling-update field and Kubernetes rejects the strategy change.
+Leave placement to `WaitForFirstConsumer` and the scheduler; do not add a
+hostname selector. Size application retention below PVC capacity so WAL,
 compaction, or other temporary files cannot fill the volume.
 
 **Subdirectories and namespaces:** `testing-lab-infra` runs with

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -303,6 +303,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app: prometheus-lightweight

--- a/tests/unit/test_build_metrics.py
+++ b/tests/unit/test_build_metrics.py
@@ -20,7 +20,10 @@ def test_prometheus_uses_bounded_local_path_storage_and_retention():
     assert pvc["spec"]["storageClassName"] == "local-path"
     assert pvc["spec"]["accessModes"] == ["ReadWriteOnce"]
     assert pvc["spec"]["resources"]["requests"]["storage"] == "50Gi"
-    assert deployment["spec"]["strategy"]["type"] == "Recreate"
+    assert deployment["spec"]["strategy"] == {
+        "type": "Recreate",
+        "rollingUpdate": None,
+    }
     assert "--storage.tsdb.retention.time=30d" in container["args"]
     assert "--storage.tsdb.retention.size=45GB" in container["args"]
     assert deployment["spec"]["template"]["spec"]["volumes"][1] == {


### PR DESCRIPTION
## Summary
- clear the Deployment `rollingUpdate` field when switching Prometheus to `Recreate`
- cover the Server-Side Apply transition in the manifest test and GitOps skill

## Live failure
ArgoCD rejected the #401 rollout because Server-Side Apply retained the previous rolling-update strategy field: `spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is Recreate`.

## Validation
- `pytest -q tests/unit/test_build_metrics.py` (4 passed)
- `just lint`