### PR TITLE
feat(argo): add GitOps recovery workflow templates

### DIFF
--- a/argo/workflow-templates/migration-upgrade-test.yaml
+++ b/argo/workflow-templates/migration-upgrade-test.yaml
@@ -1,0 +1,113 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: migration-upgrade-test
+  namespace: argo
+  annotations:
+    description: |
+      Builds a legacy ublue-os image into a fresh migration container disk,
+      provisions it, and runs bluefin-migration-test's migration sequence
+      against the requested chunkah image and storage variant.
+spec:
+  serviceAccountName: argo
+  activeDeadlineSeconds: 86400
+  entrypoint: migration-upgrade
+  onExit: teardown
+  arguments:
+    parameters:
+      - name: legacy-image
+        value: ghcr.io/ublue-os/bluefin
+      - name: legacy-image-tag
+        value: latest
+      - name: chunkah-image
+        value: ghcr.io/projectbluefin/bluefin
+      - name: chunkah-image-tag
+        value: stable
+      - name: storage-variant
+        value: default
+      - name: namespace
+        value: bluefin-test
+      - name: golden-root
+        value: /var/mnt/ghost-data/bluefin-golden
+      - name: test-root
+        value: /var/mnt/ghost-data/bluefin-test
+      - name: ssh-key-secret
+        value: bluefin-test-ssh-key
+      - name: vm-name
+        value: migration-upgrade-{{workflow.uid}}
+  volumeClaimTemplates:
+    - metadata:
+        name: staging
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 100Gi
+  templates:
+    - name: migration-upgrade
+      steps:
+        - - name: ensure-disk
+            templateRef:
+              name: build-bluefin-migration-containerdisk
+              template: build-containerdisk
+            arguments:
+              parameters:
+                - name: image
+                  value: "{{workflow.parameters.legacy-image}}"
+                - name: image-tag
+                  value: "{{workflow.parameters.legacy-image-tag}}"
+                - name: containerdisk-tag
+                  value: "{{workflow.parameters.legacy-image-tag}}"
+                - name: force
+                  value: "true"
+                - name: disk-size
+                  value: "40G"
+        - - name: provision
+            templateRef:
+              name: provision-containerdisk-vm
+              template: provision-vm
+            arguments:
+              parameters:
+                - name: image-tag
+                  value: "{{workflow.parameters.legacy-image-tag}}"
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: namespace
+                  value: "{{workflow.parameters.namespace}}"
+        - - name: migration
+            templateRef:
+              name: bluefin-migration-test
+              template: migration-sequence
+            arguments:
+              parameters:
+                - name: image-tag
+                  value: "{{workflow.parameters.legacy-image-tag}}"
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: vm-ip
+                  value: "{{steps.provision.outputs.parameters.vm-ip}}"
+                - name: ssh-user
+                  value: bluefin-test
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: legacy-image
+                  value: "{{workflow.parameters.legacy-image}}"
+                - name: chunkah-image
+                  value: "{{workflow.parameters.chunkah-image}}"
+                - name: chunkah-image-tag
+                  value: "{{workflow.parameters.chunkah-image-tag}}"
+                - name: storage-variant
+                  value: "{{workflow.parameters.storage-variant}}"
+
+    - name: teardown
+      steps:
+        - - name: delete-vm
+            templateRef:
+              name: teardown-vm
+              template: teardown-vm
+            arguments:
+              parameters:
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: namespace
+                  value: "{{workflow.parameters.namespace}}"

--- a/argo/workflow-templates/migration-upgrade-test.yaml
+++ b/argo/workflow-templates/migration-upgrade-test.yaml
@@ -13,6 +13,8 @@ spec:
   activeDeadlineSeconds: 86400
   entrypoint: migration-upgrade
   onExit: teardown
+  volumeClaimGC:
+    strategy: OnWorkflowCompletion
   arguments:
     parameters:
       - name: legacy-image
@@ -74,6 +76,10 @@ spec:
                   value: "{{workflow.parameters.vm-name}}"
                 - name: namespace
                   value: "{{workflow.parameters.namespace}}"
+                - name: golden-root
+                  value: "{{workflow.parameters.golden-root}}"
+                - name: test-root
+                  value: "{{workflow.parameters.test-root}}"
         - - name: migration
             templateRef:
               name: bluefin-migration-test
@@ -111,3 +117,5 @@ spec:
                   value: "{{workflow.parameters.vm-name}}"
                 - name: namespace
                   value: "{{workflow.parameters.namespace}}"
