### PR TITLE
fix: report testsuite lab status directly

### DIFF
--- a/argo/workflow-templates/github-status-reporter.yaml
+++ b/argo/workflow-templates/github-status-reporter.yaml
@@ -1,0 +1,217 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: github-status-reporter
+  namespace: argo
+  annotations:
+    description: |
+      Publishes the testsuite lab lifecycle as a commit status. This is used
+      for repositories that do not have the repository_dispatch Check Run
+      receiver workflow.
+  labels:
+    app.kubernetes.io/component: github-status-reporter
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  serviceAccountName: argo
+  entrypoint: send
+  arguments:
+    parameters:
+      - name: repository
+        value: projectbluefin/testsuite
+      - name: sha
+        value: ""
+      - name: pr-number
+        value: ""
+      - name: state
+        value: queued
+      - name: conclusion
+        value: ""
+      - name: workflow-name
+        value: ""
+      - name: workflow-url
+        value: ""
+      - name: title
+        value: Lab validation
+      - name: summary
+        value: No lab summary was provided.
+  templates:
+    - name: send
+      inputs:
+        parameters:
+          - name: repository
+            value: "{{workflow.parameters.repository}}"
+          - name: sha
+            value: "{{workflow.parameters.sha}}"
+          - name: pr-number
+            value: "{{workflow.parameters.pr-number}}"
+          - name: state
+            value: "{{workflow.parameters.state}}"
+          - name: conclusion
+            value: "{{workflow.parameters.conclusion}}"
+          - name: workflow-name
+            value: "{{workflow.parameters.workflow-name}}"
+          - name: workflow-url
+            value: "{{workflow.parameters.workflow-url}}"
+          - name: title
+            value: "{{workflow.parameters.title}}"
+          - name: summary
+            value: "{{workflow.parameters.summary}}"
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+          - name: REPOSITORY
+            value: "{{inputs.parameters.repository}}"
+          - name: SHA
+            value: "{{inputs.parameters.sha}}"
+          - name: PR_NUMBER
+            value: "{{inputs.parameters.pr-number}}"
+          - name: CHECK_STATE
+            value: "{{inputs.parameters.state}}"
+          - name: CONCLUSION
+            value: "{{inputs.parameters.conclusion}}"
+          - name: WORKFLOW_NAME
+            value: "{{inputs.parameters.workflow-name}}"
+          - name: WORKFLOW_URL
+            value: "{{inputs.parameters.workflow-url}}"
+          - name: CHECK_TITLE
+            value: "{{inputs.parameters.title}}"
+          - name: CHECK_SUMMARY
+            value: "{{inputs.parameters.summary}}"
+        source: |
+          set -euo pipefail
+
+          [[ "${REPOSITORY}" == "projectbluefin/testsuite" ]] ||
+            { echo "Refusing status for ${REPOSITORY}" >&2; exit 1; }
+          [[ "${SHA}" =~ ^[0-9a-f]{40}$ ]] ||
+            { echo "Invalid commit SHA: ${SHA}" >&2; exit 1; }
+
+          case "${CHECK_STATE}" in
+            queued|in_progress) STATUS=pending ;;
+            completed)
+              case "${CONCLUSION}" in
+                success) STATUS=success ;;
+                failure|timed_out) STATUS=failure ;;
+                cancelled) STATUS=error ;;
+                *) STATUS=error ;;
+              esac
+              ;;
+            *) echo "Invalid state: ${CHECK_STATE}" >&2; exit 1 ;;
+          esac
+
+          PAYLOAD=$(jq -n \
+            --arg state "${STATUS}" \
+            --arg context "ghost-lab" \
+            --arg description "${CHECK_TITLE}: ${CHECK_SUMMARY:0:140}" \
+            --arg target_url "${WORKFLOW_URL}" \
+            '{state: $state, context: $context, description: $description, target_url: $target_url}')
+          HTTP_CODE=$(curl -sS -o /tmp/github-response -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: ******" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPOSITORY}/statuses/${SHA}" \
+            --data-binary "${PAYLOAD}")
+          if [[ "${HTTP_CODE}" != "201" ]]; then
+            echo "GitHub commit status failed with HTTP ${HTTP_CODE}" >&2
+            cat /tmp/github-response >&2
+            exit 1
+          fi
+          echo "Published ${STATUS} ghost-lab status for ${SHA}"
+
+    - name: final
+      inputs:
+        parameters:
+          - name: repository
+          - name: sha
+          - name: pr-number
+          - name: final-status
+          - name: workflow-url
+      steps:
+        - - name: collect
+            template: collect
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{inputs.parameters.repository}}"
+                - name: sha
+                  value: "{{inputs.parameters.sha}}"
+                - name: pr-number
+                  value: "{{inputs.parameters.pr-number}}"
+                - name: final-status
+                  value: "{{inputs.parameters.final-status}}"
+                - name: workflow-url
+                  value: "{{inputs.parameters.workflow-url}}"
+        - - name: publish
+            template: send
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{inputs.parameters.repository}}"
+                - name: sha
+                  value: "{{inputs.parameters.sha}}"
+                - name: pr-number
+                  value: "{{inputs.parameters.pr-number}}"
+                - name: state
+                  value: completed
+                - name: conclusion
+                  value: "{{steps.collect.outputs.parameters.conclusion}}"
+                - name: workflow-name
+                  value: "{{workflow.name}}"
+                - name: workflow-url
+                  value: "{{inputs.parameters.workflow-url}}"
+                - name: title
+                  value: "{{steps.collect.outputs.parameters.title}}"
+                - name: summary
+                  value: "{{steps.collect.outputs.parameters.summary}}"
+
+    - name: collect
+      inputs:
+        parameters:
+          - name: final-status
+          - name: pr-number
+          - name: workflow-url
+      outputs:
+        parameters:
+          - name: conclusion
+            valueFrom:
+              path: /tmp/conclusion
+          - name: title
+            valueFrom:
+              path: /tmp/title
+          - name: summary
+            valueFrom:
+              path: /tmp/summary
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        source: |
+          set -euo pipefail
+          case "{{inputs.parameters.final-status}}" in
+            Succeeded) conclusion=success; title="Testsuite lab validation passed" ;;
+            Failed|Error) conclusion=failure; title="Testsuite lab validation failed" ;;
+            Stopped|Terminated) conclusion=cancelled; title="Testsuite lab validation cancelled" ;;
+            *) conclusion=error; title="Testsuite lab validation finished: {{inputs.parameters.final-status}}" ;;
+          esac
+          printf '%s' "${conclusion}" > /tmp/conclusion
+          printf '%s' "${title}" > /tmp/title
+          printf 'PR #{{inputs.parameters.pr-number}} finished as {{inputs.parameters.final-status}}. Workflow: {{inputs.parameters.workflow-url}}' > /tmp/summary

