### PR TITLE
fix(dashboard): never publish a private lab URL as public evidence

### DIFF
--- a/scripts/refresh_factory_stats.py
+++ b/scripts/refresh_factory_stats.py
@@ -372,7 +372,6 @@ def main():
                 if seen_at:
                     return {
                         'seen_at': seen_at,
-                        'run_url': run.get('run_url'),
                         'run_id': run.get('id'),
                     }
             return None
@@ -380,6 +379,9 @@ def main():
         summary = {}
         for image, cfg in image_map.items():
             repo = cfg['repo']
+            # Published as the public dashboard evidence link, so it must always resolve
+            # for an anonymous visitor. Never fall back to an in-cluster Argo UI URL.
+            public_evidence_url = f"https://github.com/{repo}/releases"
             releases = run_json(f"gh api repos/{repo}/releases?per_page=100")
             if not isinstance(releases, list):
                 releases = []
@@ -412,11 +414,11 @@ def main():
                 'stable_seen_at': stable_seen_at,
                 'stable_age_days': max(0, int((now_dt - stable_dt).total_seconds() // 86400)) if stable_dt else None,
                 'stable_tag': (stable_ghcr.get('tag') if stable_ghcr else None) or (stable_rel.get('tag_name') if stable_rel else None) or (stable_fallback.get('run_id') if stable_fallback else None),
-                'stable_source_url': (stable_ghcr.get('source_url') if stable_ghcr else None) or (stable_rel.get('html_url') if stable_rel else None) or (stable_fallback.get('run_url') if stable_fallback else None),
+                'stable_source_url': (stable_ghcr.get('source_url') if stable_ghcr else None) or (stable_rel.get('html_url') if stable_rel else None) or public_evidence_url,
                 'testing_seen_at': testing_seen_at,
                 'testing_age_days': max(0, int((now_dt - testing_dt).total_seconds() // 86400)) if testing_dt else None,
                 'testing_tag': (testing_ghcr.get('tag') if testing_ghcr else None) or (testing_rel.get('tag_name') if testing_rel else None) or (testing_fallback.get('run_id') if testing_fallback else None),
-                'testing_source_url': (testing_ghcr.get('source_url') if testing_ghcr else None) or (testing_rel.get('html_url') if testing_rel else None) or (testing_fallback.get('run_url') if testing_fallback else None),
+                'testing_source_url': (testing_ghcr.get('source_url') if testing_ghcr else None) or (testing_rel.get('html_url') if testing_rel else None) or public_evidence_url,
             }
         return summary
 


### PR DESCRIPTION
## Root cause

This is the last blocker on the `Update test results` ingestion workflow, which had **0 successful runs in its last 200**. #431 fixed two of the three failures; this fixes the third.

`refresh_factory_stats.py` builds each image stream's `*_source_url` — the *public* dashboard evidence link — from this chain:

```
GHCR org package version -> GitHub release html_url -> in-cluster Argo run_url
```

The first hop needs `read:packages` on an org container package, which a workflow `GITHUB_TOKEN` does not have. So **in CI the chain always fell through to the Argo run URL**, and the published dashboard rendered:

```
http://192.168.1.102:32746/workflows/argo/dakota-commit-poller-1785038400
```

as the evidence link for every projectbluefin stream — an unroutable private cluster address for any public visitor, and a cluster-specific URL committed into a public dataset (`docs/data/factory-stats.json`, `docs/data/upstream-status.json`) and into the built HTML.

The `images page links projectbluefin evidence` contract test correctly rejected it, so the workflow failed on every run and no dashboard data was ever committed. It passed locally only because a developer PAT *can* read GHCR packages, so the first hop succeeded — which is why this reproduced exclusively in CI.

## Diagnosis

Since it would not reproduce locally under any simulation (no cluster, no token, `npm ci` from the lockfile, full collector chain in a clean clone), I ran a temporary diagnostic branch that dumped the generated dakota row from inside the CI job:

```json
{
  "id": "dakota-testing",
  "state": "available",
  "source_url": "http://192.168.1.102:32746/workflows/argo/dakota-commit-poller-1785038400"
}
```

## Fix

Drop `run_url` from the lab-run fallback and end the `source_url` chain at `https://github.com/<repo>/releases`, which always resolves anonymously. The lab-observed timestamp is still used for `seen_at`/freshness — only the link target changes.

## Verification

Reproduced the exact CI condition locally by stubbing the GHCR lookup to return `None`. Before the fix, evidence URLs were private Argo addresses; after:

```
bluefin-testing      https://github.com/projectbluefin/bluefin/releases
bluefin-stable       https://github.com/projectbluefin/bluefin/releases/tag/stable-20260720
bluefin-lts-testing  https://github.com/projectbluefin/bluefin-lts/releases
bluefin-lts-stable   https://github.com/projectbluefin/bluefin-lts/releases/tag/stable-20260728
dakota-testing       https://github.com/projectbluefin/dakota/releases
```

`npm test` 15/15 pass with the GHCR path stubbed *and* unstubbed; `just lint` clean.

## Known remaining leak (not this PR)

`recent_runs[].run_url` still emits the private Argo address into `docs/builds/`, `docs/provisioning/`, and `docs/tests/`. Those are labelled lab-sourced run links rather than public evidence links, so I left them alone rather than widen this fix — worth a separate decision on whether they should be redacted or gated.