### PR TITLE
feat(zot): add secure candidate promotion foundation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -299,6 +299,16 @@ validate-dakota-history:
 report-dakota-history window="20":
     python3 scripts/publish_dakota_run.py report --window {{ window }}
 
+# Promote one immutable Zot candidate to :testing after its lane passes QA.
+# Usage: just run-zot-promotion dakota-testing dakota candidate-<sha> sha256:<digest>
+run-zot-promotion lane repository candidate_tag expected_digest:
+    argo submit --from workflowtemplate/zot-candidate-lifecycle \
+      -p lane={{ lane }} \
+      -p repository={{ repository }} \
+      -p candidate-tag={{ candidate_tag }} \
+      -p expected-digest={{ expected_digest }} \
+      -n {{ argo_ns }} --watch
+
 # Run the in-cluster BuildStream build pipeline for bluefin-server
 # Usage: just run-bluefin-server-build
 run-bluefin-server-build ref="main" repo="https://github.com/projectbluefin/server.git":

--- a/argo/workflow-templates/zot-candidate-lifecycle.yaml
+++ b/argo/workflow-templates/zot-candidate-lifecycle.yaml
@@ -1,0 +1,308 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: zot-candidate-lifecycle
+  namespace: argo
+  annotations:
+    description: |
+      Reusable single-lane Zot candidate checks and digest-preserving promotion.
+      Candidate tags are immutable commit-derived names. Promotion verifies the
+      pulled-back manifest digest, updates :testing by digest, and attaches OCI
+      promotion evidence. zot-writer-auth is optional until Zot auth activation.
+    bluefin.io/zot-writer-auth-secret-type: kubernetes.io/dockerconfigjson
+    bluefin.io/promotion-evidence-artifact-type: application/vnd.projectbluefin.lab.promotion-evidence.v1+json
+  labels:
+    app.kubernetes.io/component: image-promotion
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  serviceAccountName: argo
+  activeDeadlineSeconds: 3600
+  entrypoint: promote
+  podGC:
+    strategy: OnWorkflowCompletion
+  ttlStrategy:
+    secondsAfterSuccess: 86400
+    secondsAfterFailure: 604800
+  arguments:
+    parameters:
+      - name: lane
+        value: ""
+      - name: repository
+        value: ""
+      - name: candidate-tag
+        value: ""
+      - name: expected-digest
+        value: ""
+
+  templates:
+    - name: promote
+      dag:
+        tasks:
+          - name: promote-candidate
+            template: promote-candidate
+            arguments:
+              parameters:
+                - name: lane
+                  value: "{{workflow.parameters.lane}}"
+                - name: repository
+                  value: "{{workflow.parameters.repository}}"
+                - name: candidate-tag
+                  value: "{{workflow.parameters.candidate-tag}}"
+                - name: expected-digest
+                  value: "{{workflow.parameters.expected-digest}}"
+
+    - name: candidate-preflight
+      inputs:
+        parameters:
+          - name: lane
+          - name: repository
+          - name: candidate-tag
+          - name: min-free-bytes
+            value: "21474836480"
+          - name: min-free-percent
+            value: "10"
+      volumes:
+        - name: registry-data
+          hostPath:
+            path: /var/mnt/ghost-data/zot-local
+            type: Directory
+        - name: work
+          emptyDir: {}
+      nodeSelector:
+        kubernetes.io/hostname: ghost
+      script:
+        image: ghcr.io/oras-project/oras:v1.2.3@sha256:63266a046d1cf5ebebb1461733ed7548148f122e0d422096e177cfa70b521cb1
+        command: ["/bin/sh"]
+        volumeMounts:
+          - name: registry-data
+            mountPath: /registry-data
+            readOnly: true
+          - name: work
+            mountPath: /work
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+        env:
+          - name: LANE
+            value: "{{inputs.parameters.lane}}"
+          - name: REPOSITORY
+            value: "{{inputs.parameters.repository}}"
+          - name: CANDIDATE_TAG
+            value: "{{inputs.parameters.candidate-tag}}"
+          - name: MIN_FREE_BYTES
+            value: "{{inputs.parameters.min-free-bytes}}"
+          - name: MIN_FREE_PERCENT
+            value: "{{inputs.parameters.min-free-percent}}"
+          - name: REGISTRY
+            value: "192.168.1.102:30500"
+        source: |
+          set -euo pipefail
+
+          printf '%s' "${LANE}" | grep -Eq '^[a-z0-9]+(-[a-z0-9]+)*$' ||
+            { echo "ERROR: invalid lane '${LANE}'" >&2; exit 1; }
+          printf '%s' "${REPOSITORY}" | grep -Eq '^[a-z0-9]+([._/-][a-z0-9]+)*$' ||
+            { echo "ERROR: invalid repository '${REPOSITORY}'" >&2; exit 1; }
+          printf '%s' "${CANDIDATE_TAG}" | grep -Eq '^candidate-([0-9a-f]{40}|[0-9a-f]{64})$' ||
+            { echo "ERROR: candidate tag must be candidate-<40-or-64-lowercase-hex>" >&2; exit 1; }
+          printf '%s' "${MIN_FREE_BYTES}" | grep -Eq '^[0-9]+$' ||
+            { echo "ERROR: minimum free bytes must be an integer" >&2; exit 1; }
+          printf '%s' "${MIN_FREE_PERCENT}" | grep -Eq '^[0-9]+$' ||
+            { echo "ERROR: minimum free percent must be an integer" >&2; exit 1; }
+
+          set -- $(df -Pk /registry-data | awk 'NR == 2 {gsub("%", "", $5); print $2, $4, $5}')
+          CAPACITY_KIB="${1:-}"
+          AVAILABLE_KIB="${2:-}"
+          USED_PERCENT="${3:-}"
+          printf '%s %s %s' "${CAPACITY_KIB}" "${AVAILABLE_KIB}" "${USED_PERCENT}" |
+            grep -Eq '^[0-9]+ [0-9]+ [0-9]+$' ||
+            { echo "ERROR: unable to read Zot filesystem capacity" >&2; exit 1; }
+          AVAILABLE_BYTES=$((AVAILABLE_KIB * 1024))
+          FREE_PERCENT=$((100 - USED_PERCENT))
+          if [ "${AVAILABLE_BYTES}" -lt "${MIN_FREE_BYTES}" ] ||
+             [ "${FREE_PERCENT}" -lt "${MIN_FREE_PERCENT}" ]; then
+            echo "ERROR: Zot storage pressure: available=${AVAILABLE_BYTES}B free=${FREE_PERCENT}%" >&2
+            exit 1
+          fi
+
+          REF="${REGISTRY}/${REPOSITORY}:${CANDIDATE_TAG}"
+          if /bin/oras manifest fetch --plain-http --descriptor "${REF}" >/dev/null 2>/work/inspect.err; then
+            echo "ERROR: immutable candidate already exists: ${REF}" >&2
+            exit 1
+          fi
+          if ! grep -Eqi 'manifest unknown|name unknown|not found|404' /work/inspect.err; then
+            echo "ERROR: candidate existence check failed:" >&2
+            cat /work/inspect.err >&2
+            exit 1
+          fi
+
+          echo "Candidate slot available for lane=${LANE}; Zot free=${FREE_PERCENT}% (${AVAILABLE_BYTES}B)" >&2
+
+    - name: promote-candidate
+      activeDeadlineSeconds: 1800
+      retryStrategy:
+        limit: "2"
+        retryPolicy: Always
+        backoff:
+          duration: "15s"
+          factor: "2"
+          maxDuration: "1m"
+      inputs:
+        parameters:
+          - name: lane
+          - name: repository
+          - name: candidate-tag
+          - name: expected-digest
+      outputs:
+        parameters:
+          - name: promoted-digest
+            valueFrom:
+              path: /work/promoted-digest
+      volumes:
+        - name: zot-auth
+          secret:
+            secretName: zot-writer-auth
+            optional: true
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+        - name: work
+          emptyDir: {}
+      script:
+        image: ghcr.io/oras-project/oras:v1.2.3@sha256:63266a046d1cf5ebebb1461733ed7548148f122e0d422096e177cfa70b521cb1
+        command: ["/bin/sh"]
+        volumeMounts:
+          - name: zot-auth
+            mountPath: /auth
+            readOnly: true
+          - name: work
+            mountPath: /work
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        env:
+          - name: LANE
+            value: "{{inputs.parameters.lane}}"
+          - name: REPOSITORY
+            value: "{{inputs.parameters.repository}}"
+          - name: CANDIDATE_TAG
+            value: "{{inputs.parameters.candidate-tag}}"
+          - name: EXPECTED_DIGEST
+            value: "{{inputs.parameters.expected-digest}}"
+          - name: WORKFLOW_NAME
+            value: "{{workflow.name}}"
+          - name: REGISTRY
+            value: "192.168.1.102:30500"
+          - name: EVIDENCE_TYPE
+            value: "application/vnd.projectbluefin.lab.promotion-evidence.v1+json"
+        source: |
+          set -euo pipefail
+
+          printf '%s' "${LANE}" | grep -Eq '^[a-z0-9]+(-[a-z0-9]+)*$' ||
+            { echo "ERROR: invalid lane '${LANE}'" >&2; exit 1; }
+          printf '%s' "${REPOSITORY}" | grep -Eq '^[a-z0-9]+([._/-][a-z0-9]+)*$' ||
+            { echo "ERROR: invalid repository '${REPOSITORY}'" >&2; exit 1; }
+          printf '%s' "${CANDIDATE_TAG}" | grep -Eq '^candidate-([0-9a-f]{40}|[0-9a-f]{64})$' ||
+            { echo "ERROR: invalid candidate tag '${CANDIDATE_TAG}'" >&2; exit 1; }
+          printf '%s' "${EXPECTED_DIGEST}" | grep -Eq '^sha256:[0-9a-f]{64}$' ||
+            { echo "ERROR: invalid expected digest '${EXPECTED_DIGEST}'" >&2; exit 1; }
+          printf '%s' "${WORKFLOW_NAME}" | grep -Eq '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' ||
+            { echo "ERROR: invalid workflow name '${WORKFLOW_NAME}'" >&2; exit 1; }
+
+          AUTH_ARGS=""
+          COPY_AUTH_ARGS=""
+          if [ -s /auth/config.json ]; then
+            AUTH_ARGS="--registry-config /auth/config.json"
+            COPY_AUTH_ARGS="--from-registry-config /auth/config.json --to-registry-config /auth/config.json"
+          fi
+
+          CANDIDATE_REF="${REGISTRY}/${REPOSITORY}:${CANDIDATE_TAG}"
+          SUBJECT="${REGISTRY}/${REPOSITORY}@${EXPECTED_DIGEST}"
+          TESTING_REF="${REGISTRY}/${REPOSITORY}:testing"
+          REVISION="${CANDIDATE_TAG#candidate-}"
+
+          /bin/oras manifest fetch \
+            --plain-http \
+            ${AUTH_ARGS} \
+            --descriptor \
+            "${CANDIDATE_REF}" > /work/candidate-descriptor.json
+          RESOLVED_DIGEST=$(sed -n 's/.*"digest":"\([^"]*\)".*/\1/p' /work/candidate-descriptor.json)
+          if [ "${RESOLVED_DIGEST}" != "${EXPECTED_DIGEST}" ]; then
+            echo "ERROR: candidate digest mismatch: expected=${EXPECTED_DIGEST} resolved=${RESOLVED_DIGEST}" >&2
+            exit 1
+          fi
+
+          /bin/oras manifest fetch \
+            --plain-http \
+            ${AUTH_ARGS} \
+            "${SUBJECT}" > /work/pullback-manifest.json
+          PULLBACK_DIGEST="sha256:$(sha256sum /work/pullback-manifest.json | awk '{print $1}')"
+          if [ "${PULLBACK_DIGEST}" != "${EXPECTED_DIGEST}" ]; then
+            echo "ERROR: pull-back digest mismatch: expected=${EXPECTED_DIGEST} pulled=${PULLBACK_DIGEST}" >&2
+            exit 1
+          fi
+
+          /bin/oras cp \
+            --from-plain-http \
+            --to-plain-http \
+            ${COPY_AUTH_ARGS} \
+            --no-tty \
+            "${SUBJECT}" \
+            "${TESTING_REF}"
+
+          /bin/oras manifest fetch \
+            --plain-http \
+            ${AUTH_ARGS} \
+            --descriptor \
+            "${TESTING_REF}" > /work/testing-descriptor.json
+          TESTING_DIGEST=$(sed -n 's/.*"digest":"\([^"]*\)".*/\1/p' /work/testing-descriptor.json)
+          if [ "${TESTING_DIGEST}" != "${EXPECTED_DIGEST}" ]; then
+            echo "ERROR: promotion digest mismatch: expected=${EXPECTED_DIGEST} testing=${TESTING_DIGEST}" >&2
+            exit 1
+          fi
+
+          VERIFIED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          printf '%s\n' \
+            '{' \
+            '  "schemaVersion": 1,' \
+            "  \"lane\": \"${LANE}\"," \
+            "  \"repository\": \"${REPOSITORY}\"," \
+            "  \"candidateTag\": \"${CANDIDATE_TAG}\"," \
+            "  \"subjectDigest\": \"${EXPECTED_DIGEST}\"," \
+            "  \"sourceRevision\": \"${REVISION}\"," \
+            '  "targetTag": "testing",' \
+            "  \"targetDigest\": \"${TESTING_DIGEST}\"," \
+            "  \"pullBackDigest\": \"${PULLBACK_DIGEST}\"," \
+            "  \"workflow\": \"${WORKFLOW_NAME}\"," \
+            "  \"verifiedAt\": \"${VERIFIED_AT}\"" \
+            '}' > /work/promotion-evidence.json
+
+          cd /work
+          /bin/oras attach \
+            --plain-http \
+            ${AUTH_ARGS} \
+            --artifact-type "${EVIDENCE_TYPE}" \
+            --annotation "org.opencontainers.image.revision=${REVISION}" \
+            --annotation "io.projectbluefin.lab.lane=${LANE}" \
+            "${SUBJECT}" \
+            "promotion-evidence.json:application/json" > oras-attach.json
+
+          /bin/oras discover \
+            --plain-http \
+            ${AUTH_ARGS} \
+            --format json \
+            "${SUBJECT}" > oras-discover.json
+          if ! grep -Fq "${EVIDENCE_TYPE}" oras-discover.json; then
+            echo "ERROR: promotion evidence referrer was not discoverable" >&2
+            exit 1
+          fi
+
+          printf '%s' "${TESTING_DIGEST}" > /work/promoted-digest
+          echo "Promoted lane=${LANE} ${CANDIDATE_REF}@${EXPECTED_DIGEST} to ${TESTING_REF}" >&2