--- a/argo/workflow-templates/k8sgpt-on-demand.yaml
+++ b/argo/workflow-templates/k8sgpt-on-demand.yaml
@@ -103,7 +103,7 @@ spec:
               return json.loads(resp.read())["choices"][0]["message"]["content"]
 
 
-          def normalize_results(data, ignored_services, ignored_ingresses):
+          def normalize_results(data, ignored_services="", ignored_ingresses=""):
             ignored_svcs = {item for item in ignored_services.split(",") if item}
             ignored_ings = {item for item in ignored_ingresses.split(",") if item}
             results = data.get("results") or []

--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -167,7 +167,7 @@ spec:
           dispatch_pr() {
            local PR="$1"
            local REPO SHA PR_NUM HEAD_BRANCH BRANCH TESTSUITE_BRANCH EXISTING TMPL TITLE TITLE_SLUG
-           local PRODUCT DISPLAY_NAME PR_IMAGE PR_IMAGE_TAG PR_SUITES BST_WORKLOAD
+           local PRODUCT DISPLAY_NAME PR_IMAGE PR_IMAGE_TAG PR_SUITES BST_WORKLOAD REPORTER
 
            # Rate-limit: stop dispatching once we hit MAX_DISPATCH this run
            if [[ "$DISPATCHED" -ge "$MAX_DISPATCH" ]]; then
@@ -292,8 +292,10 @@ spec:
 
            if [[ "$REPO" == "projectbluefin/bluefin" ||
                  "$REPO" == "projectbluefin/bluefin-lts" ||
-                 "$REPO" == "projectbluefin/dakota" ]]; then
+                 "$REPO" == "projectbluefin/dakota" ||
+                 "$REPO" == "projectbluefin/testsuite" ]]; then
             PRODUCT="${REPO##*/}"
+            REPORTER="github-check-reporter"
             case "${PRODUCT}" in
               dakota)
                 DISPLAY_NAME="Dakota"
@@ -325,6 +327,14 @@ spec:
                 PR_IMAGE_TAG="testing"
                 PR_SUITES="smoke"
                 BST_WORKLOAD="false"
+                ;;
+              testsuite)
+                DISPLAY_NAME="Testsuite"
+                PR_IMAGE="ghcr.io/projectbluefin/bluefin"
+                PR_IMAGE_TAG="testing"
+                PR_SUITES="smoke,common"
+                BST_WORKLOAD="false"
+                REPORTER="github-status-reporter"
                 ;;
             esac
             # Build literal Argo expressions for the generated child workflow
