### PR TITLE
fix(ci): publish dashboard data through the merge queue

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/30 * * * *'
   push:
     branches: [main]
     paths:
@@ -31,23 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       packages: read
       issues: read
 
     steps:
-      # The `main — merge queue` ruleset blocks direct pushes. Only the
-      # OrganizationAdmin and MergeRaptor bypass actors may push refreshed
-      # dashboard data straight to main, so mint a MergeRaptor token here.
-      - name: Mint MergeRaptor token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
-          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install oras
         run: |
@@ -123,19 +112,45 @@ jobs:
       - name: Verify multipage dashboard
         run: npm test
 
-      - name: Commit changes
+      - name: Publish refreshed data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATA_BRANCH: bot/dashboard-data
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A docs/
           if git diff --cached --quiet; then
             echo "No changes to commit"
-          elif [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "Ref ${GITHUB_REF} is not main; refreshed data verified but not published."
-          else
-            git commit \
-              -m 'chore: refresh dashboard data (screenshots, bugs, stats)' \
-              -m 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'
-            git pull --rebase -X ours origin main
-            git push origin HEAD:main
+            exit 0
           fi
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "Ref ${GITHUB_REF} is not main; refreshed data verified but not published."
+            exit 0
+          fi
+
+          # The `main — merge queue` ruleset blocks direct pushes and GITHUB_TOKEN
+          # holds no bypass, so publish through the queue instead. The branch is
+          # always rebuilt from the checked-out main and every file is
+          # regenerated, so force-pushing it can never lose work.
+          git checkout -B "$DATA_BRANCH"
+          git commit \
+            -m 'chore: refresh dashboard data (screenshots, bugs, stats)' \
+            -m 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'
+          git push --force origin "$DATA_BRANCH"
+
+          pr=$(gh pr list --head "$DATA_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            url=$(gh pr create \
+              --base main \
+              --head "$DATA_BRANCH" \
+              --title 'chore: refresh dashboard data' \
+              --body 'Automated dashboard data refresh from `update-test-results`. Regenerated from `main` on every run; `lint` runs in the merge queue.')
+            pr="${url##*/}"
+          fi
+          echo "Publishing via PR #${pr}"
+
+          # A PR opened by GITHUB_TOKEN gets no pull_request check runs, but the
+          # ruleset evaluates `lint` against the merge group, so the queue still
+          # gates this merge.
+          gh pr merge "$pr" --auto --squash

--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -145,7 +145,7 @@ jobs:
               --base main \
               --head "$DATA_BRANCH" \
               --title 'chore: refresh dashboard data' \
-              --body 'Automated dashboard data refresh from `update-test-results`. Regenerated from `main` on every run; `lint` runs in the merge queue.')
+              --body 'Automated dashboard data refresh from the update-test-results workflow. Regenerated from main on every run; lint runs in the merge queue.')
             pr="${url##*/}"
           fi
           echo "Publishing via PR #${pr}"

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -39,39 +39,29 @@ without a check run. See the [GitHub Actions `merge_group` documentation](https:
 
 ## Automated data pushes
 
-The dashboard ingestion workflow (`update-test-results.yml`) commits regenerated
-`docs/` data directly to `main` every five minutes. Machine-generated data does
-not go through the queue, so that push depends on a **bypass actor**:
+Nothing pushes to `main` from GitHub Actions. The default `GITHUB_TOKEN` holds
+**no** ruleset bypass, so a direct push fails with `GH013: Repository rule
+violations found for refs/heads/main`.
+
+The dashboard ingestion workflow (`update-test-results.yml`) therefore publishes
+through the queue like any other change: it force-pushes regenerated `docs/`
+data to `bot/dashboard-data`, opens or reuses a pull request, and enables
+auto-merge. The branch is rebuilt from `main` on every run and every file is
+regenerated, so the force-push cannot lose work.
+
+A pull request opened with `GITHUB_TOKEN` receives no `pull_request` check runs —
+GitHub does not let one workflow trigger another. That is fine here, because the
+ruleset evaluates `lint` against the **merge group**, not the pull request. The
+queue still gates the merge.
+
+Only two actors hold a bypass, and neither is available to Actions:
 
 | Actor | Used by |
 |---|---|
-| `OrganizationAdmin` | in-cluster Argo pushes (`scripts/publish_test_results.py`) |
-| `mergeraptor` (Integration, app id `3069633`) | `update-test-results.yml` |
+| `OrganizationAdmin` | in-cluster Argo pushes (`scripts/publish_test_results.py`, `argo/workflow-templates/*cve-scan.yaml`) |
 
-The default `GITHUB_TOKEN` has **no** bypass. A workflow that pushes to `main`
-must mint a MergeRaptor installation token and hand it to `actions/checkout`:
-
-```yaml
-- name: Mint MergeRaptor token
-  id: app-token
-  uses: actions/create-github-app-token@<pinned-sha>
-  with:
-    app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
-    private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-
-- uses: actions/checkout@<pinned-sha>
-  with:
-    token: ${{ steps.app-token.outputs.token }}
-```
-
-The GitHub Actions app itself cannot be granted a bypass — the API rejects it
-with `Actor GitHub Actions integration must be part of the ruleset source or
-owner organization`.
-
-If a data workflow reports `GH013: Repository rule violations found for
-refs/heads/main`, it is pushing with `GITHUB_TOKEN`. This is silent for as long
-as an earlier step is also failing, so check the push step even when the visible
-failure is a test.
+If an automated job reports `GH013`, it is pushing to `main` directly. Route it
+through `bot/dashboard-data` instead of reaching for a bypass token.
 
 ## Queueing a PR
 


### PR DESCRIPTION
Makes the dashboard ingestion pipeline work again. It has not published since **2026-07-20 15:59 UTC**.

## Root cause
The `main — merge queue` ruleset was created at **2026-07-20 16:05 UTC** — six minutes after the last successful run. `update-test-results.yml` pushes regenerated `docs/` data directly to `main` with the default `GITHUB_TOKEN`, which holds no ruleset bypass, so the final step failed with `GH013: Repository rule violations found for refs/heads/main` on every run since, regardless of test results. The separate test failures fixed in #431 and #434 masked it.

## Fix
Publish through the queue rather than around it:
- force-push regenerated data to `bot/dashboard-data`, open or reuse a PR, enable auto-merge
- the branch is rebuilt from `main` each run and every file is regenerated, so the force-push cannot lose work
- a PR opened by `GITHUB_TOKEN` gets no `pull_request` check runs, but the ruleset evaluates `lint` against the **merge group**, so the queue still gates the merge
- schedule moved to every 30 minutes so a queued PR can land before the next refresh force-pushes the branch

Also drops the app-token step from #435: the `MERGERAPTOR_*` secrets resolve to the `bluefin-ghost-arc` app, which has no `contents` permission (`Permission to projectbluefin/lab.git denied to bluefin-ghost-arc[bot]`). No bypass token is needed with this approach.

## Verification
Run [30361238560](https://github.com/projectbluefin/lab/actions/runs/30361238560) already proved every collector, the Astro build and all 15 tests pass; only the push failed. I will confirm a green run and a published data PR after this merges.