### PR TITLE
feat(kde): add native KDE Linux OVMF QA lane

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -136,6 +136,12 @@ run-flatcar-smoke:
         -n {{ argo_ns }} \
         --watch
 
+# Run the pinned KDE Linux native OVMF lane.
+run-kde-linux:
+    argo submit argo/kde-linux-qa.yaml \
+        -n {{ argo_ns }} \
+        --watch
+
 # ── Observation ─────────────────────────────────────────────────────────────
 
 # List all test workflows

--- a/argo/kde-linux-qa.yaml
+++ b/argo/kde-linux-qa.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: kde-linux-qa-
+  namespace: argo
+spec:
+  entrypoint: pipeline
+  serviceAccountName: argo
+  activeDeadlineSeconds: 5400
+  onExit: cleanup
+  arguments:
+    parameters:
+    - name: image-url
+      value: "https://files.kde.org/kde-linux/kde-linux_202607281716.iso"
+    - name: image-sha256
+      value: "8554c25d098373a618a733656852ef25ad96c2b8ce59d57d9705e38eb95046bf"
+    - name: namespace
+      value: "kde-test"
+    - name: testsuite-branch
+      value: "main"
+  templates:
+  - name: pipeline
+    dag:
+      tasks:
+      - name: provision
+        templateRef:
+          name: provision-kde-linux-vm
+          template: provision-vm
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "kde-linux-{{workflow.uid}}"
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: image-url
+            value: "{{workflow.parameters.image-url}}"
+          - name: image-sha256
+            value: "{{workflow.parameters.image-sha256}}"
+      - name: tests
+        depends: provision.Succeeded
+        templateRef:
+          name: run-kde-tests
+          template: run-kde-tests
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "kde-linux-{{workflow.uid}}"
+          - name: vm-namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: testsuite-branch
+            value: "{{workflow.parameters.testsuite-branch}}"
+  - name: cleanup
+    steps:
+    - - name: teardown
+        templateRef:
+          name: teardown-vm
+          template: teardown-vm
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "kde-linux-{{workflow.uid}}"
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"