--- a/docs/ops/zot-candidate-promotion.md
+++ b/docs/ops/zot-candidate-promotion.md
@@ -1,0 +1,57 @@
+# Zot candidate promotion
+
+The writable Zot keeps anonymous pulls working while authenticated writes are
+prepared. `manifests/zot-writable.yaml` currently mounts `config.json`;
+`config-authenticated.json` is the activation-ready policy and is deliberately
+not active until every writer has migrated.
+
+## Candidate contract
+
+- A lane is independent and promotes only its own repository.
+- Candidate tags are immutable: `candidate-<40-or-64-lowercase-hex>`.
+- Call `zot-candidate-lifecycle/candidate-preflight` before a build pushes a
+  candidate. It rejects an existing tag and requires at least 20 GiB and 10%
+  free on the Zot data filesystem.
+- After that lane's QA succeeds, call
+  `zot-candidate-lifecycle/promote-candidate` with the pushed digest.
+- Promotion fetches the manifest back by digest, verifies its SHA-256, copies
+  the same registry digest to `:testing`, verifies the target digest, and
+  attaches `application/vnd.projectbluefin.lab.promotion-evidence.v1+json`.
+- A failed lane does not block another lane from validating or promoting.
+
+Zot retains `:testing`, the ten most recently pushed candidate tags, and the
+ten most recent legacy raw-SHA tags for each Dakota repository. Retention and
+orphan cleanup run on Zot's daily GC interval. The separate PR image GC is also
+ready to use the writer auth file.
+
+## Secret contracts and activation gate
+
+Credentials are operator-managed and never stored in git:
+
+| Namespace | Secret | Contract |
+|---|---|---|
+| `local-registry` | `zot-auth` | key `htpasswd`; contains `zot-writer` and `zot-metrics` bcrypt entries |
+| `argo` | `zot-writer-auth` | type `kubernetes.io/dockerconfigjson`; key `.dockerconfigjson` |
+
+Do not activate authentication until all of these are true:
+
+1. Provision both secrets and a Prometheus-only credential for `zot-metrics`.
+2. Migrate every existing `:30500` writer to the mounted auth file. The new
+   lifecycle template and daily PR GC already support it; the current Dakota
+   build/export DAG does not.
+3. Configure the Prometheus Zot scrape with `zot-metrics` basic auth. Zot
+   v2.1.1 requires an authenticated metrics user when repository access control
+   is enabled.
+4. Change the registry config mount to `config-authenticated.json`, set the
+   `zot-auth` volume to `optional: false`, and set writer auth volumes to
+   `optional: false` in the same GitOps rollout.
+5. Verify anonymous `/v2/` and image pulls, authenticated push/delete, denied
+   anonymous writes, and the authenticated `/metrics` scrape before removing
+   the rollout gate.
+
+## Remaining Dakota DAG integration
+
+For each Dakota lane: derive `candidate-${commit-sha}`, call
+`candidate-preflight`, push only that candidate, capture its digest, run QA
+against `repository@digest`, then call `promote-candidate` after that lane
+succeeds. Remove the current direct `:testing` push only in that DAG refactor.

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -309,6 +309,20 @@ Manual run:
 just run-dakota-publish
 ```
 
+### `zot-candidate-lifecycle`
+
+Reusable single-lane foundation for immutable local Zot candidates. Call the
+`candidate-preflight` template before pushing `candidate-<commit-sha>`; it
+rejects reused tags and fails under Zot storage pressure. After that lane's QA
+passes, call `promote-candidate` with the candidate digest. It pulls the
+manifest back by digest, promotes the same digest to `:testing`, verifies the
+target, and attaches the versioned ORAS promotion evidence contract.
+
+The optional `zot-writer-auth` docker config keeps the template compatible with
+today's anonymous-write registry and becomes required only at the documented
+authentication activation gate. See
+[Zot candidate promotion](../ops/zot-candidate-promotion.md).
+
 ---
 
 ## Catalog installs

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -11,6 +11,7 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
   - [dakota-qa-pipeline](#dakota-qa-pipeline)
   - [dakota-build-pipeline](#dakota-build-pipeline)
   - [dakota-publish-pipeline](#dakota-publish-pipeline)
+  - [zot-candidate-lifecycle](#zot-candidate-lifecycle)
   - [cosmic-build-pipeline](#cosmic-build-pipeline)
   - [bluefin-server-build-pipeline](#bluefin-server-build-pipeline)
   - [bst-qa-pipeline](#bst-qa-pipeline)
@@ -104,6 +105,19 @@ infrastructure blockers and repair the lab before retrying.
 - **Concurrency:** the `dakota-publish` semaphore allows one publication
   workflow while preserving parallel lane execution inside it.
 - **Just recipe:** `run-dakota-publish`.
+
+### zot-candidate-lifecycle
+- **Purpose:** Reusable, independent single-lane lifecycle for immutable local
+  Zot candidates and digest-preserving promotion to `:testing`.
+- **Preflight:** rejects reused `candidate-<commit-sha>` tags and fails when the
+  Zot data filesystem has less than 20 GiB or 10% free.
+- **Integrity:** resolves the expected digest, fetches and hashes the raw
+  manifest, copies that digest to `:testing`, and verifies the target digest.
+- **Evidence:** attaches and rediscovers
+  `application/vnd.projectbluefin.lab.promotion-evidence.v1+json` with ORAS.
+- **Authentication:** optionally mounts `zot-writer-auth` while anonymous writes
+  remain active; the secret becomes required at the Zot auth activation gate.
+- **Just recipe:** `run-zot-promotion`.
 
 ### cosmic-build-pipeline
 - **Purpose:** BuildStream compile pipeline for the default COSMIC image

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -102,6 +102,10 @@ The workflow authoring guidance is split by topic:
 - A BuildStream poller relying only on the `bst-build` semaphore — execution is serialized, but waiting workflows can still grow without bound. Automated callers must enforce the two-workflow `bluefin.io/bst-workload=true` admission ceiling before submission.
 - **Queue Starvation / `activeDeadlineSeconds` Trap**: Leaving a workflow's `activeDeadlineSeconds` at default (or unspecified) when it queues under a template-level semaphore or resource limit. The workflow-level deadline starts ticking upon *submission/creation*, not *execution/scheduling*. If a workflow queues for longer than the global default deadline (e.g., 2h), it gets instantly canceled with `DeadlineExceeded` as soon as it begins running. Always set a generous workflow-level deadline (e.g., 4h/14400s) on queueable templates and dynamic API submission specs.
 - **Secret leakage via shell tracing**: Never use `set -x`/`set -eux` in a script that invokes authenticated APIs or expands secret-bearing variables. Argo retains command output in workflow logs. Disable tracing for the whole script or bracket only non-secret diagnostics with explicit `set +x`/`set -x` boundaries, then inspect logs for credentials before publishing evidence.
+- **Assuming registry tools exist in `lab-runner`**: the image does not include
+  ORAS or skopeo. Use a pinned tool image (or an explicit, checked bootstrap),
+  and validate flags against that pinned release. In particular, ORAS v1.2.3
+  `discover` supports `--format json` but not `--depth`.
 - **PR approval gate bypass**: Routine labels such as `automerge` or `chore/deps` are not maintainer approval. PR-batch templates must stop before build/QA when `pr/needs-review` remains or live GitHub review data lacks a verified maintainer approval.
 - **Custom metric cardinality**: Never label workflow metrics with workflow
   names, UIDs, commit SHAs, refs, image digests, or build elements. Use only
@@ -138,3 +142,5 @@ Before marking any WorkflowTemplate change done:
 - [ ] After any disk wipe/registry migration/Zot cleanup, every affected containerDisk tag manually force-rebuilt rather than assuming a digest-comparison poller will self-heal
 - [ ] Custom metrics share identical help text and histogram buckets across
       templates, and labels are limited to low-cardinality constants/states
+- [ ] Registry workflows use a pinned image that actually contains every CLI
+      invoked by the script, with flags valid for that exact version

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -62,6 +62,14 @@ Grafana, Prometheus Operator, or another cluster dashboard.
   `kubestellar-*` controller jobs.
 - Zot metrics require `extensions.metrics` in both `zot-cache-config` and
   `zot-local-config`; both expose `/metrics` on their existing HTTP port. Bump
+- Zot v2.1.1 requires an authenticated user in
+  `http.accessControl.metrics.users` once repository access control is enabled.
+  Migrate Prometheus to basic auth in the same rollout; do not activate auth
+  while the scrape still depends on anonymous `/metrics`.
+- Stage Zot authentication separately from activation when anonymous writers
+  already exist: commit the htpasswd/Secret contract and auth-ready config,
+  migrate every writer, then switch the mounted config and make Secrets required
+  in one GitOps rollout. Bump
   each workload's `lab.projectbluefin.io/config-version` annotation when either
   ConfigMap changes because Zot reads the subPath-mounted config only at startup.
 - Argo custom build metrics use only constant `pipeline` and bounded `status`
@@ -162,6 +170,9 @@ Do not guess flags, chart schema, or MCP method names. The K8sGPT MCP server exp
 - [ ] Prometheus PVC is `Bound` on `local-path` and survives a rollout restart.
 - [ ] Required Prometheus targets report `health: up`; no target exposes a
       user-facing dashboard.
+- [ ] Authenticated Zot rollouts preserve anonymous pulls, reject anonymous
+      writes, admit the configured writer, and keep the authenticated metrics
+      scrape healthy.
 - [ ] Build workflow metric labels remain limited to `pipeline` and `status`.
 
 ## Key references

--- a/manifests/pr-image-gc.yaml
+++ b/manifests/pr-image-gc.yaml
@@ -34,9 +34,21 @@ spec:
     - name: gc
       nodeSelector:
         kubernetes.io/hostname: ghost
+      volumes:
+      - name: zot-auth
+        secret:
+          secretName: zot-writer-auth
+          optional: true
+          items:
+          - key: .dockerconfigjson
+            path: config.json
       script:
         image: ghcr.io/projectbluefin/lab-runner:latest
         command: [sh]
+        volumeMounts:
+        - name: zot-auth
+          mountPath: /auth
+          readOnly: true
         resources:
           requests:
             cpu: 100m
@@ -74,8 +86,13 @@ spec:
 
           echo "=== PR image GC: ${REGISTRY}/${REPO} ==="
 
+          ORAS_AUTH=()
+          if [[ -s /auth/config.json ]]; then
+            ORAS_AUTH=(--registry-config /auth/config.json)
+          fi
+
           # List all tags matching bluefin-pr-*
-          TAGS=$(oras repo tags "${REGISTRY}/${REPO}" --plain-http 2>/dev/null || true)
+          TAGS=$(oras repo tags "${REGISTRY}/${REPO}" --plain-http "${ORAS_AUTH[@]}" 2>/dev/null || true)
           if [[ -z "$TAGS" ]]; then
             echo "No tags found in ${REGISTRY}/${REPO} — nothing to clean."
             exit 0
@@ -92,7 +109,7 @@ spec:
             PR_NUM=$(echo "$TAG" | grep -oP '(?<=bluefin-pr-)\d+' || true)
 
             # Check age via manifest created timestamp
-            CREATED=$(oras manifest fetch "${REGISTRY}/${REPO}:${TAG}" --plain-http \
+            CREATED=$(oras manifest fetch "${REGISTRY}/${REPO}:${TAG}" --plain-http "${ORAS_AUTH[@]}" \
               | jq -r '.annotations["org.opencontainers.image.created"] // empty' 2>/dev/null || true)
 
             if [[ -n "$CREATED" ]]; then
@@ -124,7 +141,7 @@ spec:
             fi
 
             if [[ "$DELETE" == "true" ]]; then
-              oras manifest delete "${REGISTRY}/${REPO}:${TAG}" --plain-http --force 2>&1 && \
+              oras manifest delete "${REGISTRY}/${REPO}:${TAG}" --plain-http "${ORAS_AUTH[@]}" --force 2>&1 && \
                 DELETED=$((DELETED + 1)) || \
                 echo "WARNING: failed to delete ${TAG} (non-fatal)"
             else

--- a/manifests/zot-writable.yaml
+++ b/manifests/zot-writable.yaml
@@ -1,7 +1,10 @@
-# Writable OCI registry at NodePort 30500 — BIB push target and PR image store.
+# Writable OCI registry at NodePort 30500 — BIB push target and candidate store.
 # Replaces the unmanaged registry:2 Deployment that was running outside GitOps.
-# No upstream proxy — write-only / local storage.
+# No upstream proxy — local storage.
 # GC enabled: orphaned layers reclaimed after 1h delay, checked every 24h.
+# The active config keeps anonymous writes until every existing writer consumes
+# zot-writer-auth. config-authenticated.json is the activation-ready policy:
+# anonymous read, authenticated create/update/delete, authenticated metrics.
 # ArgoCD: lab-infra syncs this
 ---
 apiVersion: v1
@@ -19,13 +22,37 @@ data:
         "rootDirectory": "/var/lib/registry",
         "gc": true,
         "gcDelay": "1h",
-        "gcInterval": "24h"
+        "gcInterval": "24h",
+        "retention": {
+          "dryRun": false,
+          "delay": "24h",
+          "policies": [
+            {
+              "repositories": ["dakota", "dakota-nvidia"],
+              "deleteReferrers": true,
+              "deleteUntagged": true,
+              "keepTags": [
+                {
+                  "patterns": ["^testing$"]
+                },
+                {
+                  "patterns": ["^candidate-([0-9a-f]{40}|[0-9a-f]{64})$"],
+                  "mostRecentlyPushedCount": 10
+                },
+                {
+                  "patterns": ["^([0-9a-f]{40}|[0-9a-f]{64})$"],
+                  "mostRecentlyPushedCount": 10
+                }
+              ]
+            }
+          ]
+        }
       },
       "http": {
         "address": "0.0.0.0",
         "port": "5000"
       },
-      "log": { "level": "debug" },
+      "log": { "level": "info" },
       "extensions": {
         "metrics": {
           "enable": true,
@@ -35,6 +62,83 @@ data:
         }
       }
     }
+  config-authenticated.json: |
+      {
+        "distSpecVersion": "1.1.0",
+        "storage": {
+          "rootDirectory": "/var/lib/registry",
+          "gc": true,
+          "gcDelay": "1h",
+          "gcInterval": "24h",
+          "retention": {
+            "dryRun": false,
+            "delay": "24h",
+            "policies": [
+              {
+                "repositories": ["dakota", "dakota-nvidia"],
+                "deleteReferrers": true,
+                "deleteUntagged": true,
+                "keepTags": [
+                  {
+                    "patterns": ["^testing$"]
+                  },
+                  {
+                    "patterns": ["^candidate-([0-9a-f]{40}|[0-9a-f]{64})$"],
+                    "mostRecentlyPushedCount": 10
+                  },
+                  {
+                    "patterns": ["^([0-9a-f]{40}|[0-9a-f]{64})$"],
+                    "mostRecentlyPushedCount": 10
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "http": {
+          "address": "0.0.0.0",
+          "port": "5000",
+          "realm": "zot",
+          "auth": {
+            "failDelay": 5,
+            "htpasswd": {
+              "path": "/etc/zot/auth/htpasswd"
+            }
+          },
+          "accessControl": {
+            "metrics": {
+              "users": ["zot-metrics"]
+            },
+            "repositories": {
+              "**": {
+                "policies": [
+                  {
+                    "users": ["zot-writer"],
+                    "actions": [
+                      "read",
+                      "create",
+                      "update",
+                      "delete",
+                      "detectManifestCollision"
+                    ]
+                  }
+                ],
+                "defaultPolicy": ["read"],
+                "anonymousPolicy": ["read"]
+              }
+            }
+          }
+        },
+        "log": { "level": "info" },
+        "extensions": {
+          "metrics": {
+            "enable": true,
+            "prometheus": {
+              "path": "/metrics"
+            }
+          }
+        }
+      }
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -75,6 +179,9 @@ spec:
               subPath: config.json
             - name: data
               mountPath: /var/lib/registry
+            - name: auth
+              mountPath: /etc/zot/auth
+              readOnly: true
           resources:
             requests: { cpu: "100m", memory: "256Mi" }
             limits: { cpu: "2", memory: "4Gi" }
@@ -92,6 +199,15 @@ spec:
           hostPath:
             path: /var/mnt/ghost-data/zot-local
             type: DirectoryOrCreate
+        # Activation gate: provision local-registry/zot-auth, migrate every
+        # writer, then set optional=false and mount config-authenticated.json.
+        - name: auth
+          secret:
+            secretName: zot-auth
+            optional: true
+            items:
+              - key: htpasswd
+                path: htpasswd
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unit/test_zot_candidate_lifecycle.py
+++ b/tests/unit/test_zot_candidate_lifecycle.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ZOT_PATH = ROOT / "manifests/zot-writable.yaml"
+GC_PATH = ROOT / "manifests/pr-image-gc.yaml"
+WORKFLOW_PATH = ROOT / "argo/workflow-templates/zot-candidate-lifecycle.yaml"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def template_named(workflow, name):
+    return next(template for template in workflow["spec"]["templates"] if template["name"] == name)
+
+
+def test_zot_stages_auth_without_breaking_anonymous_writers():
+    manifests = list(yaml.safe_load_all(ZOT_PATH.read_text(encoding="utf-8")))
+    config_map, deployment = manifests[:2]
+    active = json.loads(config_map["data"]["config.json"])
+    authenticated = json.loads(config_map["data"]["config-authenticated.json"])
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    config_mount = next(mount for mount in container["volumeMounts"] if mount["name"] == "config")
+    auth_volume = next(volume for volume in deployment["spec"]["template"]["spec"]["volumes"] if volume["name"] == "auth")
+
+    assert "auth" not in active["http"]
+    assert config_mount["subPath"] == "config.json"
+    assert auth_volume["secret"]["optional"] is True
+    assert authenticated["http"]["auth"]["htpasswd"]["path"] == "/etc/zot/auth/htpasswd"
+    policy = authenticated["http"]["accessControl"]["repositories"]["**"]
+    assert policy["anonymousPolicy"] == ["read"]
+    assert policy["defaultPolicy"] == ["read"]
+    assert policy["policies"] == [
+        {
+            "users": ["zot-writer"],
+            "actions": ["read", "create", "update", "delete", "detectManifestCollision"],
+        }
+    ]
+    assert authenticated["http"]["accessControl"]["metrics"]["users"] == ["zot-metrics"]
+    assert authenticated["storage"] == active["storage"]
+
+
+def test_zot_retention_is_bounded_and_preserves_testing():
+    config_map = next(yaml.safe_load_all(ZOT_PATH.read_text(encoding="utf-8")))
+    config = json.loads(config_map["data"]["config.json"])
+    storage = config["storage"]
+    policy = storage["retention"]["policies"][0]
+
+    assert storage["gc"] is True
+    assert storage["gcInterval"] == "24h"
+    assert storage["retention"]["dryRun"] is False
+    assert policy["repositories"] == ["dakota", "dakota-nvidia"]
+    assert policy["keepTags"][0] == {"patterns": ["^testing$"]}
+    assert policy["keepTags"][1]["mostRecentlyPushedCount"] == 10
+    assert policy["keepTags"][2]["mostRecentlyPushedCount"] == 10
+
+
+def test_candidate_lifecycle_enforces_preflight_and_digest_promotion():
+    workflow = load_yaml(WORKFLOW_PATH)
+    preflight = template_named(workflow, "candidate-preflight")
+    promotion = template_named(workflow, "promote-candidate")
+    entrypoint = template_named(workflow, "promote")
+    preflight_source = preflight["script"]["source"]
+    promotion_source = promotion["script"]["source"]
+
+    assert "candidate-([0-9a-f]{40}|[0-9a-f]{64})" in preflight_source
+    assert "immutable candidate already exists" in preflight_source
+    assert "MIN_FREE_BYTES" in preflight_source
+    assert "MIN_FREE_PERCENT" in preflight_source
+    assert preflight["volumes"][0]["hostPath"]["type"] == "Directory"
+    assert preflight["script"]["volumeMounts"][0]["readOnly"] is True
+    assert preflight["script"]["image"].startswith(
+        "ghcr.io/oras-project/oras:v1.2.3@sha256:"
+    )
+    assert "if ((" not in preflight_source
+
+    assert '"${SUBJECT}" > /work/pullback-manifest.json' in promotion_source
+    assert 'PULLBACK_DIGEST="sha256:$(sha256sum' in promotion_source
+    assert '"${TESTING_REF}"' in promotion_source
+    assert 'if [ "${TESTING_DIGEST}" != "${EXPECTED_DIGEST}" ]' in promotion_source
+    assert "/bin/oras attach" in promotion_source
+    assert "/bin/oras discover" in promotion_source
+    assert promotion["script"]["image"].startswith(
+        "ghcr.io/oras-project/oras:v1.2.3@sha256:"
+    )
+    assert "application/vnd.projectbluefin.lab.promotion-evidence.v1+json" in str(
+        workflow["metadata"]["annotations"]
+    )
+    assert "set -x" not in promotion_source
+    assert "set -eux" not in promotion_source
+    assert workflow["spec"]["entrypoint"] == "promote"
+    assert entrypoint["dag"]["tasks"][0]["template"] == "promote-candidate"
+
+
+def test_writer_credentials_are_optional_contracts_not_committed_secrets():
+    workflow = load_yaml(WORKFLOW_PATH)
+    promotion = template_named(workflow, "promote-candidate")
+    secret = next(volume["secret"] for volume in promotion["volumes"] if volume["name"] == "zot-auth")
+
+    assert secret["secretName"] == "zot-writer-auth"
+    assert secret["optional"] is True
+    assert secret["items"] == [{"key": ".dockerconfigjson", "path": "config.json"}]
+
+    committed = []
+    for path in (ROOT / "manifests").glob("*.yaml"):
+        for manifest in yaml.safe_load_all(path.read_text(encoding="utf-8")):
+            if isinstance(manifest, dict) and manifest.get("kind") == "Secret":
+                if manifest.get("metadata", {}).get("name") in {"zot-auth", "zot-writer-auth"}:
+                    committed.append(path.name)
+    assert not committed
+
+
+def test_daily_gc_is_auth_ready():
+    gc = load_yaml(GC_PATH)
+    template = gc["spec"]["workflowSpec"]["templates"][0]
+    secret = template["volumes"][0]["secret"]
+    source = template["script"]["source"]
+
+    assert gc["spec"]["schedules"] == ["0 3 * * *"]
+    assert secret["secretName"] == "zot-writer-auth"
+    assert secret["optional"] is True
+    assert 'ORAS_AUTH=(--registry-config /auth/config.json)' in source
+    assert 'oras manifest delete "${REGISTRY}/${REPO}:${TAG}" --plain-http "${ORAS_AUTH[@]}"' in source


### PR DESCRIPTION
## Summary
- stage Zot auth with anonymous reads and secret-backed authenticated writes without activating it ahead of writer migration
- add bounded Dakota candidate retention, daily GC compatibility, metrics policy, and storage-pressure/immutability preflight
- add reusable independent-lane digest promotion with pull-back verification and ORAS evidence attachment
- make PR image GC auth-ready and document the activation gate plus remaining Dakota DAG wiring

## Validation
- `just lint`
- `python -m pytest -q tests/unit/` (181 passed before final rebase)
- `python -m pytest -q tests/unit/test_zot_candidate_lifecycle.py tests/unit/test_dakota_publish_workflow.py tests/unit/test_build_metrics.py` (14 passed after final rebase)
- local Zot v2.1.1 probes verified anonymous reads, denied anonymous writes, authenticated create/delete, authenticated metrics, same-registry digest promotion, pull-back digest verification, ORAS evidence discovery, immutable-tag rejection, and storage-pressure rejection

## Rollout safety
The active Zot config intentionally keeps anonymous writes. Auth activation remains gated on provisioning the documented Secrets, migrating every existing writer and Prometheus scrape, then switching to `config-authenticated.json` and making auth mounts required in one GitOps rollout.
