### PR TITLE
fix(ci): unbreak metrics ingestion and container QA lanes

### DIFF
--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -34,6 +34,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           echo "DERIVE_BRANCH=bot/derive-metrics" >> "$GITHUB_ENV"
+          # Fetch the bot branch so origin/bot/derive-metrics exists locally. Without it
+          # `git push --force-with-lease` has no remote-tracking ref to compare against and
+          # always aborts with "stale info".
+          git fetch --no-tags origin +refs/heads/bot/derive-metrics:refs/remotes/origin/bot/derive-metrics || true
           git checkout -B bot/derive-metrics
 
       - name: Set up Python 3.12

--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -261,7 +261,15 @@ spec:
           # /etc/group, while useradd only accepts local group entries.
           for group in video render input; do
             if ! grep -q "^${group}:" /etc/group; then
-              groupadd -r "${group}"
+              # groupadd resolves names through NSS and exits 9 ("already exists")
+              # for NSS-only groups, which would abort this script under `set -e`.
+              # Fall back to materializing the NSS entry as a local /etc/group line.
+              if ! groupadd -r "${group}" 2>/dev/null; then
+                nss_entry=$(getent group "${group}" || true)
+                if [ -n "${nss_entry}" ]; then
+                  printf '%s\n' "${nss_entry}" >>/etc/group
+                fi
+              fi
             fi
             grep -q "^${group}:" /etc/group || {
               echo "Failed to create required local group ${group}" >&2

--- a/tests/adoption-page.test.mjs
+++ b/tests/adoption-page.test.mjs
@@ -10,6 +10,22 @@ function html(file) {
   return readFileSync(path.join(repo, file), 'utf8');
 }
 
+// Lane coverage is derived from the same source of truth the generator uses, so adding a
+// variant or branch never requires editing a magic number here.
+function trackedLaneCount() {
+  return Object.values(trackedVariants()).reduce(
+    (total, details) => total + (details.branches || []).length,
+    0,
+  );
+}
+
+function trackedVariants() {
+  const publishers = JSON.parse(
+    readFileSync(path.join(repo, 'docs/data/variant-publishers.json'), 'utf8'),
+  );
+  return publishers.variants || {};
+}
+
 test('adoption page renders summary metrics, lane details, trust cards, chart containers, and explicit unavailable states', () => {
   execFileSync('npm', ['run', 'build'], {
     cwd: repo,
@@ -144,8 +160,16 @@ test('adoption-metrics.json contract satisfies the page model contract', () => {
   assert.ok(Array.isArray(dataset.trust_cards), 'trust_cards is an array');
   assert.ok(Array.isArray(dataset.rows), 'rows is an array');
 
-  assert.equal(dataset.rows.length, 13, 'adoption dataset has 13 lane rows');
-  assert.equal(dataset.trust_cards.length, 8, 'adoption dataset has 8 trust cards');
+  assert.equal(
+    dataset.rows.length,
+    trackedLaneCount(),
+    'adoption dataset has one lane row per tracked variant-branch in variant-publishers.json',
+  );
+  assert.equal(
+    dataset.trust_cards.length,
+    Object.keys(trackedVariants()).length,
+    'adoption dataset has one trust card per tracked variant in variant-publishers.json',
+  );
 
   // All rows carry a valid state enum value; every unavailable row carries an explicit non-empty
   // state_reason. This is a permanent behavioral contract — it holds whether 0 or all lanes

--- a/tests/homebrew-page.test.mjs
+++ b/tests/homebrew-page.test.mjs
@@ -10,6 +10,18 @@ function html(file) {
   return readFileSync(path.join(repo, file), 'utf8');
 }
 
+// Lane coverage is derived from the same source of truth the generator uses, so adding a
+// variant or branch never requires editing a magic number here.
+function trackedLaneCount() {
+  const publishers = JSON.parse(
+    readFileSync(path.join(repo, 'docs/data/variant-publishers.json'), 'utf8'),
+  );
+  return Object.values(publishers.variants || {}).reduce(
+    (total, details) => total + (details.branches || []).length,
+    0,
+  );
+}
+
 test('homebrew page renders summary metrics, lane details, explicit unavailable states, and chart containers', () => {
   execFileSync('npm', ['run', 'build'], {
     cwd: repo,
@@ -156,7 +168,11 @@ test('homebrew-ecosystem.json contract satisfies the page model contract', () =>
   assert.ok(Array.isArray(dataset.taps), 'taps is an array');
   assert.ok(Array.isArray(dataset.rows), 'rows is an array');
 
-  assert.equal(dataset.rows.length, 13, 'homebrew dataset has 13 lane rows (one per variant-branch)');
+  assert.equal(
+    dataset.rows.length,
+    trackedLaneCount(),
+    'homebrew dataset has one lane row per tracked variant-branch in variant-publishers.json',
+  );
 
   const trackedMetric = dataset.summary_metrics.find((m) => m.id === 'tracked_image_lanes');
   const withDataMetric = dataset.summary_metrics.find((m) => m.id === 'lanes_with_brew_data');


### PR DESCRIPTION
## Problem

Three independent failures were blocking factory automation:

1. **`Update test results` — 197/200 recent runs failed.** `tests/adoption-page.test.mjs` and `tests/homebrew-page.test.mjs` hardcoded `13` lane rows and `8` trust cards. Adding the zirconium lane took the generator to 14 lanes / 9 variants, so the dataset-contract assertions failed on every run and the dashboard data was never committed.
2. **`Derive metrics` — failing every hour.** The job pushes to `bot/derive-metrics` with `--force-with-lease`, but `actions/checkout` never fetches that branch. With no `origin/bot/derive-metrics` tracking ref the lease has nothing to compare against and git aborts with `! [rejected] ... (stale info)`.
3. **Every `image-poll-*` lane failing with `exit code 9`.** `run-container-tests` runs `groupadd -r <group>` for `video`/`render`/`input` when the group is missing from `/etc/group`. When the group is visible through NSS but not written to `/etc/group`, `groupadd` exits 9 (`group already exists`) and `set -euo pipefail` kills the script before the existing verification block can report anything.

## Fix

- Derive expected lane/variant counts from `docs/data/variant-publishers.json` — the same source of truth `generate_page_datasets.py` iterates — so new lanes never require editing a magic number again.
- Fetch `bot/derive-metrics` before `checkout -B` so `--force-with-lease` has a valid remote-tracking ref.
- When `groupadd` refuses an NSS-only group, materialize the `getent group` entry as a local `/etc/group` line instead of aborting.

## Verification

- `npm test` — 15/15 pass (was 13/15).
- `just lint` — clean (actionlint + argo lint + registry allowlist).
- Group fallback logic exercised against a stub reproducing the exit-9 path: `video` is recovered from NSS, `render`/`input` created normally, script exits 0.
- Reproduced the dataset failure in a clean clone of `origin/main` with the full CI collector chain (`refresh_factory_stats` → `collect_bst_cache` → `collect_release_verdict` → `generate_page_datasets` → `npm ci` → `npm run build`): 14 rows vs the asserted 13.