### PR TITLE
fix: report testsuite lab status directly

### DIFF
--- a/argo/workflow-templates/dakota-publish-pipeline.yaml
+++ b/argo/workflow-templates/dakota-publish-pipeline.yaml
@@ -234,7 +234,9 @@ spec:
             mkdir -p /workspace/oras-bin
             curl -sSfL \
               "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
-              | tar xz -C /workspace/oras-bin oras
+              -o /workspace/oras.tar.gz
+            python3 -m tarfile -e /workspace/oras.tar.gz /workspace/oras-bin
+            rm -f /workspace/oras.tar.gz
             DIGEST=$(/workspace/oras-bin/oras manifest fetch \
               --descriptor \
               --registry-config "${AUTH_FILE}" \

--- a/argo/workflow-templates/github-status-reporter.yaml
+++ b/argo/workflow-templates/github-status-reporter.yaml
@@ -1,0 +1,217 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: github-status-reporter
+  namespace: argo
+  annotations:
+    description: |
+      Publishes the testsuite lab lifecycle as a commit status. This is used
+      for repositories that do not have the repository_dispatch Check Run
+      receiver workflow.
+  labels:
+    app.kubernetes.io/component: github-status-reporter
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  serviceAccountName: argo
+  entrypoint: send
+  arguments:
+    parameters:
+      - name: repository
+        value: projectbluefin/testsuite
+      - name: sha
+        value: ""
+      - name: pr-number
+        value: ""
+      - name: state
+        value: queued
+      - name: conclusion
+        value: ""
+      - name: workflow-name
+        value: ""
+      - name: workflow-url
+        value: ""
+      - name: title
+        value: Lab validation
+      - name: summary
+        value: No lab summary was provided.
+  templates:
+    - name: send
+      inputs:
+        parameters:
+          - name: repository
+            value: "{{workflow.parameters.repository}}"
+          - name: sha
+            value: "{{workflow.parameters.sha}}"
+          - name: pr-number
+            value: "{{workflow.parameters.pr-number}}"
+          - name: state
+            value: "{{workflow.parameters.state}}"
+          - name: conclusion
+            value: "{{workflow.parameters.conclusion}}"
+          - name: workflow-name
+            value: "{{workflow.parameters.workflow-name}}"
+          - name: workflow-url
+            value: "{{workflow.parameters.workflow-url}}"
+          - name: title
+            value: "{{workflow.parameters.title}}"
+          - name: summary
+            value: "{{workflow.parameters.summary}}"
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+          - name: REPOSITORY
+            value: "{{inputs.parameters.repository}}"
+          - name: SHA
+            value: "{{inputs.parameters.sha}}"
+          - name: PR_NUMBER
+            value: "{{inputs.parameters.pr-number}}"
+          - name: CHECK_STATE
+            value: "{{inputs.parameters.state}}"
+          - name: CONCLUSION
+            value: "{{inputs.parameters.conclusion}}"
+          - name: WORKFLOW_NAME
+            value: "{{inputs.parameters.workflow-name}}"
+          - name: WORKFLOW_URL
+            value: "{{inputs.parameters.workflow-url}}"
+          - name: CHECK_TITLE
+            value: "{{inputs.parameters.title}}"
+          - name: CHECK_SUMMARY
+            value: "{{inputs.parameters.summary}}"
+        source: |
+          set -euo pipefail
+
+          [[ "${REPOSITORY}" == "projectbluefin/testsuite" ]] ||
+            { echo "Refusing status for ${REPOSITORY}" >&2; exit 1; }
+          [[ "${SHA}" =~ ^[0-9a-f]{40}$ ]] ||
+            { echo "Invalid commit SHA: ${SHA}" >&2; exit 1; }
+
+          case "${CHECK_STATE}" in
+            queued|in_progress) STATUS=pending ;;
+            completed)
+              case "${CONCLUSION}" in
+                success) STATUS=success ;;
+                failure|timed_out) STATUS=failure ;;
+                cancelled) STATUS=error ;;
+                *) STATUS=error ;;
+              esac
+              ;;
+            *) echo "Invalid state: ${CHECK_STATE}" >&2; exit 1 ;;
+          esac
+
+          PAYLOAD=$(jq -n \
+            --arg state "${STATUS}" \
+            --arg context "ghost-lab" \
+            --arg description "${CHECK_TITLE}: ${CHECK_SUMMARY:0:140}" \
+            --arg target_url "${WORKFLOW_URL}" \
+            '{state: $state, context: $context, description: $description, target_url: $target_url}')
+          HTTP_CODE=$(curl -sS -o /tmp/github-response -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: ******" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPOSITORY}/statuses/${SHA}" \
+            --data-binary "${PAYLOAD}")
+          if [[ "${HTTP_CODE}" != "201" ]]; then
+            echo "GitHub commit status failed with HTTP ${HTTP_CODE}" >&2
+            cat /tmp/github-response >&2
+            exit 1
+          fi
+          echo "Published ${STATUS} ghost-lab status for ${SHA}"
+
+    - name: final
+      inputs:
+        parameters:
+          - name: repository
+          - name: sha
+          - name: pr-number
+          - name: final-status
+          - name: workflow-url
+      steps:
+        - - name: collect
+            template: collect
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{inputs.parameters.repository}}"
+                - name: sha
+                  value: "{{inputs.parameters.sha}}"
+                - name: pr-number
+                  value: "{{inputs.parameters.pr-number}}"
+                - name: final-status
+                  value: "{{inputs.parameters.final-status}}"
+                - name: workflow-url
+                  value: "{{inputs.parameters.workflow-url}}"
+        - - name: publish
+            template: send
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{inputs.parameters.repository}}"
+                - name: sha
+                  value: "{{inputs.parameters.sha}}"
+                - name: pr-number
+                  value: "{{inputs.parameters.pr-number}}"
+                - name: state
+                  value: completed
+                - name: conclusion
+                  value: "{{steps.collect.outputs.parameters.conclusion}}"
+                - name: workflow-name
+                  value: "{{workflow.name}}"
+                - name: workflow-url
+                  value: "{{inputs.parameters.workflow-url}}"
+                - name: title
+                  value: "{{steps.collect.outputs.parameters.title}}"
+                - name: summary
+                  value: "{{steps.collect.outputs.parameters.summary}}"
+
+    - name: collect
+      inputs:
+        parameters:
+          - name: final-status
+          - name: pr-number
+          - name: workflow-url
+      outputs:
+        parameters:
+          - name: conclusion
+            valueFrom:
+              path: /tmp/conclusion
+          - name: title
+            valueFrom:
+              path: /tmp/title
+          - name: summary
+            valueFrom:
+              path: /tmp/summary
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        source: |
+          set -euo pipefail
+          case "{{inputs.parameters.final-status}}" in
+            Succeeded) conclusion=success; title="Testsuite lab validation passed" ;;
+            Failed|Error) conclusion=failure; title="Testsuite lab validation failed" ;;
+            Stopped|Terminated) conclusion=cancelled; title="Testsuite lab validation cancelled" ;;
+            *) conclusion=error; title="Testsuite lab validation finished: {{inputs.parameters.final-status}}" ;;
+          esac
+          printf '%s' "${conclusion}" > /tmp/conclusion
+          printf '%s' "${title}" > /tmp/title
+          printf 'PR #{{inputs.parameters.pr-number}} finished as {{inputs.parameters.final-status}}. Workflow: {{inputs.parameters.workflow-url}}' > /tmp/summary