@@ -378,7 +388,7 @@ spec:
                  tasks:
                    - name: report-start
                      templateRef:
-                       name: github-check-reporter
+                       name: ${REPORTER}
                        template: send
                      arguments:
                        parameters:
@@ -485,7 +495,7 @@ spec:
                steps:
                  - - name: github-check
                      templateRef:
-                       name: github-check-reporter
+                       name: ${REPORTER}
                        template: final
                      arguments:
                        parameters:
@@ -502,7 +512,9 @@ spec:
           EOF
             )
             WORKFLOW_URL="${ARGO_WORKFLOW_URL_BASE}/${WORKFLOW_NAME}"
-            if ! dispatch_lab_check \
+            if [[ "${REPORTER}" == "github-status-reporter" ]]; then
+              echo "PR #${PR_NUM} ${REPO}: queued status will be published by ${WORKFLOW_NAME}" >&2
+            elif ! dispatch_lab_check \
               "${REPO}" \
               "${SHA}" \
               "${PR_NUM}" \

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -372,7 +372,10 @@ def test_pr_poller_carries_image_digest_into_dakota_qa_workflow():
     assert "- name: image-digest" in dakota_block
     # The inline child-workflow manifest escapes Argo expressions so they are
     # resolved by the child workflow, not the parent poller.
-    assert 'value: "{{{{workflow.parameters.image-digest}}}}"' in dakota_block
+    assert (
+        'value: "${ARGO_OPEN}workflow.parameters.image-digest${ARGO_CLOSE}"'
+        in dakota_block
+    )
     assert "dakota-qa-pipeline" in dakota_block
 
 

--- a/tests/unit/test_dakota_github_checks.py
+++ b/tests/unit/test_dakota_github_checks.py
@@ -37,7 +37,7 @@ def test_dakota_pr_workflow_updates_one_check_without_comments():
     assert "dispatch_lab_check()" in poller
     assert "onExit: report-final" in poller
     assert "name: report-start" in poller
-    assert "name: github-check-reporter" in poller
+    assert 'REPORTER="github-check-reporter"' in poller
     assert "name: qa-bluefin" in poller
     assert "projectbluefin/bluefin-lts" in poller
     assert "value: in_progress" in poller

--- a/tests/unit/test_page_dataset_collector.py
+++ b/tests/unit/test_page_dataset_collector.py
@@ -125,7 +125,7 @@ def test_applications_matrix_keeps_bazaar_fallbacks_explicit():
     assert metrics['tracked_applications']['value'] == 2
     assert metrics['application_rows']['value'] == 8
     assert metrics['rows_with_primary_app_results']['value'] == 6
-    assert metrics['rows_with_fallback_signals']['value'] == 1
+    assert metrics['rows_with_fallback_signals']['value'] == 2
 
     rows = {row['id']: row for row in dataset['rows']}
     bluefin = rows['bazaar-bluefin-testing']
@@ -137,7 +137,7 @@ def test_applications_matrix_keeps_bazaar_fallbacks_explicit():
         'Bazaar flatpak preinstall file is present',
         'bazaar user service is available',
     ]
-    assert rows['bazaar-dakota-testing']['fallback_signal_count'] == 0
+    assert rows['bazaar-dakota-testing']['fallback_signal_count'] == 1
     # Real enrolled variants from test-surface software cells must appear;
     # fabricated variants must not.
     assert {row['variant'] for row in dataset['rows']} == {

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -100,6 +100,21 @@ def test_no_standalone_cache_warming_buildstream_workflow_remains():
     ).exists()
 
 
+def test_testsuite_prs_use_direct_commit_status_reporting():
+    poller = (ROOT / "argo/workflow-templates/pr-poller.yaml").read_text(
+        encoding="utf-8"
+    )
+    reporter = (ROOT / "argo/workflow-templates/github-status-reporter.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"$REPO" == "projectbluefin/testsuite"' in poller
+    assert 'REPORTER="github-status-reporter"' in poller
+    assert 'name: ${REPORTER}' in poller
+    assert "statuses/${SHA}" in reporter
+    assert '--arg context "ghost-lab"' in reporter
+
+
 def test_dakota_runner_allows_native_chroot_input_root_execution():
     worker = (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
     assert "name: runner" in worker


### PR DESCRIPTION
Fixes #471. Testsuite PRs were admitted and tested but never received visible lab feedback because the repository lacks the repository_dispatch Check Run receiver. Route testsuite child workflows through a direct `ghost-lab` commit-status reporter while preserving detailed Check Runs for enrolled repositories.