### PR TITLE
fix(ci): dispatch lint after the data PR settles

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -140,12 +140,6 @@ jobs:
             -m 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'
           git push --force origin "$DATA_BRANCH"
 
-          # A PR opened by GITHUB_TOKEN gets no pull_request check runs, so the
-          # required `lint` context would never report and the PR could not
-          # enter the queue. workflow_dispatch is exempt from that restriction,
-          # so trigger the real Lint workflow against the branch head.
-          gh workflow run lint.yaml --ref "$DATA_BRANCH"
-
           pr=$(gh pr list --head "$DATA_BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -z "$pr" ]; then
             url=$(gh pr create \
@@ -157,7 +151,12 @@ jobs:
           fi
           echo "Publishing via PR #${pr}"
 
-          # A PR opened by GITHUB_TOKEN gets no pull_request check runs, but the
-          # ruleset evaluates `lint` against the merge group, so the queue still
-          # gates this merge.
+          # GitHub records a pull_request-triggered `lint` run for this branch and
+          # immediately marks it action_required, because GITHUB_TOKEN may not
+          # start workflows. Required checks resolve to the newest run of a given
+          # name, so dispatch the real Lint workflow *after* the pull request
+          # settles; its success then supersedes the blocked record.
+          # workflow_dispatch is exempt from the GITHUB_TOKEN restriction.
+          gh workflow run lint.yaml --ref "$DATA_BRANCH"
+
           gh pr merge "$pr" --auto --squash

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -49,11 +49,17 @@ data to `bot/dashboard-data`, opens or reuses a pull request, and enables
 auto-merge. The branch is rebuilt from `main` on every run and every file is
 regenerated, so the force-push cannot lose work.
 
-A pull request opened with `GITHUB_TOKEN` receives no `pull_request` check runs —
-GitHub does not let one workflow trigger another. `workflow_dispatch` is exempt
-from that restriction, so the job triggers the real `Lint` workflow against the
-branch head to produce the required `lint` check. The merge group then runs
-`lint` again authoritatively before the merge lands.
+A pull request opened with `GITHUB_TOKEN` cannot start workflows, so GitHub
+records the `pull_request` run of `Lint` and immediately marks it
+`action_required`. Required checks resolve to the newest run of a given name, so
+the job dispatches the real `Lint` workflow *after* the pull request settles —
+`workflow_dispatch` is exempt from the restriction, and its success supersedes
+the blocked record. The merge group then runs `lint` again authoritatively
+before the merge lands.
+
+`strict_required_status_checks_policy` is on, so the data pull request shows
+`BEHIND` whenever `main` moves. This self-heals: the next scheduled run rebuilds
+the branch from current `main`.
 
 Only two actors hold a bypass, and neither is available to Actions:
 


### PR DESCRIPTION
Follow-up to #439. The dispatched `lint` run succeeded, but the data PR still could not enter the queue.

GitHub records a `pull_request`-triggered `lint` run for `bot/dashboard-data` and immediately marks it `action_required`, because `GITHUB_TOKEN` may not start workflows. Required checks resolve to the **newest** run of a given name, so the blocked record was overriding the dispatched success.

Dispatching `Lint` after the pull request settles makes the real, successful run the newest one. The merge group still runs `lint` authoritatively before the merge lands.

Also documents that the data PR shows `BEHIND` whenever `main` moves — `strict_required_status_checks_policy` is on — and that this self-heals on the next scheduled run, which rebuilds the branch from current `main`.