### PR TITLE
fix/kubestellar console dev mode and kubeconfig

### DIFF
--- a/argocd/kubestellar-console-app.yaml
+++ b/argocd/kubestellar-console-app.yaml
@@ -50,18 +50,27 @@ spec:
           enabled: false
         clusterName: ghost
         consoleProject: kubestellar
+        kubeconfig:
+          existingSecret: kubestellar-console-kubeconfig
+          existingSecretKey: kubeconfig
         enabledDashboards: "dashboard,clusters,cluster-admin,deploy,compute,workloads,deployments,pods,services,nodes,events,gitops,helm,operators,security,storage,network"
         extraEnv:
+          - name: XDG_CACHE_HOME
+            value: "/tmp/cache"
+          - name: KUBECTL_CACHE_DIR
+            value: "/tmp/kube-cache"
+          - name: HELM_CACHE_HOME
+            value: "/tmp/helm-cache"
+          - name: DEV_MODE
+            value: "true"
+          - name: ALLOW_DEV_MODE_IN_CLUSTERS
+            value: "true"
           - name: ENABLE_DEMO_DASHBOARDS
             value: "false"
           - name: SHOW_DEMO_TO_LOCAL_CTA
             value: "false"
           - name: DISABLE_DYNAMIC_CARDS
             value: "true"
-          - name: NO_LOCAL_AGENT
-            value: "true"
-          - name: ALLOW_DEV_MODE_IN_CLUSTERS
-            value: "false"
         auth:
           allowedGitHubLogins: castrojo
           adminGitHubLogins: castrojo

--- a/argocd/kubestellar-console-kubeconfig.yaml
+++ b/argocd/kubestellar-console-kubeconfig.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubestellar-console-kubeconfig
+  namespace: kubestellar-console
+  labels:
+    app.kubernetes.io/part-of: lab
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - cluster:
+        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        server: https://kubernetes.default.svc
+      name: ghost
+    contexts:
+    - context:
+        cluster: ghost
+        user: in-cluster
+      name: ghost
+    current-context: ghost
+    users:
+    - name: in-cluster
+      user:
+        tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
- **fix(console): disable demo mode and force live cluster configuration**
- **fix(console): enable dev-mode auth and wire kubeconfig secret**
