### PR TITLE
feat(argo): persist Dakota publish history

### DIFF
--- a/argo/workflow-templates/dakota-publish-pipeline.yaml
+++ b/argo/workflow-templates/dakota-publish-pipeline.yaml
@@ -16,6 +16,7 @@ spec:
   serviceAccountName: argo
   activeDeadlineSeconds: 14400
   entrypoint: publish-all
+  onExit: publish-run-history
   podGC:
     strategy: OnWorkflowCompletion
   ttlStrategy:
@@ -177,6 +178,107 @@ spec:
           fi
 
           echo "Published ${DESTINATION_REF}@${DESTINATION_DIGEST}" >&2
+
+    - name: publish-run-history
+      volumes:
+        - name: ghcr-auth
+          secret:
+            secretName: ghcr-publish-auth
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+        - name: history-work
+          emptyDir: {}
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        volumeMounts:
+          - name: ghcr-auth
+            mountPath: /auth
+            readOnly: true
+          - name: history-work
+            mountPath: /workspace
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+            ephemeral-storage: 1Gi
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+          - name: WORKFLOW_NAME
+            value: "{{workflow.name}}"
+          - name: WORKFLOW_STATUS
+            value: "{{workflow.status}}"
+          - name: STARTED_AT
+            value: "{{workflow.creationTimestamp.RFC3339}}"
+        source: |
+          set -Eeuo pipefail
+          trap 'rc=$?; echo "ERROR: Dakota publish history persistence failed (exit ${rc})" >&2; exit "${rc}"' ERR
+
+          AUTH_FILE=/auth/config.json
+          DESTINATION_REF=ghcr.io/projectbluefin/dakota:testing
+          FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          RUN_URL="http://192.168.1.102:2746/workflows/argo/${WORKFLOW_NAME}"
+          RECORD=/workspace/run.json
+
+          if [ "${WORKFLOW_STATUS}" = Succeeded ]; then
+            ORAS_VERSION=1.2.3
+            mkdir -p /workspace/oras-bin
+            curl -sSfL \
+              "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+              | tar xz -C /workspace/oras-bin oras
+            DIGEST=$(/workspace/oras-bin/oras manifest fetch \
+              --descriptor \
+              --registry-config "${AUTH_FILE}" \
+              "${DESTINATION_REF}" | jq -r '.digest')
+            jq -n \
+              --arg workflow_name "${WORKFLOW_NAME}" \
+              --arg started_at "${STARTED_AT}" \
+              --arg finished_at "${FINISHED_AT}" \
+              --arg run_url "${RUN_URL}" \
+              --arg digest "${DIGEST}" \
+              '{
+                kind: "publish",
+                workflow_name: $workflow_name,
+                status: "passed",
+                started_at: $started_at,
+                finished_at: $finished_at,
+                run_url: $run_url,
+                digest: $digest
+              }' > "${RECORD}"
+          else
+            jq -n \
+              --arg workflow_name "${WORKFLOW_NAME}" \
+              --arg started_at "${STARTED_AT}" \
+              --arg finished_at "${FINISHED_AT}" \
+              --arg run_url "${RUN_URL}" \
+              '{
+                kind: "publish",
+                workflow_name: $workflow_name,
+                status: "failed",
+                started_at: $started_at,
+                finished_at: $finished_at,
+                run_url: $run_url,
+                failure_class: "publish",
+                failure_stage: "publish-pipeline"
+              }' > "${RECORD}"
+          fi
+
+          curl -sSfL \
+            https://raw.githubusercontent.com/projectbluefin/lab/main/scripts/publish_dakota_run.py \
+            -o /workspace/publish_dakota_run.py
+          python3 /workspace/publish_dakota_run.py publish "${RECORD}" --work-dir /workspace
+
+          trap - ERR
+          echo "Dakota publish history persisted for ${WORKFLOW_NAME}" >&2
 
     - name: verify-lane-results
       inputs:

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -303,6 +303,14 @@ recursively when present. No referrers, an unsupported discovery API, or a
 missing ORAS binary is logged explicitly and does not invalidate the image
 copy; a failed copy of discovered referrers fails that lane.
 