+                - name: test-root
+                  value: "{{workflow.parameters.test-root}}"

--- a/argo/workflow-templates/toggle-testing-rebase.yaml
+++ b/argo/workflow-templates/toggle-testing-rebase.yaml
@@ -1,0 +1,258 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: toggle-testing-rebase
+  namespace: argo
+  annotations:
+    description: |
+      Starts a Bluefin VM from a stable or testing image, exercises the
+      production toggle-testing flow in both directions, reboots after each
+      switch, and verifies the booted image with bootc status.
+spec:
+  serviceAccountName: argo
+  activeDeadlineSeconds: 14400
+  entrypoint: toggle-testing
+  onExit: teardown
+  arguments:
+    parameters:
+      - name: image
+        value: ghcr.io/projectbluefin/bluefin
+      - name: disk-image
+        value: ghcr.io/projectbluefin/bluefin:stable
+      - name: start-tag
+        value: stable
+      - name: target-tag
+        value: testing
+      - name: namespace
+        value: bluefin-test
+      - name: test-root
+        value: /var/mnt/ghost-data/bluefin-test
+      - name: ssh-key-secret
+        value: bluefin-test-ssh-key
+      - name: vm-name
+        value: toggle-testing-{{workflow.uid}}
+  volumeClaimTemplates:
+    - metadata:
+        name: staging
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 100Gi
+  templates:
+    - name: toggle-testing
+      steps:
+        - - name: ensure-disk
+            templateRef:
+              name: build-bluefin-migration-containerdisk
+              template: build-containerdisk
+            arguments:
+              parameters:
+                - name: image
+                  value: "{{workflow.parameters.image}}"
+                - name: image-tag
+                  value: "{{workflow.parameters.start-tag}}"
+                - name: containerdisk-tag
+                  value: "{{workflow.parameters.start-tag}}"
+                - name: force
+                  value: "false"
+        - - name: provision
+            templateRef:
+              name: provision-containerdisk-vm
+              template: provision-vm
+            arguments:
+              parameters:
+                - name: image-tag
+                  value: "{{workflow.parameters.start-tag}}"
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: namespace
+                  value: "{{workflow.parameters.namespace}}"
+        - - name: toggle-forward
+            template: run-toggle-testing
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{steps.provision.outputs.parameters.vm-ip}}"
+                - name: image
+                  value: "{{workflow.parameters.image}}"
+                - name: target-tag
+                  value: "{{workflow.parameters.target-tag}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+        - - name: reboot-forward
+            template: reboot-and-wait
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{steps.provision.outputs.parameters.vm-ip}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+        - - name: verify-forward
+            template: verify-bootc-state
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{steps.provision.outputs.parameters.vm-ip}}"
+                - name: expected-tag
+                  value: "{{workflow.parameters.target-tag}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+        - - name: toggle-back
+            template: run-toggle-testing
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{steps.provision.outputs.parameters.vm-ip}}"
+                - name: image
+                  value: "{{workflow.parameters.image}}"
+                - name: target-tag
+                  value: "{{workflow.parameters.start-tag}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+        - - name: reboot-back
+            template: reboot-and-wait
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{steps.provision.outputs.parameters.vm-ip}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+        - - name: verify-back
+            template: verify-bootc-state
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{steps.provision.outputs.parameters.vm-ip}}"
+                - name: expected-tag
+                  value: "{{workflow.parameters.start-tag}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+
+    - name: run-toggle-testing
+      activeDeadlineSeconds: 1800
+      inputs:
+        parameters:
+          - name: vm-ip
+          - name: image
+          - name: target-tag
+          - name: ssh-key-secret
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 1
+            memory: 1Gi
+        source: |
+          set -euo pipefail
+          KEY=/etc/ssh/test-key/id_ed25519
+          SSH=(ssh -i "${KEY}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -o LogLevel=ERROR "bluefin-test@{{inputs.parameters.vm-ip}}")
+          TARGET="{{inputs.parameters.target-tag}}"
+          IMAGE="{{inputs.parameters.image}}:${TARGET}"
+          echo "Running the production toggle-testing command toward ${IMAGE}"
+          "${SSH[@]}" "if command -v bctl >/dev/null 2>&1; then yes | bctl toggle-testing; else yes | ujust toggle-testing; fi"
+          status="$("${SSH[@]}" "sudo bootc status --json")"
+          if ! grep -q "${TARGET}" <<<"${status}"; then
+            echo "toggle-testing did not stage ${IMAGE}; using the same signed bootc switch as the production command" >&2
+            "${SSH[@]}" "sudo bootc switch --enforce-container-sigpolicy '${IMAGE}'"
+          fi
+        volumeMounts:
+          - name: ssh-key
+            mountPath: /etc/ssh/test-key
+            readOnly: true
+      volumes:
+        - name: ssh-key
+          secret:
+            secretName: "{{inputs.parameters.ssh-key-secret}}"
+
+    - name: reboot-and-wait
+      activeDeadlineSeconds: 900
+      inputs:
+        parameters:
+          - name: vm-ip
+          - name: ssh-key-secret
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        source: |
+          set -euo pipefail
+          KEY=/etc/ssh/test-key/id_ed25519
+          SSH=(ssh -i "${KEY}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o LogLevel=ERROR "bluefin-test@{{inputs.parameters.vm-ip}}")
+          set +e
+          "${SSH[@]}" sudo reboot >/dev/null 2>&1
+          set -e
+          for _ in $(seq 1 24); do
+            if ! "${SSH[@]}" true >/dev/null 2>&1; then break; fi
+            sleep 5
+          done
+          for _ in $(seq 1 72); do
+            if "${SSH[@]}" true >/dev/null 2>&1; then exit 0; fi
+            sleep 5
+          done
+          echo "Timed out waiting for SSH after reboot" >&2
+          exit 1
+        volumeMounts:
+          - name: ssh-key
+            mountPath: /etc/ssh/test-key
+            readOnly: true
+      volumes:
+        - name: ssh-key
+          secret:
+            secretName: "{{inputs.parameters.ssh-key-secret}}"
+
+    - name: verify-bootc-state
+      activeDeadlineSeconds: 900
+      inputs:
+        parameters:
+          - name: vm-ip
+          - name: expected-tag
+          - name: ssh-key-secret
+      script:
+        image: ghcr.io/projectbluefin/lab-runner:latest
+        command: [bash]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        source: |
+          set -euo pipefail
+          KEY=/etc/ssh/test-key/id_ed25519
+          SSH=(ssh -i "${KEY}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -o LogLevel=ERROR "bluefin-test@{{inputs.parameters.vm-ip}}")
+          status="$("${SSH[@]}" "sudo bootc status --json")"
+          echo "${status}"
+          grep -q "{{inputs.parameters.expected-tag}}" <<<"${status}"
+        volumeMounts:
+          - name: ssh-key
+            mountPath: /etc/ssh/test-key
+            readOnly: true
+      volumes:
+        - name: ssh-key
+          secret:
+            secretName: "{{inputs.parameters.ssh-key-secret}}"
+
+    - name: teardown
+      steps:
+        - - name: delete-vm
+            templateRef:
+              name: teardown-vm
+              template: teardown-vm
+            arguments:
+              parameters:
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: namespace
+                  value: "{{workflow.parameters.namespace}}"

--- a/argo/workflow-templates/toggle-testing-rebase.yaml
+++ b/argo/workflow-templates/toggle-testing-rebase.yaml
@@ -13,6 +13,8 @@ spec:
   activeDeadlineSeconds: 14400
   entrypoint: toggle-testing
   onExit: teardown
+  volumeClaimGC:
+    strategy: OnWorkflowCompletion
   arguments:
     parameters:
       - name: image
@@ -68,6 +70,8 @@ spec:
                   value: "{{workflow.parameters.vm-name}}"
                 - name: namespace
                   value: "{{workflow.parameters.namespace}}"
+                - name: test-root
+                  value: "{{workflow.parameters.test-root}}"
         - - name: toggle-forward
             template: run-toggle-testing
             arguments:
@@ -80,6 +84,10 @@ spec:
                   value: "{{workflow.parameters.target-tag}}"
                 - name: ssh-key-secret
                   value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: disk-image
+                  value: "{{workflow.parameters.disk-image}}"
+                - name: test-root
+                  value: "{{workflow.parameters.test-root}}"
         - - name: reboot-forward
             template: reboot-and-wait
             arguments:
@@ -110,6 +118,10 @@ spec:
                   value: "{{workflow.parameters.start-tag}}"
                 - name: ssh-key-secret
                   value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: disk-image
+                  value: "{{workflow.parameters.disk-image}}"
+                - name: test-root
+                  value: "{{workflow.parameters.test-root}}"
         - - name: reboot-back
             template: reboot-and-wait
             arguments:
@@ -137,6 +149,8 @@ spec:
           - name: image
           - name: target-tag
           - name: ssh-key-secret
+          - name: disk-image
+          - name: test-root
       script:
         image: ghcr.io/projectbluefin/lab-runner:latest
         command: [bash]
@@ -153,13 +167,20 @@ spec:
           SSH=(ssh -i "${KEY}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -o LogLevel=ERROR "bluefin-test@{{inputs.parameters.vm-ip}}")
           TARGET="{{inputs.parameters.target-tag}}"
           IMAGE="{{inputs.parameters.image}}:${TARGET}"
+          START_IMAGE="{{inputs.parameters.disk-image}}"
+          echo "Starting from ${START_IMAGE}; test root is {{inputs.parameters.test-root}}"
+          start_status="$("${SSH[@]}" "sudo bootc status --json")"
+          grep -q "${START_IMAGE}" <<<"${start_status}" || {
+            echo "VM is not running ${START_IMAGE}" >&2
+            exit 1
+          }
           echo "Running the production toggle-testing command toward ${IMAGE}"
           "${SSH[@]}" "if command -v bctl >/dev/null 2>&1; then yes | bctl toggle-testing; else yes | ujust toggle-testing; fi"
           status="$("${SSH[@]}" "sudo bootc status --json")"
-          if ! grep -q "${TARGET}" <<<"${status}"; then
-            echo "toggle-testing did not stage ${IMAGE}; using the same signed bootc switch as the production command" >&2
-            "${SSH[@]}" "sudo bootc switch --enforce-container-sigpolicy '${IMAGE}'"
-          fi
+          grep -q "${TARGET}" <<<"${status}" || {
+            echo "toggle-testing did not stage ${IMAGE}" >&2
+            exit 1
+          }
         volumeMounts:
           - name: ssh-key
             mountPath: /etc/ssh/test-key
@@ -256,3 +277,5 @@ spec:
                   value: "{{workflow.parameters.vm-name}}"
                 - name: namespace
                   value: "{{workflow.parameters.namespace}}"
+                - name: test-root
+                  value: "{{workflow.parameters.test-root}}"

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -68,6 +68,15 @@ The workflow authoring guidance is split by topic:
   paths between steps; pass file *content* via an output parameter
   (`valueFrom.path`, 256KB cap) or an artifact.
 - A pipeline with no `onExit` handler (VM will leak on failure)
+- A workflow that declares `volumeClaimTemplates` without
+  `volumeClaimGC.strategy: OnWorkflowCompletion` — completed runs leave staging
+  PVCs behind.
+- A test that falls back to a direct `bootc switch` after the production
+  toggle command fails to stage — this masks the behavior under test; fail the
+  step and report the staging failure instead.
+- A declared workflow parameter that is not passed to the template or helper
+  that consumes it — especially disk/image and host-root parameters. Trace
+  every contract parameter through the call-site arguments.
 - Any `script:` template without `resources:` limits
 - Templates in `argo/workflow-templates/` applied with `kubectl apply` (not via git)
 - A `pr-poller` (or any PR-gating workflow) that skips on ANY existing commit status — it must skip only `pending` (in-flight) and `success` (already passed), and re-test on `error`/`failure`. Skipping `error` means stale statuses from deleted workflows permanently block retests.

--- a/docs/skills/argo-workflows/authoring.md
+++ b/docs/skills/argo-workflows/authoring.md
@@ -37,6 +37,12 @@ spec:
 - `serviceAccountName: argo` on every WorkflowTemplate
 - `namespace: argo` always
 - `description:` annotation on every template — one paragraph saying what it does
+- `volumeMounts` for a `script` or `container` belong inside that executor
+  block, while matching `volumes` belong on the surrounding template. Argo's
+  strict decoder rejects executor mounts placed directly on the template.
+- Template names are unique within one WorkflowTemplate. Give an entrypoint
+  and its executable step distinct names (for example, `toggle-testing` and
+  `run-toggle-testing`) rather than reusing the same name.
 
 ### 1b. Debugging a workflow stuck on a dead node
 

--- a/tests/unit/test_recovery_workflow_templates.py
+++ b/tests/unit/test_recovery_workflow_templates.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_template(name: str) -> dict:
+    return yaml.safe_load(
+        (ROOT / "argo" / "workflow-templates" / name).read_text(encoding="utf-8")
+    )
+
+
+def parameter_names(template: dict) -> set[str]:
+    return {
+        parameter["name"]
+        for parameter in template["spec"]["arguments"]["parameters"]
+    }
+
+
+def template_names(template: dict) -> set[str]:
+    return {item["name"] for item in template["spec"]["templates"]}
+
+
+def test_toggle_testing_rebase_is_gitops_managed_and_covers_both_directions():
+    template = load_template("toggle-testing-rebase.yaml")
+
+    assert template["metadata"]["name"] == "toggle-testing-rebase"
+    assert "description" in template["metadata"]["annotations"]
+    assert {
+        "image",
+        "disk-image",
+        "start-tag",
+        "target-tag",
+        "namespace",
+        "test-root",
+        "ssh-key-secret",
+    } <= parameter_names(template)
+    assert template["spec"]["onExit"] == "teardown"
+    assert {
+        "run-toggle-testing",
+        "reboot-and-wait",
+        "verify-bootc-state",
+        "teardown",
+    } <= template_names(template)
+
+    steps = template["spec"]["templates"][0]["steps"]
+    step_names = [group[0]["name"] for group in steps]
+    assert step_names == [
+        "ensure-disk",
+        "provision",
+        "toggle-forward",
+        "reboot-forward",
+        "verify-forward",
+        "toggle-back",
+        "reboot-back",
+        "verify-back",
+    ]
+
+
+def test_migration_upgrade_wraps_migration_sequence_with_disk_build():
+    template = load_template("migration-upgrade-test.yaml")
+
+    assert template["metadata"]["name"] == "migration-upgrade-test"
+    assert "description" in template["metadata"]["annotations"]
+    assert {
+        "legacy-image",
+        "legacy-image-tag",
+        "chunkah-image",
+        "chunkah-image-tag",
+        "storage-variant",
+        "namespace",
+        "golden-root",
+        "test-root",
+        "ssh-key-secret",
+    } <= parameter_names(template)
+    assert template["spec"]["onExit"] == "teardown"
+    steps = template["spec"]["templates"][0]["steps"]
+    assert [group[0]["name"] for group in steps] == [
+        "ensure-disk",
+        "provision",
+        "migration",
+    ]
+    assert steps[-1][0]["templateRef"]["name"] == "bluefin-migration-test"
+    assert steps[-1][0]["templateRef"]["template"] == "migration-sequence"

--- a/tests/unit/test_recovery_workflow_templates.py
+++ b/tests/unit/test_recovery_workflow_templates.py
@@ -38,6 +38,7 @@ def test_toggle_testing_rebase_is_gitops_managed_and_covers_both_directions():
         "ssh-key-secret",
     } <= parameter_names(template)
     assert template["spec"]["onExit"] == "teardown"
+    assert template["spec"]["volumeClaimGC"]["strategy"] == "OnWorkflowCompletion"
     assert {
         "run-toggle-testing",
         "reboot-and-wait",
@@ -57,6 +58,12 @@ def test_toggle_testing_rebase_is_gitops_managed_and_covers_both_directions():
         "reboot-back",
         "verify-back",
     ]
+    content = (ROOT / "argo" / "workflow-templates" / "toggle-testing-rebase.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "bootc switch" not in content
+    assert content.count("workflow.parameters.disk-image") >= 2
+    assert content.count("workflow.parameters.test-root") >= 3
 
 
 def test_migration_upgrade_wraps_migration_sequence_with_disk_build():
@@ -76,6 +83,7 @@ def test_migration_upgrade_wraps_migration_sequence_with_disk_build():
         "ssh-key-secret",
     } <= parameter_names(template)
     assert template["spec"]["onExit"] == "teardown"
+    assert template["spec"]["volumeClaimGC"]["strategy"] == "OnWorkflowCompletion"
     steps = template["spec"]["templates"][0]["steps"]
     assert [group[0]["name"] for group in steps] == [
         "ensure-disk",
@@ -84,3 +92,8 @@ def test_migration_upgrade_wraps_migration_sequence_with_disk_build():
     ]
     assert steps[-1][0]["templateRef"]["name"] == "bluefin-migration-test"
     assert steps[-1][0]["templateRef"]["template"] == "migration-sequence"
+    content = (ROOT / "argo" / "workflow-templates" / "migration-upgrade-test.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert content.count("workflow.parameters.golden-root") >= 1
+    assert content.count("workflow.parameters.test-root") >= 2


### PR DESCRIPTION
Closes #225

## Summary
- add GitOps-managed toggle-testing-rebase workflow for stable/testing round trips with reboots and bootc verification
- add migration-upgrade-test wrapper that builds the legacy source, provisions a VM, and invokes migration-sequence
- add unit coverage for required parameters and workflow ordering

## Validation
- just lint
- python -m pytest -q tests/unit/test_recovery_workflow_templates.py tests/unit/test_container_only_qa_workflows.py

No kubectl apply was used.