### PR TITLE
docs(argo): record lab-runner and nested template pitfalls

### DIFF
--- a/argo/workflow-templates/dakota-publish-pipeline.yaml
+++ b/argo/workflow-templates/dakota-publish-pipeline.yaml
@@ -234,7 +234,9 @@ spec:
             mkdir -p /workspace/oras-bin
             curl -sSfL \
               "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
-              | tar xz -C /workspace/oras-bin oras
+              -o /workspace/oras.tar.gz
+            python3 -m tarfile -e /workspace/oras.tar.gz /workspace/oras-bin
+            rm -f /workspace/oras.tar.gz
             DIGEST=$(/workspace/oras-bin/oras manifest fetch \
               --descriptor \
               --registry-config "${AUTH_FILE}" \

--- a/argo/workflow-templates/k8sgpt-on-demand.yaml
+++ b/argo/workflow-templates/k8sgpt-on-demand.yaml
@@ -27,6 +27,8 @@ spec:
         value: "Pod,Deployment,Service,Ingress,Node"
       - name: ignored-services
         value: "argocd/argocd-applicationset-controller,argocd/argocd-dex-server,argocd/argocd-notifications-controller-metrics,kubevirt/virt-exportproxy,llm-d/llm-d-modelserver"
+      - name: ignored-ingresses
+        value: "wds1-system/wds1"
       - name: provider
         value: "openai"
       - name: model
@@ -101,12 +103,14 @@ spec:
               return json.loads(resp.read())["choices"][0]["message"]["content"]
 
 
-          def normalize_results(data, ignored_services):
-            ignored = {item for item in ignored_services.split(",") if item}
+          def normalize_results(data, ignored_services, ignored_ingresses):
+            ignored_svcs = {item for item in ignored_services.split(",") if item}
+            ignored_ings = {item for item in ignored_ingresses.split(",") if item}
             results = data.get("results") or []
             data["results"] = [
               item for item in results
-              if item.get("kind") != "Service" or item.get("name") not in ignored
+              if not (item.get("kind") == "Service" and item.get("name") in ignored_svcs)
+              and not (item.get("kind") == "Ingress" and item.get("name") in ignored_ings)
             ]
             return data
 
@@ -116,6 +120,7 @@ spec:
             namespace = "{{workflow.parameters.namespace}}"
             filters = "{{workflow.parameters.filters}}"
             ignored_services = "{{workflow.parameters.ignored-services}}"
+            ignored_ingresses = "{{workflow.parameters.ignored-ingresses}}"
             model = "{{workflow.parameters.model}}"
             base_url = "{{workflow.parameters.base-url}}"
             api_key = os.environ.get("K8SGPT_API_KEY", "")
@@ -172,7 +177,7 @@ spec:
             if prometheus_url:
               cmd += ["--prometheus-url", prometheus_url]
             result = subprocess.run(cmd, capture_output=True, text=True)
-            data = normalize_results(json.loads(result.stdout or "{}"), ignored_services)
+            data = normalize_results(json.loads(result.stdout or "{}"), ignored_services, ignored_ingresses)
             findings = data.get("results") or []
             print(f"k8sgpt local findings: {len(findings)}")
 

--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -327,6 +327,10 @@ spec:
                 BST_WORKLOAD="false"
                 ;;
             esac
+            # Build literal Argo expressions for the generated child workflow
+            # without exposing double braces to this outer template.
+            ARGO_OPEN=$(printf '\x7b\x7b')
+            ARGO_CLOSE=$(printf '\x7d\x7d')
             WORKFLOW_NAME=$(kubectl create -f - -o jsonpath='{.metadata.name}' <<EOF
           apiVersion: argoproj.io/v1alpha1
           kind: Workflow
@@ -379,26 +383,26 @@ spec:
                      arguments:
                        parameters:
                          - name: repository
-                           value: "{{{{workflow.parameters.repository}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}"
                          - name: sha
-                           value: "{{{{workflow.parameters.commit-sha}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.commit-sha${ARGO_CLOSE}"
                          - name: pr-number
-                           value: "{{{{workflow.parameters.pr-number}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.pr-number${ARGO_CLOSE}"
                          - name: state
                            value: in_progress
                          - name: conclusion
                            value: ""
                          - name: workflow-name
-                           value: "{{{{workflow.name}}}}"
+                           value: "${ARGO_OPEN}workflow.name${ARGO_CLOSE}"
                          - name: workflow-url
-                           value: "${ARGO_WORKFLOW_URL_BASE}/{{{{workflow.name}}}}"
+                           value: "${ARGO_WORKFLOW_URL_BASE}/${ARGO_OPEN}workflow.name${ARGO_CLOSE}"
                          - name: title
                            value: ${DISPLAY_NAME} lab validation is running
                          - name: summary
                            value: |
                              The lab admitted PR #${PR_NUM} at commit \`${SHA}\`.
 
-                             Validation is running in Argo workflow \`{{{{workflow.name}}}}\`.
+                             Validation is running in Argo workflow \`${ARGO_OPEN}workflow.name${ARGO_CLOSE}\`.
                          - name: text
                            value: ""
                          - name: started-at
@@ -407,7 +411,7 @@ spec:
                            value: ""
                    - name: build
                      depends: "(report-start.Succeeded || report-start.Failed || report-start.Errored)"
-                     when: "'{{{{workflow.parameters.repository}}}}' == 'projectbluefin/dakota'"
+                     when: "'${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}' == 'projectbluefin/dakota'"
                      templateRef:
                        name: dakota-build-pipeline
                        template: build
@@ -427,56 +431,56 @@ spec:
                            value: "bst-build"
                    - name: qa-dakota
                      depends: "build.Succeeded"
-                     when: "'{{{{workflow.parameters.repository}}}}' == 'projectbluefin/dakota'"
+                     when: "'${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}' == 'projectbluefin/dakota'"
                      templateRef:
                        name: dakota-qa-pipeline
                        template: pipeline
                      arguments:
                        parameters:
                          - name: image
-                           value: "{{{{workflow.parameters.image}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.image${ARGO_CLOSE}"
                          - name: image-tag
-                           value: "{{{{workflow.parameters.image-tag}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.image-tag${ARGO_CLOSE}"
                          - name: image-digest
-                           value: "{{{{workflow.parameters.image-digest}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.image-digest${ARGO_CLOSE}"
                          - name: suites
-                           value: "{{{{workflow.parameters.suites}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.suites${ARGO_CLOSE}"
                          - name: variant
-                           value: "{{{{workflow.parameters.variant}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.variant${ARGO_CLOSE}"
                          - name: branch
-                           value: "{{{{workflow.parameters.branch}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.branch${ARGO_CLOSE}"
                          - name: testsuite-branch
-                           value: "{{{{workflow.parameters.testsuite-branch}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.testsuite-branch${ARGO_CLOSE}"
                          - name: testsuite-repo
-                           value: "{{{{workflow.parameters.testsuite-repo}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.testsuite-repo${ARGO_CLOSE}"
                    - name: qa-bluefin
                      depends: "(report-start.Succeeded || report-start.Failed || report-start.Errored)"
-                     when: "'{{{{workflow.parameters.repository}}}}' != 'projectbluefin/dakota'"
+                     when: "'${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}' != 'projectbluefin/dakota'"
                      templateRef:
                        name: bluefin-qa-pipeline
                        template: pipeline
                      arguments:
                        parameters:
                           - name: image
-                            value: "{{{{workflow.parameters.image}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.image${ARGO_CLOSE}"
                           - name: image-tag
-                            value: "{{{{workflow.parameters.image-tag}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.image-tag${ARGO_CLOSE}"
                           - name: suites
-                            value: "{{{{workflow.parameters.suites}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.suites${ARGO_CLOSE}"
                           - name: variant
-                            value: "{{{{workflow.parameters.variant}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.variant${ARGO_CLOSE}"
                           - name: branch
-                            value: "{{{{workflow.parameters.branch}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.branch${ARGO_CLOSE}"
                           - name: pr-number
-                            value: "{{{{workflow.parameters.pr-number}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.pr-number${ARGO_CLOSE}"
                           - name: sha
-                            value: "{{{{workflow.parameters.commit-sha}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.commit-sha${ARGO_CLOSE}"
                           - name: repo
-                            value: "{{{{workflow.parameters.repository}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}"
                           - name: testsuite-branch
-                            value: "{{{{workflow.parameters.testsuite-branch}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.testsuite-branch${ARGO_CLOSE}"
                           - name: testsuite-repo
-                            value: "{{{{workflow.parameters.testsuite-repo}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.testsuite-repo${ARGO_CLOSE}"
              - name: report-final
                steps:
                  - - name: github-check
@@ -486,15 +490,15 @@ spec:
                      arguments:
                        parameters:
                          - name: repository
-                           value: "{{{{workflow.parameters.repository}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}"
                          - name: sha
-                           value: "{{{{workflow.parameters.commit-sha}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.commit-sha${ARGO_CLOSE}"
                          - name: pr-number
-                           value: "{{{{workflow.parameters.pr-number}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.pr-number${ARGO_CLOSE}"
                          - name: final-status
-                           value: "{{{{workflow.status}}}}"
+                           value: "${ARGO_OPEN}workflow.status${ARGO_CLOSE}"
                          - name: workflow-url
-                           value: "${ARGO_WORKFLOW_URL_BASE}/{{{{workflow.name}}}}"
+                           value: "${ARGO_WORKFLOW_URL_BASE}/${ARGO_OPEN}workflow.name${ARGO_CLOSE}"
           EOF
             )
             WORKFLOW_URL="${ARGO_WORKFLOW_URL_BASE}/${WORKFLOW_NAME}"

--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -268,6 +268,16 @@ spec:
                 nss_entry=$(getent group "${group}" || true)
                 if [ -n "${nss_entry}" ]; then
                   printf '%s\n' "${nss_entry}" >>/etc/group
+                else
+                  # Image has no entry anywhere — synthesize with well-known fallback GIDs
+                  # so tests can run on minimal images (e.g. common, knuckle CI images).
+                  case "${group}" in
+                    video)  gid=39  ;;
+                    render) gid=989 ;;
+                    input)  gid=999 ;;
+                    *)      gid=997 ;;
+                  esac
+                  printf '%s:x:%s:\n' "${group}" "${gid}" >>/etc/group
                 fi
               fi
             fi

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -110,6 +110,15 @@ The workflow authoring guidance is split by topic:
   ORAS or skopeo. Use a pinned tool image (or an explicit, checked bootstrap),
   and validate flags against that pinned release. In particular, ORAS v1.2.3
   `discover` supports `--format json` but not `--depth`.
+- **Assuming archive utilities exist in `lab-runner`**: the image includes
+  Python, `curl`, and `jq`, but not `tar`. Download archives to a workspace,
+  extract them with `python3 -m tarfile`, and remove the archive afterward, or
+  use a pinned image that provides the required utility.
+- **Doubling braces for generated child workflows**: `{{{{workflow.*}}}}`
+  reaches a child Workflow literally and its `when` expressions compare the
+  wrong value. When an outer script must emit an Argo expression, build the
+  braces at runtime (for example with `printf '\x7b\x7b'`) so the outer
+  template does not consume them.
 - **PR approval gate bypass**: Routine labels such as `automerge` or `chore/deps` are not maintainer approval. PR-batch templates must stop before build/QA when `pr/needs-review` remains or live GitHub review data lacks a verified maintainer approval.
 - **Custom metric cardinality**: Never label workflow metrics with workflow
   names, UIDs, commit SHAs, refs, image digests, or build elements. Use only


### PR DESCRIPTION
Document two live failure modes found during lab recovery:

- `lab-runner` does not provide `tar`; use Python tarfile extraction for archive bootstraps.
- quadrupled Argo braces in generated child workflows remain literal and break `when` expressions; construct braces at runtime.

These are durable operator guidance only.