### PR TITLE
fix: prometheus scrape HTTPS, arc-systems SSA, k8sgpt local mode

### DIFF
--- a/argo/workflow-templates/k8sgpt-on-demand.yaml
+++ b/argo/workflow-templates/k8sgpt-on-demand.yaml
@@ -35,6 +35,8 @@ spec:
         value: "k8sgpt-openai"
       - name: api-key-secret-key
         value: "api-key"
+      - name: prometheus-url
+        value: "http://prometheus.kube-system:9090"
   templates:
     - name: analyze
       activeDeadlineSeconds: 1800
@@ -76,6 +78,7 @@ spec:
             provider = "{{workflow.parameters.provider}}"
             model = "{{workflow.parameters.model}}"
             api_key = os.environ.get("K8SGPT_API_KEY", "")
+            prometheus_url = "{{workflow.parameters.prometheus-url}}"
             results_dir = Path("/tmp/results")
             bin_dir = Path("/tmp/bin")
             home_dir = Path("/tmp/home")
@@ -93,8 +96,6 @@ spec:
               raise SystemExit(f"invalid filters parameter: {filters}")
             if ignored_services and not re.fullmatch(r"[a-z0-9./,_-]+", ignored_services):
               raise SystemExit(f"invalid ignored-services parameter: {ignored_services}")
-            if not api_key:
-              raise SystemExit("K8SGPT_API_KEY is not set; create the k8sgpt-openai secret or override api-key-secret-name/key")
     
             arch = os.uname().machine
             if arch in {"x86_64", "amd64"}:
@@ -115,15 +116,22 @@ spec:
             k8sgpt = bin_dir / "k8sgpt"
             k8sgpt.chmod(0o755)
 
-            print(f"configuring k8sgpt provider={provider} model={model}")
-            subprocess.run([str(k8sgpt), "auth", "add", "--backend", provider, "--model", model, "--password", api_key], check=True, capture_output=True, text=True)
-            subprocess.run([str(k8sgpt), "auth", "default", "-p", provider], check=True, capture_output=True, text=True)
+            if api_key:
+              print(f"configuring k8sgpt provider={provider} model={model}")
+              subprocess.run([str(k8sgpt), "auth", "add", "--backend", provider, "--model", model, "--password", api_key], check=True, capture_output=True, text=True)
+              subprocess.run([str(k8sgpt), "auth", "default", "-p", provider], check=True, capture_output=True, text=True)
+            else:
+              print("no API key found — running in local analysis mode (no AI explanations)")
     
             cmd = [str(k8sgpt), "analyze", "--output=json"]
             if filters:
               cmd += ["--filter", filters]
             if namespace:
               cmd += ["--namespace", namespace]
+            if api_key:
+              cmd += ["--explain"]
+            if prometheus_url:
+              cmd += ["--prometheus-url", prometheus_url]
     
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
             data = normalize_results(json.loads(result.stdout), ignored_services)

--- a/argocd/arc-controller-app.yaml
+++ b/argocd/arc-controller-app.yaml
@@ -20,3 +20,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -123,6 +123,9 @@ data:
             target_label: node
 
       - job_name: 'argo-workflow-controller'
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
         kubernetes_sd_configs:
           - role: pod
             namespaces:


### PR DESCRIPTION
## Summary

Three fixes bundled on this branch:

### fix(argo): add HTTPS scheme for argo-workflow-controller metrics scrape
Fixes Prometheus scrape target for the argo-workflow-controller.

### fix(arc-systems): add ServerSideApply to resolve CRD annotation size error
Resolves ArgoCD sync error on arc-systems caused by oversized annotations.

### fix(k8sgpt): support local mode and add Prometheus integration
- **Root cause**: `k8sgpt-openai` secret is absent from the cluster; the workflow hard-failed on missing API key even though k8sgpt can run without AI for basic cluster analysis
- **Fix**: Make API key optional — skip auth config and `--explain` when no key is present; workflow now succeeds in local analysis mode
- **Enhancement**: Add `prometheus-url` parameter (default: `http://prometheus.kube-system:9090`) and pass `--prometheus-url` to `k8sgpt analyze` for enriched metrics context

The k8sgpt WorkflowTemplate (`k8sgpt-on-demand`) is ArgoCD-managed via the `testing-lab` app.