### PR TITLE
fix(zot): roll out metrics configuration

### DIFF
--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -61,7 +61,9 @@ Grafana, Prometheus Operator, or another cluster dashboard.
   `argo-workflow-controller`, `zot`, `buildbarn`, and the existing
   `kubestellar-*` controller jobs.
 - Zot metrics require `extensions.metrics` in both `zot-cache-config` and
-  `zot-local-config`; both expose `/metrics` on their existing HTTP port.
+  `zot-local-config`; both expose `/metrics` on their existing HTTP port. Bump
+  each workload's `lab.projectbluefin.io/config-version` annotation when either
+  ConfigMap changes because Zot reads the subPath-mounted config only at startup.
 - Argo custom build metrics use only constant `pipeline` and bounded `status`
   labels. Never label metrics with workflow name, UID, commit SHA, image digest,
   ref, or element.

--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -137,6 +137,8 @@ spec:
       labels:
         app: zot-cache
         app.kubernetes.io/part-of: lab
+      annotations:
+        lab.projectbluefin.io/config-version: metrics-v1
     spec:
       automountServiceAccountToken: false
       priorityClassName: system-cluster-critical

--- a/manifests/zot-writable.yaml
+++ b/manifests/zot-writable.yaml
@@ -56,6 +56,8 @@ spec:
       labels:
         app: registry
         app.kubernetes.io/part-of: lab
+      annotations:
+        lab.projectbluefin.io/config-version: metrics-v1
     spec:
       automountServiceAccountToken: false
       priorityClassName: system-cluster-critical

--- a/tests/unit/test_build_metrics.py
+++ b/tests/unit/test_build_metrics.py
@@ -58,14 +58,22 @@ def test_prometheus_scrapes_required_build_and_node_targets():
 
 
 def test_zot_metrics_are_enabled_on_both_registries():
-    for path in ("manifests/zot-cache.yaml", "manifests/zot-writable.yaml"):
-        config_map = next(doc for doc in load_documents(path) if doc["kind"] == "ConfigMap")
+    for path, workload_kind in (
+        ("manifests/zot-cache.yaml", "DaemonSet"),
+        ("manifests/zot-writable.yaml", "Deployment"),
+    ):
+        documents = load_documents(path)
+        config_map = next(doc for doc in documents if doc["kind"] == "ConfigMap")
+        workload = next(doc for doc in documents if doc["kind"] == workload_kind)
         config = json.loads(config_map["data"]["config.json"])
 
         assert config["extensions"]["metrics"] == {
             "enable": True,
             "prometheus": {"path": "/metrics"},
         }
+        assert workload["spec"]["template"]["metadata"]["annotations"][
+            "lab.projectbluefin.io/config-version"
+        ] == "metrics-v1"
 
 
 def test_safe_build_workflows_emit_only_low_cardinality_metrics():


### PR DESCRIPTION
## Summary
- restart both Zot workloads when metrics configuration changes
- test the required pod-template config-version annotations
- document the subPath-mounted config rollout rule

## Live finding
#401 updated both ConfigMaps, but the long-running Zot pods do not reload subPath-mounted configuration. Without a pod-template annotation change, `/metrics` remains 404.

## Validation
- `pytest -q tests/unit/test_build_metrics.py` (4 passed)
- `just lint`