### PR TITLE
fix: prometheus HTTPS scrape, k8sgpt GitHub Models MAI-Code-1-Flash

### DIFF
--- a/argo/workflow-templates/k8sgpt-on-demand.yaml
+++ b/argo/workflow-templates/k8sgpt-on-demand.yaml
@@ -30,9 +30,11 @@ spec:
       - name: provider
         value: "openai"
       - name: model
-        value: "gpt-5-mini"
+        value: "MAI-Code-1-Flash"
+      - name: base-url
+        value: "https://models.inference.ai.azure.com"
       - name: api-key-secret-name
-        value: "k8sgpt-openai"
+        value: "k8sgpt-github"
       - name: api-key-secret-key
         value: "api-key"
       - name: prometheus-url
@@ -77,6 +79,7 @@ spec:
             ignored_services = "{{workflow.parameters.ignored-services}}"
             provider = "{{workflow.parameters.provider}}"
             model = "{{workflow.parameters.model}}"
+            base_url = "{{workflow.parameters.base-url}}"
             api_key = os.environ.get("K8SGPT_API_KEY", "")
             prometheus_url = "{{workflow.parameters.prometheus-url}}"
             results_dir = Path("/tmp/results")
@@ -117,8 +120,11 @@ spec:
             k8sgpt.chmod(0o755)
 
             if api_key:
-              print(f"configuring k8sgpt provider={provider} model={model}")
-              subprocess.run([str(k8sgpt), "auth", "add", "--backend", provider, "--model", model, "--password", api_key], check=True, capture_output=True, text=True)
+              print(f"configuring k8sgpt provider={provider} model={model} base_url={base_url or '(default)'}")
+              auth_cmd = [str(k8sgpt), "auth", "add", "--backend", provider, "--model", model, "--password", api_key]
+              if base_url:
+                auth_cmd += ["--baseurl", base_url]
+              subprocess.run(auth_cmd, check=True, capture_output=True, text=True)
               subprocess.run([str(k8sgpt), "auth", "default", "-p", provider], check=True, capture_output=True, text=True)
             else:
               print("no API key found — running in local analysis mode (no AI explanations)")


### PR DESCRIPTION
## Changes

### Prometheus: fix argo-workflow-controller scrape
The controller exposes metrics over HTTPS with a self-signed cert. Added `scheme: https` and `tls_config.insecure_skip_verify: true` to the scrape job in `manifests/prometheus-lightweight.yaml`.

### K8sGPT: switch to GitHub Models (MAI-Code-1-Flash)
- Default backend points to `https://models.inference.ai.azure.com`
- Default model: `MAI-Code-1-Flash`
- New `base-url` parameter passed as `--baseurl` to `k8sgpt auth add`
- Secret renamed to `k8sgpt-github` (created in cluster with `gh auth token`)
- Falls back gracefully to local analysis mode if secret is absent

### K8sGPT: local mode fallback (no API key required)
Removed hard `SystemExit` on missing API key; `--explain` and auth only applied when key present. Added Prometheus URL integration.

### ArgoCD arc-systems: fix CRD annotation size
Added `ServerSideApply=true` to bypass 262144-byte annotation limit on `AutoscalingRunnerSets` CRD.