### PR TITLE
fix(ci): mirror the lint run into a commit status on the data PR

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -33,6 +33,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
+      statuses: write
       packages: read
       issues: read
 
@@ -139,6 +140,7 @@ jobs:
             -m 'chore: refresh dashboard data (screenshots, bugs, stats)' \
             -m 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'
           git push --force origin "$DATA_BRANCH"
+          sha=$(git rev-parse HEAD)
 
           pr=$(gh pr list --head "$DATA_BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -z "$pr" ]; then
@@ -151,12 +153,42 @@ jobs:
           fi
           echo "Publishing via PR #${pr}"
 
-          # GitHub records a pull_request-triggered `lint` run for this branch and
-          # immediately marks it action_required, because GITHUB_TOKEN may not
-          # start workflows. Required checks resolve to the newest run of a given
-          # name, so dispatch the real Lint workflow *after* the pull request
-          # settles; its success then supersedes the blocked record.
-          # workflow_dispatch is exempt from the GITHUB_TOKEN restriction.
+          # GITHUB_TOKEN may not start workflows, so this pull request gets no
+          # pull_request run of Lint and the required `lint` context would never
+          # report. workflow_dispatch is exempt from that restriction, but a
+          # dispatched run's check is not associated with the pull request, so it
+          # cannot satisfy the requirement either. Run the real Lint workflow and
+          # mirror its conclusion into a commit status, which does count. The
+          # merge group still runs lint authoritatively before the merge lands.
           gh workflow run lint.yaml --ref "$DATA_BRANCH"
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            run_id=$(gh run list --workflow=lint.yaml --branch "$DATA_BRANCH" \
+              --event workflow_dispatch --limit 5 \
+              --json databaseId,headSha \
+              --jq "[.[] | select(.headSha == \"$sha\")][0].databaseId // empty")
+            [ -n "$run_id" ] && break
+            sleep 5
+          done
+          if [ -z "$run_id" ]; then
+            echo "Lint dispatch never started for $sha"
+            exit 1
+          fi
+
+          lint_state=success
+          gh run watch "$run_id" --exit-status >/dev/null 2>&1 || lint_state=failure
+          echo "Lint run $run_id concluded: $lint_state"
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${sha}" \
+            -f state="$lint_state" \
+            -f context=lint \
+            -f description='Mirrored from the dispatched Lint run' \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${run_id}" >/dev/null
+
+          if [ "$lint_state" != success ]; then
+            echo "Lint failed; not publishing."
+            exit 1
+          fi
 
           gh pr merge "$pr" --auto --squash

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -49,13 +49,17 @@ data to `bot/dashboard-data`, opens or reuses a pull request, and enables
 auto-merge. The branch is rebuilt from `main` on every run and every file is
 regenerated, so the force-push cannot lose work.
 
-A pull request opened with `GITHUB_TOKEN` cannot start workflows, so GitHub
-records the `pull_request` run of `Lint` and immediately marks it
-`action_required`. Required checks resolve to the newest run of a given name, so
-the job dispatches the real `Lint` workflow *after* the pull request settles —
-`workflow_dispatch` is exempt from the restriction, and its success supersedes
-the blocked record. The merge group then runs `lint` again authoritatively
-before the merge lands.
+`GITHUB_TOKEN` may not start workflows, so the data pull request gets no
+`pull_request` run of `Lint` and the required `lint` context would never report.
+`workflow_dispatch` is exempt from that restriction, but a dispatched run's
+check is **not associated with the pull request**, so it cannot satisfy the
+requirement either — enqueueing fails with `Required status check "lint" is
+expected`.
+
+The job therefore runs the real `Lint` workflow against the branch head, waits
+for it, and mirrors its conclusion into a **commit status** named `lint`, which
+does count toward the PR rollup. If lint fails, nothing is published. The merge
+group then runs `lint` again authoritatively before the merge lands.
 
 `strict_required_status_checks_policy` is on, so the data pull request shows
 `BEHIND` whenever `main` moves. This self-heals: the next scheduled run rebuilds


### PR DESCRIPTION
Follow-up to #440. Explicit enqueue surfaced the exact blocker:

```
Pull request Required status check "lint" is expected.
```

`GITHUB_TOKEN` may not start workflows, so the data PR gets no `pull_request` run of `Lint`. `workflow_dispatch` is exempt from that restriction, but a dispatched run’s check is **not associated with the pull request**, so it cannot satisfy the requirement either — which is why the PR stayed `BLOCKED` even with a green dispatched `lint`.

This runs the real `Lint` workflow against the branch head, waits for it, and mirrors its conclusion into a **commit status** named `lint`, which does count toward the PR rollup. Nothing is published if lint fails. The merge group still runs `lint` authoritatively before the merge lands, so this is a mirror of a real run rather than a fabricated gate.