--- a/argo/workflow-templates/provision-kde-linux-vm.yaml
+++ b/argo/workflow-templates/provision-kde-linux-vm.yaml
@@ -1,0 +1,194 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: provision-kde-linux-vm
+  namespace: argo
+  annotations:
+    description: |
+      Downloads a published KDE Linux hybrid ISO, verifies its pinned SHA256,
+      wraps it as a containerDisk, and boots it as an ephemeral OVMF/KubeVirt VM.
+      KDE Linux publishes a GPT disk image and El Torito ISO in the same artifact.
+spec:
+  templates:
+  - name: provision-vm
+    inputs:
+      parameters:
+      - name: vm-name
+      - name: namespace
+        value: "kde-test"
+      - name: image-url
+        value: "https://files.kde.org/kde-linux/kde-linux_202607281716.iso"
+      - name: image-sha256
+        value: "8554c25d098373a618a733656852ef25ad96c2b8ce59d57d9705e38eb95046bf"
+    outputs:
+      parameters:
+      - name: vm-ip
+        valueFrom:
+          parameter: "{{steps.wait-for-vm.outputs.result}}"
+    steps:
+    - - name: prepare-disk
+        template: prepare-disk
+        arguments:
+          parameters:
+          - name: image-url
+            value: "{{inputs.parameters.image-url}}"
+          - name: image-sha256
+            value: "{{inputs.parameters.image-sha256}}"
+    - - name: create-vm
+        template: create-vm
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "{{inputs.parameters.vm-name}}"
+          - name: namespace
+            value: "{{inputs.parameters.namespace}}"
+    - - name: wait-for-vm
+        template: wait-for-vm
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "{{inputs.parameters.vm-name}}"
+          - name: namespace
+            value: "{{inputs.parameters.namespace}}"
+
+  - name: prepare-disk
+    inputs:
+      parameters:
+      - name: image-url
+      - name: image-sha256
+    volumes:
+    - name: work
+      emptyDir:
+        sizeLimit: 12Gi
+    script:
+      image: quay.io/buildah/stable:latest
+      command: [bash]
+      securityContext:
+        privileged: true
+        runAsUser: 0
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "4"
+          memory: 8Gi
+      volumeMounts:
+      - name: work
+        mountPath: /mnt/work
+      source: |
+        set -euo pipefail
+        URL="{{inputs.parameters.image-url}}"
+        SHA="{{inputs.parameters.image-sha256}}"
+        WORK=/mnt/work
+        IMAGE="${WORK}/kde-linux.iso"
+        CONTAINERDISK="192.168.1.102:30500/kde-linux-containerdisk:latest"
+
+        [[ "${SHA}" =~ ^[[:xdigit:]]{64}$ ]] || {
+          echo "image-sha256 must be a 64-character hexadecimal digest" >&2
+          exit 1
+        }
+        curl --fail --location --retry 3 --retry-all-errors \
+          --output "${IMAGE}" "${URL}"
+        printf '%s  %s\n' "${SHA}" "${IMAGE}" | sha256sum -c -
+
+        ctr=$(buildah from scratch)
+        trap 'buildah rm "${ctr}" >/dev/null 2>&1 || true' EXIT
+        buildah copy --chown 107:107 "${ctr}" "${IMAGE}" /disk/kde-linux.iso
+        printf '%s\n' \
+          '{"volumes":[{"image":"kde-linux.iso","capacity":"12Gi"}]}' \
+          > "${WORK}/containerDisk.json"
+        buildah copy "${ctr}" "${WORK}/containerDisk.json" /containerDisk.json
+        buildah commit "${ctr}" "${CONTAINERDISK}"
+        buildah push --tls-verify=false "${CONTAINERDISK}"
+
+  - name: create-vm
+    inputs:
+      parameters:
+      - name: vm-name
+      - name: namespace
+    resource:
+      action: apply
+      manifest: |
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: "{{inputs.parameters.vm-name}}"
+          namespace: "{{inputs.parameters.namespace}}"
+          labels:
+            app: kde-linux-test
+            argo-workflow: "{{workflow.name}}"
+        spec:
+          runStrategy: Always
+          template:
+            metadata:
+              labels:
+                kubevirt.io/vm: "{{inputs.parameters.vm-name}}"
+            spec:
+              priorityClassName: lab-test-vm
+              domain:
+                firmware:
+                  bootloader:
+                    efi:
+                      secureBoot: false
+                cpu:
+                  cores: 4
+                memory:
+                  guest: 8Gi
+                devices:
+                  blockMultiQueue: true
+                  rng: {}
+                  disks:
+                  - name: rootdisk
+                    disk:
+                      bus: virtio
+                    bootOrder: 1
+                  - name: cloudinit
+                    disk:
+                      bus: virtio
+                  interfaces:
+                  - name: default
+                    masquerade: {}
+              networks:
+              - name: default
+                pod: {}
+              volumes:
+              - name: rootdisk
+                containerDisk:
+                  image: 192.168.1.102:30500/kde-linux-containerdisk:latest
+              - name: cloudinit
+                cloudInitNoCloud:
+                  userData: |
+                    #cloud-config
+                    users:
+                    - name: bluefin-test
+                      groups: [wheel]
+                      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                      shell: /bin/bash
+                      ssh_authorized_keys:
+                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIkkCyAz7Z1Kk+nUx7K9gKLmeE1ns3jYQ7RMEJx/+PEg bluefin-test-suite@ghost
+
+  - name: wait-for-vm
+    inputs:
+      parameters:
+      - name: vm-name
+      - name: namespace
+    script:
+      image: ghcr.io/projectbluefin/lab-runner:latest
+      command: [bash]
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+      source: |
+        set -euo pipefail
+        exec 3>&1
+        exec 1>&2
+        NS="{{inputs.parameters.namespace}}"
+        VM="{{inputs.parameters.vm-name}}"
+        kubectl wait vmi -n "${NS}" "${VM}" --for=condition=Ready --timeout=900s >&2
+        kubectl get pod -n "${NS}" -l "kubevirt.io/vm=${VM}" \
+          -o jsonpath='{.items[0].status.podIP}' >&3

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -1,0 +1,127 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: run-kde-tests
+  namespace: argo
+  annotations:
+    description: |
+      Runs testsuite's kde-smoke suite against a KDE Linux KubeVirt VM.
+      SSH and WebDriver are forwarded through virtctl; the ISO already ships
+      selenium-webdriver-at-spi, so no prebake or in-VM source build is needed.
+spec:
+  serviceAccountName: argo
+  templates:
+  - name: run-kde-tests
+    inputs:
+      parameters:
+      - name: vm-name
+      - name: vm-namespace
+        value: "kde-test"
+      - name: testsuite-branch
+        value: "main"
+    activeDeadlineSeconds: 3600
+    initContainers:
+    - name: git-sync
+      image: ghcr.io/projectbluefin/lab-runner:latest
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      env:
+      - name: BRANCH
+        value: "{{inputs.parameters.testsuite-branch}}"
+      command: [bash, -c]
+      args:
+      - |
+        set -euo pipefail
+        git clone --depth 1 --branch "${BRANCH}" \
+          https://github.com/projectbluefin/testsuite /workspace/testsuite
+      volumeMounts:
+      - name: workspace
+        mountPath: /workspace
+    container:
+      image: ghcr.io/projectbluefin/lab-runner:latest
+      resources:
+        requests:
+          cpu: "1"
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 2Gi
+      env:
+      - name: VM_NAME
+        value: "{{inputs.parameters.vm-name}}"
+      - name: VM_NS
+        value: "{{inputs.parameters.vm-namespace}}"
+      - name: SSH_KEY
+        value: /etc/ssh/test-key/id_ed25519
+      - name: VM_USER
+        value: bluefin-test
+      - name: IMAGE
+        value: kde-linux
+      - name: VM_HOST
+        value: 127.0.0.1
+      - name: SSH_PORT
+        value: "2222"
+      - name: KDE_WEBDRIVER_URL
+        value: http://127.0.0.1:4723
+      volumeMounts:
+      - name: workspace
+        mountPath: /workspace
+        readOnly: true
+      - name: results
+        mountPath: /results
+      - name: results-store
+        mountPath: /var/mnt/ghost-data/test-results
+      - name: ssh-key
+        mountPath: /etc/ssh/test-key
+        readOnly: true
+      command: [bash, -c]
+      args:
+      - |
+        set -euo pipefail
+        VIRTCTL=/usr/local/bin/virtctl
+        if [[ ! -x "${VIRTCTL}" ]]; then
+          curl --fail --location --retry 3 --output "${VIRTCTL}" \
+            https://github.com/kubevirt/kubevirt/releases/download/v1.8.2/virtctl-v1.8.2-linux-amd64
+          chmod +x "${VIRTCTL}"
+        fi
+        "${VIRTCTL}" port-forward -n "${VM_NS}" "vmi/${VM_NAME}" 2222:22 4723:4723 &
+        PF_PID=$!
+        trap 'kill "${PF_PID}" 2>/dev/null || true' EXIT
+        timeout 600 bash -c '
+          until ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no
+              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10
+              "${VM_USER}@127.0.0.1" true 2>/dev/null; do sleep 5; done'
+        ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
+          'command -v selenium-webdriver-at-spi-run && \
+           nohup selenium-webdriver-at-spi-run \
+             >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &'
+        timeout 120 bash -c 'until curl --fail --silent "${KDE_WEBDRIVER_URL}/status" >/dev/null; do sleep 2; done'
+        cd /workspace/testsuite
+        python3 -m pip install --quiet selenium behave
+        export PYTHONPATH=/workspace/testsuite
+        python3 -m behave tests/kde-smoke/features \
+          --format json.pretty --outfile /results/results.json --no-capture \
+          --tags ~@wip
+        mkdir -p /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke
+        cp /results/results.json \
+          /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke/
+    volumes:
+    - name: workspace
+      emptyDir:
+        sizeLimit: 2Gi
+    - name: ssh-key
+      secret:
+        secretName: bluefin-test-ssh-key
+    - name: results
+      emptyDir:
+        sizeLimit: 1Gi
+    - name: results-store
+      hostPath:
+        path: /var/mnt/ghost-data/test-results
+        type: DirectoryOrCreate

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -160,6 +160,17 @@ persistence, reachability, redeploy, and teardown assertions.
 
 ## Supporting templates (called via `templateRef`)
 
