### PR TITLE
fix(ci): enqueue the data PR explicitly

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -191,4 +191,15 @@ jobs:
             exit 1
           fi
 
-          gh pr merge "$pr" --auto --squash
+          # The stale action_required record leaves the pull request UNSTABLE,
+          # and auto-merge waits on every check rather than just the required
+          # ones, so enqueue explicitly. --auto remains as a fallback for when
+          # the branch is momentarily BEHIND.
+          gh pr merge "$pr" --auto --squash || true
+          pr_id=$(gh pr view "$pr" --json id --jq .id)
+          # shellcheck disable=SC2016  # $id is a GraphQL variable, not a shell one
+          gh api graphql -f query='mutation($id: ID!) {
+            enqueuePullRequest(input: {pullRequestId: $id}) {
+              mergeQueueEntry { position state }
+            }
+          }' -f id="$pr_id" || echo "Enqueue deferred to the next run."

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -65,6 +65,11 @@ group then runs `lint` again authoritatively before the merge lands.
 `BEHIND` whenever `main` moves. This self-heals: the next scheduled run rebuilds
 the branch from current `main`.
 
+The blocked `action_required` record also leaves the pull request `UNSTABLE`.
+Auto-merge waits on *every* check rather than just the required ones, so it
+never enqueues on its own — the job enqueues explicitly through the
+`enqueuePullRequest` GraphQL mutation and keeps `--auto` only as a fallback.
+
 Only two actors hold a bypass, and neither is available to Actions:
 
 | Actor | Used by |


### PR DESCRIPTION
Last gap in the ingestion pipeline. #441 got the required `lint` status reporting and the data PR #437 reached `UNSTABLE` — required checks satisfied — but auto-merge still never enqueued it. Enqueueing explicitly through GraphQL worked immediately and #437 merged.

Auto-merge waits on *every* check rather than only the required ones, and the stale `action_required` record for the `pull_request` run of `Lint` never resolves, so the PR stays `UNSTABLE` indefinitely. This enqueues via `enqueuePullRequest` and keeps `--auto` as a fallback for when the branch is momentarily `BEHIND`.