### PR TITLE
fix(prometheus): use zero-surge PVC rollout

### DIFF
--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -53,8 +53,9 @@ metadata:
 service. Keep it as a single `ClusterIP` deployment: do not add an ingress,
 Grafana, Prometheus Operator, or another cluster dashboard.
 
-- Storage is a `local-path` RWO PVC. The Deployment uses `Recreate` so two pods
-  never contend for the node-local volume.
+- Storage is a `local-path` RWO PVC. The Deployment uses zero-surge rolling
+  updates (`maxSurge: 0`, `maxUnavailable: 1`) so two pods never contend for
+  the node-local volume.
 - The PVC is 50Gi; Prometheus keeps at most 30 days or 45GB, whichever limit is
   reached first. The remaining space is headroom for WAL and compaction.
 - Required scrape jobs are `kubernetes-nodes`, `kubernetes-cadvisor`,

--- a/docs/skills/gitops-argocd/SKILL.md
+++ b/docs/skills/gitops-argocd/SKILL.md
@@ -127,13 +127,16 @@ names to track resources. Always use a fixed `name:`.
 
 **Exception — intentional runtime-state ConfigMap contract:** If the Git manifest must define an explicit set of runtime keys (for example, to document a lifecycle-state contract with known empty marker keys), scope an `ignoreDifferences` rule to that one ConfigMap and ignore `/data`, then enable `RespectIgnoreDifferences=true` on the Application. This keeps the key contract in git without ArgoCD patching live runtime values back to placeholders.
 
-**Singleton local-path PVC rollout:** When a GitOps-managed singleton Deployment
-moves from `emptyDir` to a `local-path` `ReadWriteOnce` PVC, set its strategy to
-`Recreate` and explicitly set `rollingUpdate: null`; Server-Side Apply otherwise
-retains the old rolling-update field and Kubernetes rejects the strategy change.
-Leave placement to `WaitForFirstConsumer` and the scheduler; do not add a
-hostname selector. Size application retention below PVC capacity so WAL,
-compaction, or other temporary files cannot fill the volume.
+**Singleton local-path PVC rollout:** When an existing Server-Side Apply managed
+Deployment moves from `emptyDir` to a `local-path` `ReadWriteOnce` PVC, keep
+`RollingUpdate` but set `maxSurge: 0` and `maxUnavailable: 1`. Changing the live
+strategy to `Recreate` in one SSA operation retains the old `rollingUpdate`
+field until validation and Kubernetes rejects the update. Zero surge deletes
+the old singleton before creating its replacement, avoiding RWO contention
+without a two-stage migration. Leave placement to `WaitForFirstConsumer` and
+the scheduler; do not add a hostname selector. Size application retention below
+PVC capacity so WAL, compaction, or other temporary files cannot fill the
+volume.
 
 **Subdirectories and namespaces:** `testing-lab-infra` runs with
 `directory.recurse: true` (live-patched 2026-07-25; the Application object is

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -302,8 +302,10 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
-    rollingUpdate: null
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: prometheus-lightweight

--- a/tests/unit/test_build_metrics.py
+++ b/tests/unit/test_build_metrics.py
@@ -21,8 +21,8 @@ def test_prometheus_uses_bounded_local_path_storage_and_retention():
     assert pvc["spec"]["accessModes"] == ["ReadWriteOnce"]
     assert pvc["spec"]["resources"]["requests"]["storage"] == "50Gi"
     assert deployment["spec"]["strategy"] == {
-        "type": "Recreate",
-        "rollingUpdate": None,
+        "type": "RollingUpdate",
+        "rollingUpdate": {"maxSurge": 0, "maxUnavailable": 1},
     }
     assert "--storage.tsdb.retention.time=30d" in container["args"]
     assert "--storage.tsdb.retention.size=45GB" in container["args"]


### PR DESCRIPTION
## Summary
- use `RollingUpdate` with `maxSurge: 0`/`maxUnavailable: 1` for the singleton RWO Prometheus PVC
- update tests and evergreen skills with the safe Server-Side Apply migration pattern

## Live finding
Even with `rollingUpdate: null`, Kubernetes validates the retained live rolling-update field before the Server-Side Apply transition to `Recreate`, so ArgoCD cannot perform that one-step strategy change. Zero surge preserves delete-before-create behavior without changing strategy type.

## Validation
- `pytest -q tests/unit/test_build_metrics.py` (4 passed)
- `just lint`