### PR TITLE
fix(qa): repair GDM session setup in container runner

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -243,6 +243,19 @@ spec:
           rm -rf /run/gdm /var/log/gdm
           mkdir -p /run/gdm /var/log/gdm
 
+          # GDM and its PreSession helpers (e.g. brew-preinstall) run as the gdm
+          # user and need write access to their runtime/state directories. Ensure
+          # the account and group exist and that the directories are owned by gdm.
+          if ! getent group gdm >/dev/null 2>&1; then
+            groupadd -r gdm
+          fi
+          if ! id -u gdm >/dev/null 2>&1; then
+            useradd -r -g gdm -d /var/lib/gdm -s /usr/sbin/nologin gdm
+          fi
+          chown -R gdm:gdm /run/gdm /var/log/gdm
+          chmod 755 /run/gdm
+          chmod 750 /var/log/gdm
+
           # Make sure groups exist so the test user can access DRI/input devices.
           # Some target images expose groups through NSS without writing
           # /etc/group, while useradd only accepts local group entries.
@@ -261,6 +274,16 @@ spec:
             useradd -m -u 1000 -G video,render,input bluefin-test
           else
             usermod -aG video,render,input bluefin-test
+          fi
+
+          # GDM PAM autologin requires a non-expired shadow lastchg value. Without
+          # it the user is forced to change the password and the session never
+          # registers.
+          if command -v chage >/dev/null 2>&1; then
+            chage -d "$(date +%Y-%m-%d)" bluefin-test
+          else
+            today=$(( $(date +%s) / 86400 ))
+            sed -i "s/^bluefin-test:!*/bluefin-test:!:${today}:0:99999:7:::/" /etc/shadow
           fi
 
           # Configure sudo and auto-login before GDM starts.

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -136,7 +136,9 @@ def test_container_runner_creates_runtime_directories_before_gdm():
     )
 
     assert "mkdir -p /run/dbus /run/systemd/seats /run/systemd/users /run/gdm /var/log/gdm" in content
+    assert "chown -R gdm:gdm /run/gdm /var/log/gdm" in content
     assert "chmod 755 /run/gdm" in content
+    assert 'chage -d "$(date +%Y-%m-%d)" bluefin-test' in content
 
 
 def test_native_systemd_runner_uses_a_scheduler_managed_target_pod():


### PR DESCRIPTION
## Summary

Fix the nested GDM setup used by `run-container-tests` so GNOME sessions can register reliably.

Closes #297

## Root cause

The runner clears `/run/gdm` and `/var/log/gdm` but does not restore ownership for the `gdm` account. PreSession helpers such as `brew-preinstall` then fail with permission errors. The test user can also carry an expired shadow `lastchg` value, causing GDM autologin to stop before registering the session.

## Changes

- Ensure the `gdm` user/group exists.
- Restore `gdm:gdm` ownership and expected permissions on GDM runtime/log directories.
- Set a current non-expired `bluefin-test` shadow `lastchg` value.
- Add unit assertions covering both protections.

## Validation

- `python3 -m pytest tests/unit/test_container_only_qa_workflows.py -q` — 29 passed
- `just lint` — passed
- Previous lab evidence from `dakota-qa-pipeline-rglls` showed the targeted symptoms: GDM session registration failures, `/run/gdm` permission errors, and missing results artifact.

The change has not yet been revalidated by a post-fix Argo run; that will follow after GitOps synchronization.
