### PR TITLE
fix(argo): provide Dakota publisher registry tools

### DIFF
--- a/argo/workflow-templates/dakota-publish-pipeline.yaml
+++ b/argo/workflow-templates/dakota-publish-pipeline.yaml
@@ -77,7 +77,7 @@ spec:
               - key: .dockerconfigjson
                 path: config.json
       script:
-        image: ghcr.io/projectbluefin/lab-runner:latest
+        image: quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615
         command: [bash]
         volumeMounts:
           - name: ghcr-auth
@@ -87,9 +87,11 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+            ephemeral-storage: 1Gi
           limits:
             cpu: "1"
             memory: 2Gi
+            ephemeral-storage: 4Gi
         env:
           - name: IMAGE
             value: "{{inputs.parameters.image}}"
@@ -124,17 +126,32 @@ spec:
             "docker://${DESTINATION_REF}"
 
           SOURCE_DIGEST_REF="${SOURCE_REGISTRY}/${IMAGE}@${SOURCE_DIGEST}"
+          if ! command -v oras >/dev/null 2>&1; then
+            ORAS_VERSION=1.2.3
+            ORAS_DIR=/tmp/oras-bin
+            mkdir -p "${ORAS_DIR}"
+            if curl -sSfL \
+              "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+              | tar xz -C "${ORAS_DIR}" oras; then
+              export PATH="${ORAS_DIR}:${PATH}"
+            else
+              echo "OCI referrers: ORAS bootstrap unavailable; image publication continues" >&2
+            fi
+          fi
+
           if command -v oras >/dev/null 2>&1; then
             if DISCOVERY=$(oras discover \
               --plain-http \
               --format json \
               --depth 1 \
               "${SOURCE_DIGEST_REF}" 2>/dev/null); then
-              REFERRER_COUNT=$(printf '%s' "${DISCOVERY}" | jq '(.referrers // []) | length')
-              if [ "${REFERRER_COUNT}" -eq 0 ]; then
+              DISCOVERY_COMPACT=$(printf '%s' "${DISCOVERY}" | awk '{printf "%s",$0}')
+              if ! printf '%s' "${DISCOVERY_COMPACT}" | grep -q '"referrers"'; then
+                echo "OCI referrers: discovery output unavailable for ${SOURCE_DIGEST_REF}; image publication continues" >&2
+              elif printf '%s' "${DISCOVERY_COMPACT}" | grep -Eq '"referrers"[[:space:]]*:[[:space:]]*\[[[:space:]]*\]'; then
                 echo "OCI referrers: none present for ${SOURCE_DIGEST_REF}; image publication continues" >&2
               else
-                echo "OCI referrers: found ${REFERRER_COUNT}; copying recursively" >&2
+                echo "OCI referrers: found; copying recursively" >&2
                 oras cp \
                   --recursive \
                   --from-plain-http \
@@ -173,9 +190,11 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+            ephemeral-storage: 16Mi
           limits:
             cpu: 100m
             memory: 128Mi
+            ephemeral-storage: 64Mi
         env:
           - name: DAKOTA_STATUS
             value: "{{inputs.parameters.dakota-status}}"

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -73,6 +73,7 @@ The workflow authoring guidance is split by topic:
 - Python inside bash inside YAML (colons + quotes cause parse errors — use `curl`+`jq` instead; never `python3 -c` or heredoc Python; see §16 GitHub Contents API pattern)
 - Heredoc `<< 'EOF'` inside a YAML block scalar — indentation breaks the YAML parser. ArgoCD returns `ManifestGenerationError: yaml: could not find expected ':'`. Write scripts to files in initContainers or use inline jq instead.
 - `registry.k8s.io/kubectl` used as a shell-capable image — it is distroless, has no bash, nc, or any shell utilities. Use `cgr.dev/chainguard/kubectl:latest-dev` when you need kubectl + bash together
+- `ghcr.io/projectbluefin/lab-runner:latest` assumed to contain `skopeo` or `oras` — the live image can omit both. Use pinned `quay.io/skopeo/stable` and bootstrap pinned ORAS when registry referrers are required.
 - A WorkflowTemplate file name that doesn't match its `metadata.name` (confuses ArgoCD tracking)
 - Templates annotated `DEPRECATED` that haven't been deleted from git
 - Two CronWorkflows with the same schedule covering overlapping namespaces

--- a/docs/skills/argo-workflows/authoring.md
+++ b/docs/skills/argo-workflows/authoring.md
@@ -179,7 +179,7 @@ echo "$SUMMARIES" | jq '
 
 This avoids `jq` parse errors when the aggregated values arrive as strings and keeps the template compatible if Argo later normalizes them to objects.
 
