### PR TITLE
fix(workflows): stop pushing BuildStream source caches through bb-remote-asset

### DIFF
--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -298,14 +298,12 @@ spec:
                 - url: https://cache.projectbluefin.io:11001
                   push: false
               source-caches:
-                override-project-caches: false
+                # The deployed bb-remote-asset endpoint cannot FetchBlob/FetchDirectory
+                # BuildStream URNs (it treats them as HTTP/URN and returns UNIMPLEMENTED /
+                # PERMISSION_DENIED). Override junction source-cache entries so no
+                # incompatible source-push server is inherited.
+                override-project-caches: true
                 servers:
-                - url: grpc://bb-remote-asset.buildbarn.svc.cluster.local:8984
-                  type: index
-                  push: true
-                - url: grpc://frontend.buildbarn.svc.cluster.local:8980
-                  type: storage
-                  push: true
                 - url: https://gbm.gnome.org:11003
                   push: false
                 - url: https://cache.projectbluefin.io:11001

--- a/argo/workflow-templates/bst-qa-pipeline.yaml
+++ b/argo/workflow-templates/bst-qa-pipeline.yaml
@@ -144,14 +144,12 @@ spec:
                 - url: https://cache.projectbluefin.io:11001
                   push: false
               source-caches:
-                override-project-caches: false
+                # The deployed bb-remote-asset endpoint cannot FetchBlob/FetchDirectory
+                # BuildStream URNs (it treats them as HTTP/URN and returns UNIMPLEMENTED /
+                # PERMISSION_DENIED). Override junction source-cache entries so no
+                # incompatible source-push server is inherited.
+                override-project-caches: true
                 servers:
-                - url: grpc://bb-remote-asset.buildbarn.svc.cluster.local:8984
-                  type: index
-                  push: true
-                - url: grpc://frontend.buildbarn.svc.cluster.local:8980
-                  type: storage
-                  push: true
                 - url: https://gbm.gnome.org:11003
                   push: false
                 - url: https://cache.projectbluefin.io:11001

--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -294,14 +294,12 @@ spec:
                 - url: https://cache.projectbluefin.io:11001
                   push: false
               source-caches:
-                override-project-caches: false
+                # The deployed bb-remote-asset endpoint cannot FetchBlob/FetchDirectory
+                # BuildStream URNs (it treats them as HTTP/URN and returns UNIMPLEMENTED /
+                # PERMISSION_DENIED). Override junction source-cache entries so no
+                # incompatible source-push server is inherited.
+                override-project-caches: true
                 servers:
-                - url: grpc://bb-remote-asset.buildbarn.svc.cluster.local:8984
-                  type: index
-                  push: true
-                - url: grpc://frontend.buildbarn.svc.cluster.local:8980
-                  type: storage
-                  push: true
                 - url: https://gbm.gnome.org:11003
                   push: false
                 - url: https://cache.projectbluefin.io:11001


### PR DESCRIPTION
The deployed bb-remote-asset endpoint cannot handle BuildStream source-key URNs, causing cosmic/bluefin-server/bst-qa source fetches to fail with FetchDirectory PERMISSION_DENIED, unsupported HTTP directory fetch, and action-cache Object not found. Apply the same workaround Dakota already uses: override project source-cache entries and rely only on upstream read-only source caches. No cache deletion or stateful-storage restart was performed.