+The root `onExit` handler writes one compact `kind=publish` record through
+`scripts/publish_dakota_run.py`. A passed record carries the verified primary
+`dakota:testing` digest; because the workflow succeeds only when both Dakota
+lanes succeed, that record represents the aggregate publication run. Failed
+runs persist a normalized `publish` failure without raw logs. History
+persistence is mandatory: a fetch, validation, commit, or push failure remains
+visible as a failed exit-handler node and is never swallowed.
+
 Manual run:
 
 ```bash

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -266,6 +266,19 @@ oras cp --recursive --from-plain-http \
   "${SOURCE}@${DIGEST}" "${DESTINATION}:testing"
 ```
 
+For durable run history, attach a root `onExit` template and pass
+`{{workflow.status}}`, `{{workflow.name}}`, and
+`{{workflow.creationTimestamp.RFC3339}}` through environment variables. Build a
+compact record with `jq`, then invoke the validated publisher CLI. Do not append
+`|| true`: persistence is part of the workflow contract, so an exit-handler
+failure must remain visible and make an otherwise successful run fail. Never
+put the GitHub token in a clone URL or command argument; expose it only as
+`GITHUB_TOKEN` from a Secret and let the CLI's `GIT_ASKPASS` path consume it.
+
+> Source: Context7 `/argoproj/argo-workflows` exit-handler and global-variable
+> documentation. Exit handlers always run and receive the terminal workflow
+> status; `workflow.creationTimestamp.RFC3339` is available in the exit handler.
+
 ### 18. `when` condition trap — never reference a Skipped task's outputs
 
 **Verified against Context7 `/argoproj/argo-workflows` enhanced-depends-logic docs:**

--- a/tests/unit/test_dakota_publish_workflow.py
+++ b/tests/unit/test_dakota_publish_workflow.py
@@ -74,6 +74,40 @@ def test_publish_lane_handles_oci_referrers_explicitly():
     assert "OCI referrers: ORAS bootstrap unavailable" in source
 
 
+def test_publish_pipeline_persists_compact_history_from_on_exit():
+    workflow = load_yaml(PIPELINE_PATH)
+    history = template_named(workflow, "publish-run-history")
+    source = history["script"]["source"]
+    env = {item["name"]: item for item in history["script"]["env"]}
+
+    assert workflow["spec"]["onExit"] == "publish-run-history"
+    assert env["WORKFLOW_STATUS"]["value"] == "{{workflow.status}}"
+    assert env["STARTED_AT"]["value"] == "{{workflow.creationTimestamp.RFC3339}}"
+    assert env["GITHUB_TOKEN"]["valueFrom"]["secretKeyRef"] == {
+        "name": "github-token",
+        "key": "token",
+    }
+    assert "publish_dakota_run.py publish" in source
+    assert 'kind: "publish"' in source
+    assert 'status: "passed"' in source
+    assert 'status: "failed"' in source
+    assert 'failure_class: "publish"' in source
+    assert "raw.githubusercontent.com/projectbluefin/lab/main/scripts/publish_dakota_run.py" in source
+
+
+def test_publish_history_failure_is_visible_and_credentials_are_not_logged():
+    source = template_named(load_yaml(PIPELINE_PATH), "publish-run-history")["script"][
+        "source"
+    ]
+
+    assert "Dakota publish history persistence failed" in source
+    assert "|| true" not in source
+    assert "set -x" not in source
+    assert "set -eux" not in source
+    assert "x-access-token" not in source
+    assert "${GITHUB_TOKEN}" not in source
+
+
 def test_nightly_publish_schedule_and_manual_entrypoint():
     cron = load_yaml(CRON_PATH)
     justfile = (ROOT / "Justfile").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a root `onExit` handler to the Dakota GHCR publisher
- emit one compact aggregate publish record and invoke `scripts/publish_dakota_run.py`
- persist normalized failures without raw logs and fail visibly when history persistence fails
- document the onExit durability/security pattern and add focused wiring tests

A successful record uses the verified primary `dakota:testing` digest; workflow success already requires both Dakota publication lanes.

## Validation
- `python -m pytest tests/unit/test_dakota_publish_workflow.py tests/unit/test_publish_dakota_run.py -q` (42 passed)
- `argo lint --offline argo/workflow-templates/ manifests/nightly-dakota-publish.yaml`
- embedded scripts: `bash -n`
- `just lint`