### PR TITLE
fix: Prometheus HTTPS scrape, k8sgpt local mode, and pr-poller metric expressions

### DIFF
--- a/argo/workflow-templates/k8sgpt-on-demand.yaml
+++ b/argo/workflow-templates/k8sgpt-on-demand.yaml
@@ -35,6 +35,8 @@ spec:
         value: "k8sgpt-openai"
       - name: api-key-secret-key
         value: "api-key"
+      - name: prometheus-url
+        value: "http://prometheus.kube-system:9090"
   templates:
     - name: analyze
       activeDeadlineSeconds: 1800
@@ -76,6 +78,7 @@ spec:
             provider = "{{workflow.parameters.provider}}"
             model = "{{workflow.parameters.model}}"
             api_key = os.environ.get("K8SGPT_API_KEY", "")
+            prometheus_url = "{{workflow.parameters.prometheus-url}}"
             results_dir = Path("/tmp/results")
             bin_dir = Path("/tmp/bin")
             home_dir = Path("/tmp/home")
@@ -93,8 +96,6 @@ spec:
               raise SystemExit(f"invalid filters parameter: {filters}")
             if ignored_services and not re.fullmatch(r"[a-z0-9./,_-]+", ignored_services):
               raise SystemExit(f"invalid ignored-services parameter: {ignored_services}")
-            if not api_key:
-              raise SystemExit("K8SGPT_API_KEY is not set; create the k8sgpt-openai secret or override api-key-secret-name/key")
     
             arch = os.uname().machine
             if arch in {"x86_64", "amd64"}:
@@ -115,15 +116,22 @@ spec:
             k8sgpt = bin_dir / "k8sgpt"
             k8sgpt.chmod(0o755)
 
-            print(f"configuring k8sgpt provider={provider} model={model}")
-            subprocess.run([str(k8sgpt), "auth", "add", "--backend", provider, "--model", model, "--password", api_key], check=True, capture_output=True, text=True)
-            subprocess.run([str(k8sgpt), "auth", "default", "-p", provider], check=True, capture_output=True, text=True)
+            if api_key:
+              print(f"configuring k8sgpt provider={provider} model={model}")
+              subprocess.run([str(k8sgpt), "auth", "add", "--backend", provider, "--model", model, "--password", api_key], check=True, capture_output=True, text=True)
+              subprocess.run([str(k8sgpt), "auth", "default", "-p", provider], check=True, capture_output=True, text=True)
+            else:
+              print("no API key found — running in local analysis mode (no AI explanations)")
     
             cmd = [str(k8sgpt), "analyze", "--output=json"]
             if filters:
               cmd += ["--filter", filters]
             if namespace:
               cmd += ["--namespace", namespace]
+            if api_key:
+              cmd += ["--explain"]
+            if prometheus_url:
+              cmd += ["--prometheus-url", prometheus_url]
     
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
             data = normalize_results(json.loads(result.stdout), ignored_services)

--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -42,7 +42,7 @@ spec:
           - key: pipeline
             value: pr-poller
           - key: status
-            value: "{workflow.status}"
+            value: "{{workflow.status}}"
         counter:
           value: "1"
       - name: lab_build_workflow_duration_seconds
@@ -51,10 +51,10 @@ spec:
           - key: pipeline
             value: pr-poller
           - key: status
-            value: "{workflow.status}"
+            value: "{{workflow.status}}"
         histogram:
           buckets: [300, 900, 1800, 3600, 7200, 14400, 28800, 43200, 86400]
-          value: "{workflow.duration}"
+          value: "{{workflow.duration}}"
 
   entrypoint: poll-labeled-prs
   templates:

--- a/argocd/arc-controller-app.yaml
+++ b/argocd/arc-controller-app.yaml
@@ -20,3 +20,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true

--- a/manifests/prometheus-lightweight.yaml
+++ b/manifests/prometheus-lightweight.yaml
@@ -123,6 +123,9 @@ data:
             target_label: node
 
       - job_name: 'argo-workflow-controller'
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
         kubernetes_sd_configs:
           - role: pod
             namespaces:


### PR DESCRIPTION
## Summary

This branch contains three fixes for lab workflows:

### 1. fix: HTTPS scheme for argo-workflow-controller metrics scrape (`c3973889`)
Corrects the Prometheus scrape config to use HTTPS for the argo-workflow-controller metrics endpoint.

### 2. fix: ServerSideApply for arc-systems CRD annotation size error (`6a7d3241`)
Adds ServerSideApply to arc-systems to resolve a CRD annotation size error.

### 3. fix(k8sgpt): support local mode and add Prometheus integration (`19631b74`)
- Removes hard failure when k8sgpt-openai secret is absent; workflow now runs in local analysis mode (no AI explanations) when no API key is available
- Auth backend configuration is skipped and --explain omitted in local mode
- Adds prometheus-url parameter (default: `http://prometheus.kube-system:9090`) and passes `--prometheus-url` to k8sgpt analyze for enriched metrics context

### 4. fix(pr-poller): correct single-brace Prometheus metric expressions (`c9fecb1f`)
The pr-poller WorkflowTemplate metrics block used single-brace expressions (`{workflow.status}`, `{workflow.duration}`) where Argo requires double-brace (`{{workflow.status}}`, `{{workflow.duration}}`). This caused Prometheus metrics to record literal strings instead of actual values.

## Validation
- `just lint` passes ✓
- `actionlint` passes on all non-dakota GHA workflows ✓