--- a/argo/workflow-templates/k8sgpt-on-demand.yaml
+++ b/argo/workflow-templates/k8sgpt-on-demand.yaml
@@ -27,6 +27,8 @@ spec:
         value: "Pod,Deployment,Service,Ingress,Node"
       - name: ignored-services
         value: "argocd/argocd-applicationset-controller,argocd/argocd-dex-server,argocd/argocd-notifications-controller-metrics,kubevirt/virt-exportproxy,llm-d/llm-d-modelserver"
+      - name: ignored-ingresses
+        value: "wds1-system/wds1"
       - name: provider
         value: "openai"
       - name: model
@@ -101,12 +103,14 @@ spec:
               return json.loads(resp.read())["choices"][0]["message"]["content"]
 
 
-          def normalize_results(data, ignored_services):
-            ignored = {item for item in ignored_services.split(",") if item}
+          def normalize_results(data, ignored_services, ignored_ingresses):
+            ignored_svcs = {item for item in ignored_services.split(",") if item}
+            ignored_ings = {item for item in ignored_ingresses.split(",") if item}
             results = data.get("results") or []
             data["results"] = [
               item for item in results
-              if item.get("kind") != "Service" or item.get("name") not in ignored
+              if not (item.get("kind") == "Service" and item.get("name") in ignored_svcs)
+              and not (item.get("kind") == "Ingress" and item.get("name") in ignored_ings)
             ]
             return data
 
@@ -116,6 +120,7 @@ spec:
             namespace = "{{workflow.parameters.namespace}}"
             filters = "{{workflow.parameters.filters}}"
             ignored_services = "{{workflow.parameters.ignored-services}}"