-**`ghcr.io/projectbluefin/lab-runner:latest`** is the preferred, organization-owned FSDK container for pollers, GC, and CronWorkflows in this cluster. It contains `kubectl`, `oras`, `skopeo`, `curl`, `jq`, and full shell capabilities prebuilt. Using organization-owned containers eliminates external runtime package-manager download dependencies and improves offline resiliency.
+**`ghcr.io/projectbluefin/lab-runner:latest`** is the preferred, organization-owned FSDK container for pollers, GC, and CronWorkflows that need `kubectl`, `curl`, `jq`, and a full shell. Do not assume it contains registry clients: the live `latest` image has lacked both `skopeo` and `oras`. Use the pinned `quay.io/skopeo/stable` image for image transfer and bootstrap a pinned ORAS binary when referrer handling is required.
 
 For steps that still use other images, **`cgr.dev/chainguard/kubectl:latest-dev`** can be used as a fallback if it needs both `kubectl` and `bash`. `registry.k8s.io/kubectl` is distroless (no shell — `nc`, `bash /dev/tcp` all fail).
 
@@ -189,7 +189,7 @@ If a step needs shell features (`mkdir`, redirection, `jq`/`awk` parsing, heredo
 - run the binary directly with `container.command`/`args` and avoid shell syntax entirely, or
 - switch to a shell-capable base image (`cgr.dev/chainguard/wolfi-base@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795`, `cgr.dev/chainguard/kubectl:latest-dev`) and install/fetch the CLI inside the step.
 
-To handle any lag in upstream FSDK container image rebuilds, use an inline on-demand bootstrap/fallback wrapper (e.g. `command -v kubectl || curl ...`) inside the shell scripts to guarantee continuous offline execution.
+To handle any lag in upstream FSDK container image rebuilds, use an inline on-demand bootstrap/fallback wrapper (for example, `command -v oras || curl ...`) inside the shell scripts rather than trusting a mutable image tag's historical tool list.
 
 A runtime `/bin/sh: not found` or missing-coreutils failure from a CLI image usually means the image is distroless, not that the WorkflowTemplate syntax is wrong.
 

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -253,6 +253,11 @@ Log explicit `none present` or `discovery unavailable` states as non-fatal;
 failure to copy referrers that were discovered is a lane failure. Verify the
 destination digest after this optional evidence step.
 
+Do not rely on `lab-runner:latest` for registry clients. Use the pinned Skopeo
+image and bootstrap a pinned ORAS release with its included `curl` and `tar`;
+if that unauthenticated bootstrap is unavailable, log the missing referrer
+capability explicitly and continue with digest verification.
+
 ```bash
 # Source: Context7 /oras-project/oras
 oras discover --plain-http --format json --depth 1 "${SOURCE}@${DIGEST}"

--- a/tests/unit/test_dakota_publish_workflow.py
+++ b/tests/unit/test_dakota_publish_workflow.py
@@ -45,6 +45,7 @@ def test_publish_lane_preserves_and_verifies_digest_without_logging_credentials(
     assert lane["retryStrategy"]["limit"] == "2"
     assert lane["retryStrategy"]["retryPolicy"] == "Always"
     assert lane["retryStrategy"]["backoff"]["maxDuration"] == "2m"
+    assert lane["script"]["image"].startswith("quay.io/skopeo/stable@sha256:")
     assert secret["secretName"] == "ghcr-publish-auth"
     assert secret["items"][0]["key"] == ".dockerconfigjson"
     assert (
@@ -66,9 +67,11 @@ def test_publish_lane_handles_oci_referrers_explicitly():
     assert "oras discover" in source
     assert "oras cp" in source
     assert "--recursive" in source
+    assert "ORAS_VERSION=1.2.3" in source
+    assert "oras_${ORAS_VERSION}_linux_amd64.tar.gz" in source
     assert "OCI referrers: none present" in source
     assert "OCI referrers: discovery unavailable" in source
-    assert "OCI referrers: ORAS unavailable" in source
+    assert "OCI referrers: ORAS bootstrap unavailable" in source
 
 
 def test_nightly_publish_schedule_and_manual_entrypoint():


### PR DESCRIPTION
## Summary
- use the pinned Skopeo image because live `lab-runner:latest` lacks `skopeo` and `oras`
- bootstrap pinned ORAS 1.2.3 for optional referrer discovery/copy
- retain non-fatal explicit referrer-unavailable behavior and add ephemeral-storage bounds
- document the verified mutable-image tool trap

## Live failure fixed
`dakota-publish-pipeline-st4fm` failed both lanes with exit 127. A diagnostic pod confirmed `skopeo=missing` and `oras=missing` in `lab-runner:latest`; the pinned Skopeo image contains Skopeo/curl/tar and successfully bootstrapped ORAS 1.2.3.

## Validation
- `python -m pytest tests/unit/test_dakota_publish_workflow.py -q` (5 passed)
- `argo lint --offline argo/workflow-templates/ manifests/nightly-dakota-publish.yaml`
- `just lint`
- live ORAS bootstrap probe in the pinned Skopeo image