### PR TITLE
fix(argo): bound the ghost-lab status description to 140 characters

### DIFF
--- a/argo/workflow-templates/github-status-reporter.yaml
+++ b/argo/workflow-templates/github-status-reporter.yaml
@@ -111,12 +111,29 @@ spec:
             *) echo "Invalid state: ${CHECK_STATE}" >&2; exit 1 ;;
           esac
 
+          # GitHub rejects commit-status descriptions longer than 140
+          # characters, so the composed title + summary is truncated as a
+          # whole. jq does the clipping because its string length and slicing
+          # are codepoint-based, while bash substring expansion is byte-based
+          # under a C locale and could emit invalid UTF-8.
+          if [[ -n "${CHECK_TITLE}" && -n "${CHECK_SUMMARY}" ]]; then
+            DESCRIPTION="${CHECK_TITLE}: ${CHECK_SUMMARY}"
+          else
+            DESCRIPTION="${CHECK_TITLE}${CHECK_SUMMARY}"
+          fi
+          [[ -n "${DESCRIPTION}" ]] || DESCRIPTION="Testsuite lab validation"
+
           PAYLOAD=$(jq -n \
             --arg state "${STATUS}" \
             --arg context "ghost-lab" \
-            --arg description "${CHECK_TITLE}: ${CHECK_SUMMARY:0:140}" \
+            --arg description "${DESCRIPTION}" \
             --arg target_url "${WORKFLOW_URL}" \
-            '{state: $state, context: $context, description: $description, target_url: $target_url}')
+            '{state: $state,
+              context: $context,
+              description: (if ($description | length) > 140
+                            then ($description[0:137] + "...")
+                            else $description end),
+              target_url: $target_url}')
           HTTP_CODE=$(curl -sS -o /tmp/github-response -w '%{http_code}' \
             -X POST \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \

--- a/tests/unit/test_github_status_reporter_description.py
+++ b/tests/unit/test_github_status_reporter_description.py
@@ -1,0 +1,129 @@
+"""Regression tests for the ghost-lab commit-status description length.
+
+GitHub rejects commit statuses whose description exceeds 140 characters with
+HTTP 422 ("Validation failed: Description is too long"). The reporter used to
+truncate only the summary and then prepend the title, so the composed
+description could still overflow.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORTER = ROOT / "argo/workflow-templates/github-status-reporter.yaml"
+MAX_DESCRIPTION = 140
+
+CURL_STUB = """#!/usr/bin/env bash
+printf '%s' "${@: -1}" > "${PAYLOAD_OUT}"
+printf '201'
+"""
+
+
+def _send_script_source():
+    template = yaml.safe_load(REPORTER.read_text(encoding="utf-8"))
+    for entry in template["spec"]["templates"]:
+        if entry["name"] == "send":
+            return entry["script"]["source"]
+    raise AssertionError("github-status-reporter has no 'send' template")
+
+
+def _run_reporter(tmp_path, title, summary):
+    """Execute the real send script with a stubbed curl and return the payload."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    curl = bin_dir / "curl"
+    curl.write_text(CURL_STUB, encoding="utf-8")
+    curl.chmod(0o755)
+
+    payload_out = tmp_path / "payload.json"
+    script = tmp_path / "send.sh"
+    script.write_text(_send_script_source(), encoding="utf-8")
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "PAYLOAD_OUT": str(payload_out),
+            "GITHUB_TOKEN": "unused-in-test",
+            "REPOSITORY": "projectbluefin/testsuite",
+            "SHA": "0" * 40,
+            "PR_NUMBER": "660",
+            "CHECK_STATE": "completed",
+            "CONCLUSION": "failure",
+            "WORKFLOW_NAME": "testsuite-660-docs-ci-zsn6n",
+            "WORKFLOW_URL": "https://argo.example.com/workflows/argo/testsuite-660",
+            "CHECK_TITLE": title,
+            "CHECK_SUMMARY": summary,
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    raw = payload_out.read_bytes()
+    raw.decode("utf-8")  # a mid-multibyte clip would raise here
+    return json.loads(raw)
+
+
+needs_tools = pytest.mark.skipif(
+    shutil.which("jq") is None or shutil.which("bash") is None,
+    reason="requires bash and jq",
+)
+
+
+@needs_tools
+@pytest.mark.parametrize(
+    "title,summary",
+    [
+        ("Testsuite lab validation failed", "PR #660 finished as Failed. " + "x" * 400),
+        ("T" * 400, "PR #660 finished as Failed."),
+        ("T" * 400, "S" * 400),
+        ("é" * 400, "ü" * 400),
+        ("Testsuite lab validation passed", ""),
+        ("", "PR #660 finished as Succeeded."),
+    ],
+)
+def test_composed_description_never_exceeds_github_limit(tmp_path, title, summary):
+    payload = _run_reporter(tmp_path, title, summary)
+    description = payload["description"]
+
+    assert description, "description must never be empty"
+    assert len(description) <= MAX_DESCRIPTION, description
+    assert payload["state"] in {"error", "failure", "pending", "success"}
+    assert payload["context"] == "ghost-lab"
+
+
+@needs_tools
+def test_truncated_description_is_marked_with_an_ellipsis(tmp_path):
+    payload = _run_reporter(tmp_path, "Testsuite lab validation failed", "s" * 400)
+
+    assert payload["description"].startswith("Testsuite lab validation failed: ")
+    assert payload["description"].endswith("...")
+    assert len(payload["description"]) == MAX_DESCRIPTION
+
+
+@needs_tools
+def test_short_description_is_passed_through_unchanged(tmp_path):
+    payload = _run_reporter(tmp_path, "Testsuite lab validation passed", "PR #660 ok.")
+
+    assert payload["description"] == "Testsuite lab validation passed: PR #660 ok."
+
+
+def test_reporter_does_not_truncate_the_summary_before_prepending_the_title():
+    source = _send_script_source()
+
+    assert "${CHECK_SUMMARY:0:140}" not in source
+    assert '--arg description "${DESCRIPTION}"' in source
+    assert "140" in source


### PR DESCRIPTION
## Live evidence

Workflow `testsuite-660-docs-ci-re-point-the-ghost-lab-zsn6n`, namespace `argo`, 2026-07-28T23:21:13Z:

```
GitHub commit status failed with HTTP 422
{
  "message": "Validation Failed",
  "errors": "Validation failed: Description is too long (maximum is 140 characters)",
  "documentation_url": "https://docs.github.com/rest/commits/statuses#create-a-commit-status",
  "status": "422"
}
Error: exit status 1
```

## Root cause

`argo/workflow-templates/github-status-reporter.yaml`, `send` template:

```bash
--arg description "${CHECK_TITLE}: ${CHECK_SUMMARY:0:140}" \
```

The summary was truncated to 140 characters and *then* the title was prepended, so the composed description was `len(title) + 2 + 140` characters — always over GitHub's documented 140-character maximum for commit-status descriptions. `report-start` is a DAG task in `pr-poller.yaml`, so the non-201 response exits 1 and fails every testsuite child workflow.

## Fix

Compose first, clip the whole string:

```bash
if [[ -n "${CHECK_TITLE}" && -n "${CHECK_SUMMARY}" ]]; then
  DESCRIPTION="${CHECK_TITLE}: ${CHECK_SUMMARY}"
else
  DESCRIPTION="${CHECK_TITLE}${CHECK_SUMMARY}"
fi
[[ -n "${DESCRIPTION}" ]] || DESCRIPTION="Testsuite lab validation"

PAYLOAD=$(jq -n \
  --arg description "${DESCRIPTION}" \
  ... \
  '{..., description: (if ($description | length) > 140
                       then ($description[0:137] + "...")
                       else $description end), ...}')
```

Edge cases handled:

- **Overlong title alone** — the bound applies to the composed string, so a title over 140 characters is clipped too.
- **UTF-8 safety** — jq's `length`/slicing are codepoint-based. Bash `${VAR:0:140}` is byte-based under the C locale that containers typically run with, so it could split a multibyte sequence and produce invalid UTF-8 that jq itself would reject. Truncation therefore happens inside jq.
- **Empty title or empty summary** — no dangling `": "` separator, and a non-empty fallback description is always sent.
- **Ellipsis** — appended only when truncation occurs, inside the 140 budget (137 + `...`).

Rest of the payload audited against the [REST docs](https://docs.github.com/en/rest/commits/statuses): `state` is always one of `error|failure|pending|success` (the `case` has a catch-all), `context` is the literal `ghost-lab` (well under the 255 limit), `target_url` is optional and nullable. No other guaranteed-422 case found, so no speculative changes were made.

## Regression test

`tests/unit/test_github_status_reporter_description.py` extracts the real `send` script from the YAML and executes it in bash with a stubbed `curl`, then inspects the actual JSON payload:

- parametrised over long summary, long title, both long, multibyte, empty summary, empty title — asserts `len(description) <= 140`, non-empty, decodable as UTF-8, valid `state`, `context == "ghost-lab"`;
- asserts an ellipsis marks real truncation and that short descriptions pass through unchanged;
- static check that `${CHECK_SUMMARY:0:140}` is gone.

Pre-fix: 6 failed / 3 passed. Post-fix: 9 passed.

Suite: **195 → 204 passing** (`python3 -m pytest tests/unit -q`). `ruff check tests/` clean for the new file (4 pre-existing errors elsewhere, unchanged). `argo lint --offline argo/workflow-templates/` — no linting errors.

Auth fix from #479 preserved, verified by count rather than by reading the masked header line: `grep -c GITHUB_TOKEN` = 2, `grep -c Bearer` = 1, no `set -x` and the token is never echoed (lab#305).

## Note

This is the **third** defect in this reporter chain: #474 (routing) → #479 (auth/401) → this one (422 description length).

**The gate must be validated by observing a real `ghost-lab` status on a live testsuite PR head SHA**, not by this PR merging. Do not treat merge as proof.