### PR TITLE
fix(ci): push refreshed dashboard data with a bypass-capable token

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -35,7 +35,19 @@ jobs:
       issues: read
 
     steps:
+      # The `main — merge queue` ruleset blocks direct pushes. Only the
+      # OrganizationAdmin and MergeRaptor bypass actors may push refreshed
+      # dashboard data straight to main, so mint a MergeRaptor token here.
+      - name: Mint MergeRaptor token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install oras
         run: |
@@ -118,6 +130,8 @@ jobs:
           git add -A docs/
           if git diff --cached --quiet; then
             echo "No changes to commit"
+          elif [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "Ref ${GITHUB_REF} is not main; refreshed data verified but not published."
           else
             git commit \
               -m 'chore: refresh dashboard data (screenshots, bugs, stats)' \

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -37,6 +37,42 @@ A `pull_request` trigger alone does not run on the temporary
 `gh-readonly-queue/main/...` ref. The queue then remains in `AWAITING_CHECKS`
 without a check run. See the [GitHub Actions `merge_group` documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group).
 
+## Automated data pushes
+
+The dashboard ingestion workflow (`update-test-results.yml`) commits regenerated
+`docs/` data directly to `main` every five minutes. Machine-generated data does
+not go through the queue, so that push depends on a **bypass actor**:
+
+| Actor | Used by |
+|---|---|
+| `OrganizationAdmin` | in-cluster Argo pushes (`scripts/publish_test_results.py`) |
+| `mergeraptor` (Integration, app id `3069633`) | `update-test-results.yml` |
+
+The default `GITHUB_TOKEN` has **no** bypass. A workflow that pushes to `main`
+must mint a MergeRaptor installation token and hand it to `actions/checkout`:
+
+```yaml
+- name: Mint MergeRaptor token
+  id: app-token
+  uses: actions/create-github-app-token@<pinned-sha>
+  with:
+    app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+    private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+
+- uses: actions/checkout@<pinned-sha>
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+```
+
+The GitHub Actions app itself cannot be granted a bypass — the API rejects it
+with `Actor GitHub Actions integration must be part of the ruleset source or
+owner organization`.
+
+If a data workflow reports `GH013: Repository rule violations found for
+refs/heads/main`, it is pushing with `GITHUB_TOKEN`. This is silent for as long
+as an earlier step is also failing, so check the push step even when the visible
+failure is a test.
+
 ## Queueing a PR
 
 Only queue a PR after its review/approval policy is satisfied and its required
@@ -65,6 +101,9 @@ configuration change that must land before the queue can validate itself.
   workflow is missing the `merge_group` trigger.
 - `DIRTY` or `UNMERGEABLE` after an earlier queue merge means the PR branch is
   stale. Update it against current `main`, rerun `lint`, and requeue it.
+- `GH013: Repository rule violations found` from an automated job means it is
+  pushing to `main` with `GITHUB_TOKEN` instead of a bypass-capable token. See
+  [Automated data pushes](#automated-data-pushes).
 - Never remove the required check just to make the queue advance.
 
 The Ruleset is configured in GitHub repository settings rather than in ArgoCD;


### PR DESCRIPTION
The `main — merge queue` ruleset (created 2026-07-20 16:05 UTC) blocked every push from `update-test-results.yml`. Its last successful run was 15:59 UTC — six minutes earlier.

The job pushes regenerated `docs/` data directly to `main` with the default `GITHUB_TOKEN`, which holds no ruleset bypass, so the final step failed with `GH013: Repository rule violations found for refs/heads/main` regardless of test results. This was masked by the separate test failures fixed in #431 and #434.

## Changes
- Mint a MergeRaptor installation token and hand it to `actions/checkout`, so the push runs as an actor with a ruleset bypass. MergeRaptor was added to the ruleset `bypass_actors` as an `Integration`; the GitHub Actions app itself is not eligible (`Actor GitHub Actions integration must be part of the ruleset source or owner organization`).
- Guard the push so a `workflow_dispatch` on a topic branch verifies refreshed data without publishing it to `main`.
- Document the invariant in `docs/ops/merge-queue.md`.

## Verification
Run [30358557210](https://github.com/projectbluefin/lab/actions/runs/30358557210) on the #434 branch passed every collector, the Astro build and all 15 tests, failing only on the blocked push — so this is the last remaining blocker.