### PR TITLE
fix(argo): send the bearer token from the ghost-lab status reporter

### DIFF
--- a/argo/workflow-templates/github-status-reporter.yaml
+++ b/argo/workflow-templates/github-status-reporter.yaml
@@ -119,7 +119,7 @@ spec:
             '{state: $state, context: $context, description: $description, target_url: $target_url}')
           HTTP_CODE=$(curl -sS -o /tmp/github-response -w '%{http_code}' \
             -X POST \
-            -H "Authorization: ******" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${REPOSITORY}/statuses/${SHA}" \

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -115,6 +115,20 @@ def test_testsuite_prs_use_direct_commit_status_reporting():
     assert '--arg context "ghost-lab"' in reporter
 
 
+def test_ghost_lab_status_reporter_authenticates_with_the_github_token():
+    reporter = (ROOT / "argo/workflow-templates/github-status-reporter.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "name: GITHUB_TOKEN" in reporter
+    assert "name: github-token" in reporter
+    assert '-H "Authorization: Bearer ${GITHUB_TOKEN}"' in reporter
+    assert reporter.count("GITHUB_TOKEN") == 2
+    assert "set -x" not in reporter
+    assert "echo ${GITHUB_TOKEN}" not in reporter
+    assert 'echo "${GITHUB_TOKEN}"' not in reporter
+
+
 def test_dakota_runner_allows_native_chroot_input_root_execution():
     worker = (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
     assert "name: runner" in worker


### PR DESCRIPTION
Follow-up to #474 (merged 2026-07-28T22:26:58Z), which routed testsuite PRs to the new `github-status-reporter` WorkflowTemplate but shipped it without a usable credential.

## The defect

`argo/workflow-templates/github-status-reporter.yaml` defined `GITHUB_TOKEN` from the `github-token` Secret (`secretKeyRef`, key `token`) but never referenced it in the curl call — the `Authorization` header carried a literal placeholder. This one-line change copies the exact, proven header construction from `github-check-reporter.yaml`, the reporter already used by bluefin/bluefin-lts/dakota.

## Evidence (counts, not token text)

| file | `grep -c GITHUB_TOKEN` | `grep -c Bearer` | Authorization line length |
|---|---|---|---|
| `github-check-reporter.yaml` (working) | 2 | 1 | 58 (14-space indent) |
| `github-status-reporter.yaml` **before** | 1 | 0 | 40 |
| `github-status-reporter.yaml` **after** | 2 | 1 | 56 (12-space indent) |

Post-fix the two Authorization lines are identical modulo the 2-space indent difference.

## Impact

1. Every status POST returned **401**, so `HTTP_CODE != "201"` → `exit 1`.
2. `report-start` is a DAG task in `pr-poller.yaml`, so **every testsuite child workflow failed at its first step** — a regression strictly worse than the original bug, which merely discarded results.
3. No `ghost-lab` status was posted. Verified zero commit statuses on testsuite PR head SHAs: #651 `c39288cf`, #650 `27c57015`, #632 `e92d639a`, #658 `8e883490`.
4. Issue #471 is closed but the gate is still a no-op — reopening it.

## Live blast radius (read-only Argo query)

Post-merge testsuite child workflows in the `argo` namespace are Failed with the reporter step failing:

```
testsuite-658-fix-dashboard-pin-astro-to-v5-6b27q  Failed  (send step)
  GitHub commit status failed with HTTP 401
    "status": "401"
  Error: exit status 1

testsuite-657-refactor-kde-use-the-shared-is-dcdlf  Failed  (send step)
  GitHub commit status failed with HTTP 401
```

This confirms impact item 2.

## Security

- Token stays sourced from the `github-token` Secret; nothing hardcoded.
- No `set -x` / shell tracing anywhere in the script block (checked explicitly given lab#305).
- Token is never echoed; only the HTTP code and the response body are logged.

## Regression test

`tests/unit/test_workflow_defaults.py::test_ghost_lab_status_reporter_authenticates_with_the_github_token` asserts the reporter's curl contains `-H "Authorization: Bearer ${GITHUB_TOKEN}"`, that `GITHUB_TOKEN` appears exactly twice (defined and used), and that the script has no tracing and never echoes the token. It asserts on the YAML substring pattern, never on a real token value.

The existing `test_testsuite_prs_use_direct_commit_status_reporting` only asserted the `ghost-lab` context and the statuses URL, which is precisely why #474 shipped green.

## Validation

- `python3 -m pytest tests/unit -q`: **194 passed** before → **195 passed** after.
- The new test **fails** against the pre-fix template (verified by stashing the YAML change), so it genuinely guards the regression.
- `argo lint --offline argo/workflow-templates/`: `no linting errors found!`

Refs #471
