### PR TITLE
fix(ci): trigger lint on the data branch so the queue can accept it

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
   merge_group:
     types: [checks_requested]
+  # Lets `update-test-results` produce a real lint check run on the
+  # bot/dashboard-data head. A PR opened by GITHUB_TOKEN gets no pull_request
+  # runs, so without this the data PR can never enter the merge queue.
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
       packages: read
       issues: read
 
@@ -138,6 +139,12 @@ jobs:
             -m 'chore: refresh dashboard data (screenshots, bugs, stats)' \
             -m 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'
           git push --force origin "$DATA_BRANCH"
+
+          # A PR opened by GITHUB_TOKEN gets no pull_request check runs, so the
+          # required `lint` context would never report and the PR could not
+          # enter the queue. workflow_dispatch is exempt from that restriction,
+          # so trigger the real Lint workflow against the branch head.
+          gh workflow run lint.yaml --ref "$DATA_BRANCH"
 
           pr=$(gh pr list --head "$DATA_BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -z "$pr" ]; then

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -50,9 +50,10 @@ auto-merge. The branch is rebuilt from `main` on every run and every file is
 regenerated, so the force-push cannot lose work.
 
 A pull request opened with `GITHUB_TOKEN` receives no `pull_request` check runs —
-GitHub does not let one workflow trigger another. That is fine here, because the
-ruleset evaluates `lint` against the **merge group**, not the pull request. The
-queue still gates the merge.
+GitHub does not let one workflow trigger another. `workflow_dispatch` is exempt
+from that restriction, so the job triggers the real `Lint` workflow against the
+branch head to produce the required `lint` check. The merge group then runs
+`lint` again authoritatively before the merge lands.
 
 Only two actors hold a bypass, and neither is available to Actions:
 


### PR DESCRIPTION
Follow-up to #436. The pipeline now runs green and opens its data PR (#437), but that PR sits at `BLOCKED` and never enters the merge queue.

A PR opened with `GITHUB_TOKEN` receives no `pull_request` check runs, so the required `lint` context never reports. `workflow_dispatch` is an explicit exception to the `GITHUB_TOKEN` restriction, so the job now dispatches the real `Lint` workflow against the `bot/dashboard-data` head. That produces a genuine `lint` check run on the PR head rather than a fabricated status, and the merge group still runs `lint` authoritatively before the merge lands.

- `lint.yaml`: add `workflow_dispatch`
- `update-test-results.yml`: dispatch `Lint` after the force-push, add `actions: write`