+            ignored_ingresses = "{{workflow.parameters.ignored-ingresses}}"
             model = "{{workflow.parameters.model}}"
             base_url = "{{workflow.parameters.base-url}}"
             api_key = os.environ.get("K8SGPT_API_KEY", "")
@@ -172,7 +177,7 @@ spec:
             if prometheus_url:
               cmd += ["--prometheus-url", prometheus_url]
             result = subprocess.run(cmd, capture_output=True, text=True)
-            data = normalize_results(json.loads(result.stdout or "{}"), ignored_services)
+            data = normalize_results(json.loads(result.stdout or "{}"), ignored_services, ignored_ingresses)
             findings = data.get("results") or []
             print(f"k8sgpt local findings: {len(findings)}")
 

--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -167,7 +167,7 @@ spec:
           dispatch_pr() {
            local PR="$1"
            local REPO SHA PR_NUM HEAD_BRANCH BRANCH TESTSUITE_BRANCH EXISTING TMPL TITLE TITLE_SLUG
-           local PRODUCT DISPLAY_NAME PR_IMAGE PR_IMAGE_TAG PR_SUITES BST_WORKLOAD
+           local PRODUCT DISPLAY_NAME PR_IMAGE PR_IMAGE_TAG PR_SUITES BST_WORKLOAD REPORTER
 
            # Rate-limit: stop dispatching once we hit MAX_DISPATCH this run
            if [[ "$DISPATCHED" -ge "$MAX_DISPATCH" ]]; then
@@ -292,8 +292,10 @@ spec:
 
            if [[ "$REPO" == "projectbluefin/bluefin" ||
                  "$REPO" == "projectbluefin/bluefin-lts" ||
-                 "$REPO" == "projectbluefin/dakota" ]]; then
+                 "$REPO" == "projectbluefin/dakota" ||
+                 "$REPO" == "projectbluefin/testsuite" ]]; then
             PRODUCT="${REPO##*/}"
+            REPORTER="github-check-reporter"
             case "${PRODUCT}" in
               dakota)
                 DISPLAY_NAME="Dakota"
@@ -325,6 +327,14 @@ spec:
                 PR_IMAGE_TAG="testing"
                 PR_SUITES="smoke"
                 BST_WORKLOAD="false"
+                ;;
+              testsuite)
+                DISPLAY_NAME="Testsuite"
+                PR_IMAGE="ghcr.io/projectbluefin/bluefin"
+                PR_IMAGE_TAG="testing"
+                PR_SUITES="smoke,common"
+                BST_WORKLOAD="false"
+                REPORTER="github-status-reporter"
                 ;;
             esac
             # Build literal Argo expressions for the generated child workflow
@@ -378,7 +388,7 @@ spec:
                  tasks:
                    - name: report-start
                      templateRef:
-                       name: github-check-reporter
+                       name: ${REPORTER}
                        template: send
                      arguments:
                        parameters:
@@ -485,7 +495,7 @@ spec:
                steps:
                  - - name: github-check
                      templateRef:
-                       name: github-check-reporter
+                       name: ${REPORTER}
                        template: final
                      arguments:
                        parameters:
@@ -502,7 +512,9 @@ spec:
           EOF
             )
             WORKFLOW_URL="${ARGO_WORKFLOW_URL_BASE}/${WORKFLOW_NAME}"
-            if ! dispatch_lab_check \
+            if [[ "${REPORTER}" == "github-status-reporter" ]]; then
+              echo "PR #${PR_NUM} ${REPO}: queued status will be published by ${WORKFLOW_NAME}" >&2
+            elif ! dispatch_lab_check \
               "${REPO}" \
               "${SHA}" \
               "${PR_NUM}" \

--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -327,6 +327,10 @@ spec:
                 BST_WORKLOAD="false"
                 ;;
             esac