+### `kde-linux-qa`
+
+Downloads the published KDE Linux hybrid ISO pinned by SHA256, wraps it as a
+containerDisk, boots it under KubeVirt OVMF, forwards SSH and port 4723 with
+virtctl, and runs the `testsuite` `kde-smoke` suite. The VM is deleted by the
+mandatory `onExit` teardown.
+
+```
+just run-kde-linux
+```
+
 These are exposed only because they are referenced by the entry points;
 submit them directly only for diagnosis.
 

--- a/docs/skills/argo-workflows/authoring.md
+++ b/docs/skills/argo-workflows/authoring.md
@@ -37,6 +37,12 @@ spec:
 - `serviceAccountName: argo` on every WorkflowTemplate
 - `namespace: argo` always
 - `description:` annotation on every template — one paragraph saying what it does
+- `volumeMounts` for a `script` or `container` belong inside that executor
+  block, while matching `volumes` belong on the surrounding template. Argo's
+  strict decoder rejects executor mounts placed directly on the template.
+- Template names are unique within one WorkflowTemplate. Give an entrypoint
+  and its executable step distinct names (for example, `toggle-testing` and
+  `run-toggle-testing`) rather than reusing the same name.
 
 ### 1b. Debugging a workflow stuck on a dead node
 

--- a/manifests/kde-test-namespace.yaml
+++ b/manifests/kde-test-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kde-test
+  labels:
+    kubernetes.io/metadata.name: kde-test
+    pod-security.kubernetes.io/enforce: baseline


### PR DESCRIPTION
Implements issue #470.

- Pins KDE Linux 202607281716 ISO and verifies SHA256.
- Adds native OVMF/KubeVirt VM provisioning and mandatory teardown.
- Adds KDE WebDriver forwarding and testsuite kde-smoke execution.
- Persists results using the lab test-results convention.

Validation: `argo lint --offline argo/workflow-templates/ argo/kde-linux-qa.yaml`.