+            # Build literal Argo expressions for the generated child workflow
+            # without exposing double braces to this outer template.
+            ARGO_OPEN=$(printf '\x7b\x7b')
+            ARGO_CLOSE=$(printf '\x7d\x7d')
             WORKFLOW_NAME=$(kubectl create -f - -o jsonpath='{.metadata.name}' <<EOF
           apiVersion: argoproj.io/v1alpha1
           kind: Workflow
@@ -379,26 +383,26 @@ spec:
                      arguments:
                        parameters:
                          - name: repository
-                           value: "{{{{workflow.parameters.repository}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}"
                          - name: sha
-                           value: "{{{{workflow.parameters.commit-sha}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.commit-sha${ARGO_CLOSE}"
                          - name: pr-number
-                           value: "{{{{workflow.parameters.pr-number}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.pr-number${ARGO_CLOSE}"
                          - name: state
                            value: in_progress
                          - name: conclusion
                            value: ""
                          - name: workflow-name
-                           value: "{{{{workflow.name}}}}"
+                           value: "${ARGO_OPEN}workflow.name${ARGO_CLOSE}"
                          - name: workflow-url
-                           value: "${ARGO_WORKFLOW_URL_BASE}/{{{{workflow.name}}}}"
+                           value: "${ARGO_WORKFLOW_URL_BASE}/${ARGO_OPEN}workflow.name${ARGO_CLOSE}"
                          - name: title
                            value: ${DISPLAY_NAME} lab validation is running
                          - name: summary
                            value: |
                              The lab admitted PR #${PR_NUM} at commit \`${SHA}\`.
 
-                             Validation is running in Argo workflow \`{{{{workflow.name}}}}\`.
+                             Validation is running in Argo workflow \`${ARGO_OPEN}workflow.name${ARGO_CLOSE}\`.
                          - name: text
                            value: ""
                          - name: started-at
@@ -407,7 +411,7 @@ spec:
                            value: ""
                    - name: build
                      depends: "(report-start.Succeeded || report-start.Failed || report-start.Errored)"
-                     when: "'{{{{workflow.parameters.repository}}}}' == 'projectbluefin/dakota'"
+                     when: "'${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}' == 'projectbluefin/dakota'"
                      templateRef:
                        name: dakota-build-pipeline
                        template: build
@@ -427,56 +431,56 @@ spec:
                            value: "bst-build"
                    - name: qa-dakota
                      depends: "build.Succeeded"
-                     when: "'{{{{workflow.parameters.repository}}}}' == 'projectbluefin/dakota'"
+                     when: "'${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}' == 'projectbluefin/dakota'"
                      templateRef:
                        name: dakota-qa-pipeline
                        template: pipeline
                      arguments:
                        parameters:
                          - name: image
-                           value: "{{{{workflow.parameters.image}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.image${ARGO_CLOSE}"
                          - name: image-tag
-                           value: "{{{{workflow.parameters.image-tag}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.image-tag${ARGO_CLOSE}"
                          - name: image-digest
-                           value: "{{{{workflow.parameters.image-digest}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.image-digest${ARGO_CLOSE}"
                          - name: suites
-                           value: "{{{{workflow.parameters.suites}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.suites${ARGO_CLOSE}"
                          - name: variant
-                           value: "{{{{workflow.parameters.variant}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.variant${ARGO_CLOSE}"
                          - name: branch
-                           value: "{{{{workflow.parameters.branch}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.branch${ARGO_CLOSE}"
                          - name: testsuite-branch
-                           value: "{{{{workflow.parameters.testsuite-branch}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.testsuite-branch${ARGO_CLOSE}"
                          - name: testsuite-repo
-                           value: "{{{{workflow.parameters.testsuite-repo}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.testsuite-repo${ARGO_CLOSE}"
                    - name: qa-bluefin
                      depends: "(report-start.Succeeded || report-start.Failed || report-start.Errored)"
-                     when: "'{{{{workflow.parameters.repository}}}}' != 'projectbluefin/dakota'"
+                     when: "'${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}' != 'projectbluefin/dakota'"
                      templateRef:
                        name: bluefin-qa-pipeline
                        template: pipeline
                      arguments:
                        parameters:
                           - name: image
-                            value: "{{{{workflow.parameters.image}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.image${ARGO_CLOSE}"
                           - name: image-tag
-                            value: "{{{{workflow.parameters.image-tag}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.image-tag${ARGO_CLOSE}"
                           - name: suites
-                            value: "{{{{workflow.parameters.suites}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.suites${ARGO_CLOSE}"
                           - name: variant
-                            value: "{{{{workflow.parameters.variant}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.variant${ARGO_CLOSE}"
                           - name: branch
-                            value: "{{{{workflow.parameters.branch}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.branch${ARGO_CLOSE}"
                           - name: pr-number
-                            value: "{{{{workflow.parameters.pr-number}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.pr-number${ARGO_CLOSE}"
                           - name: sha
-                            value: "{{{{workflow.parameters.commit-sha}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.commit-sha${ARGO_CLOSE}"
                           - name: repo
-                            value: "{{{{workflow.parameters.repository}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}"
                           - name: testsuite-branch
-                            value: "{{{{workflow.parameters.testsuite-branch}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.testsuite-branch${ARGO_CLOSE}"
                           - name: testsuite-repo
-                            value: "{{{{workflow.parameters.testsuite-repo}}}}"
+                            value: "${ARGO_OPEN}workflow.parameters.testsuite-repo${ARGO_CLOSE}"
              - name: report-final
                steps:
                  - - name: github-check
@@ -486,15 +490,15 @@ spec:
                      arguments:
                        parameters:
                          - name: repository
-                           value: "{{{{workflow.parameters.repository}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.repository${ARGO_CLOSE}"
                          - name: sha
-                           value: "{{{{workflow.parameters.commit-sha}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.commit-sha${ARGO_CLOSE}"
                          - name: pr-number
-                           value: "{{{{workflow.parameters.pr-number}}}}"
+                           value: "${ARGO_OPEN}workflow.parameters.pr-number${ARGO_CLOSE}"
                          - name: final-status
-                           value: "{{{{workflow.status}}}}"
+                           value: "${ARGO_OPEN}workflow.status${ARGO_CLOSE}"
                          - name: workflow-url
-                           value: "${ARGO_WORKFLOW_URL_BASE}/{{{{workflow.name}}}}"
+                           value: "${ARGO_WORKFLOW_URL_BASE}/${ARGO_OPEN}workflow.name${ARGO_CLOSE}"
           EOF
             )
             WORKFLOW_URL="${ARGO_WORKFLOW_URL_BASE}/${WORKFLOW_NAME}"

--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -268,6 +268,16 @@ spec:
                 nss_entry=$(getent group "${group}" || true)
                 if [ -n "${nss_entry}" ]; then
                   printf '%s\n' "${nss_entry}" >>/etc/group
+                else
+                  # Image has no entry anywhere — synthesize with well-known fallback GIDs
+                  # so tests can run on minimal images (e.g. common, knuckle CI images).
+                  case "${group}" in
+                    video)  gid=39  ;;
+                    render) gid=989 ;;
+                    input)  gid=999 ;;
+                    *)      gid=997 ;;
+                  esac
+                  printf '%s:x:%s:\n' "${group}" "${gid}" >>/etc/group
                 fi
               fi
             fi

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -110,6 +110,15 @@ The workflow authoring guidance is split by topic:
   ORAS or skopeo. Use a pinned tool image (or an explicit, checked bootstrap),
   and validate flags against that pinned release. In particular, ORAS v1.2.3
   `discover` supports `--format json` but not `--depth`.
+- **Assuming archive utilities exist in `lab-runner`**: the image includes
+  Python, `curl`, and `jq`, but not `tar`. Download archives to a workspace,
+  extract them with `python3 -m tarfile`, and remove the archive afterward, or
+  use a pinned image that provides the required utility.
+- **Doubling braces for generated child workflows**: `{{{{workflow.*}}}}`
+  reaches a child Workflow literally and its `when` expressions compare the
+  wrong value. When an outer script must emit an Argo expression, build the
+  braces at runtime (for example with `printf '\x7b\x7b'`) so the outer
+  template does not consume them.
 - **PR approval gate bypass**: Routine labels such as `automerge` or `chore/deps` are not maintainer approval. PR-batch templates must stop before build/QA when `pr/needs-review` remains or live GitHub review data lacks a verified maintainer approval.
 - **Custom metric cardinality**: Never label workflow metrics with workflow
   names, UIDs, commit SHAs, refs, image digests, or build elements. Use only

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -100,6 +100,21 @@ def test_no_standalone_cache_warming_buildstream_workflow_remains():
     ).exists()
 
 
+def test_testsuite_prs_use_direct_commit_status_reporting():
+    poller = (ROOT / "argo/workflow-templates/pr-poller.yaml").read_text(
+        encoding="utf-8"
+    )
+    reporter = (ROOT / "argo/workflow-templates/github-status-reporter.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"$REPO" == "projectbluefin/testsuite"' in poller
+    assert 'REPORTER="github-status-reporter"' in poller
+    assert 'name: ${REPORTER}' in poller
+    assert "statuses/${SHA}" in reporter
+    assert '--arg context "ghost-lab"' in reporter
+
+
 def test_dakota_runner_allows_native_chroot_input_root_execution():
     worker = (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
     assert "name: runner" in worker


### PR DESCRIPTION
Fixes #471. Testsuite PRs were admitted and tested but never received visible lab feedback because the repository lacks the repository_dispatch receiver workflow. Route testsuite child workflows through a direct `ghost-lab` commit-status reporter while preserving detailed Check Runs for the enrolled repositories.