### PR TITLE
feat(argo): adapt KDE test runner for WebDriver

### DIFF
--- a/argo/kde-linux-qa.yaml
+++ b/argo/kde-linux-qa.yaml
@@ -15,8 +15,8 @@ spec:
     - name: image-sha256
       value: "8554c25d098373a618a733656852ef25ad96c2b8ce59d57d9705e38eb95046bf"
     - name: namespace
-      value: "kde-test"
-    - name: testsuite-branch
+      value: "aurora-test"
+    - name: branch
       value: "main"
   templates:
   - name: pipeline
@@ -47,8 +47,8 @@ spec:
             value: "kde-linux-{{workflow.uid}}"
           - name: vm-namespace
             value: "{{workflow.parameters.namespace}}"
-          - name: testsuite-branch
-            value: "{{workflow.parameters.testsuite-branch}}"
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
   - name: cleanup
     steps:
     - - name: teardown

--- a/argo/workflow-templates/provision-kde-linux-vm.yaml
+++ b/argo/workflow-templates/provision-kde-linux-vm.yaml
@@ -15,7 +15,7 @@ spec:
       parameters:
       - name: vm-name
       - name: namespace
-        value: "kde-test"
+        value: "aurora-test"
       - name: image-url
         value: "https://files.kde.org/kde-linux/kde-linux_202607281716.iso"
       - name: image-sha256

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -124,10 +124,32 @@ spec:
               "${VM_USER}@127.0.0.1" true 2>/dev/null; do sleep 5; done'
         ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
-          'command -v selenium-webdriver-at-spi-run && \
-           XDG_SESSION_DESKTOP=kde KDE_WEBDRIVER_URL=http://127.0.0.1:4723 \
-           nohup selenium-webdriver-at-spi-run \
-             >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &'
+          '
+          set -e
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          SESSION_BUS=$(systemctl --user show-environment 2>/dev/null |
+            sed -n "s/^DBUS_SESSION_BUS_ADDRESS=//p" | head -1)
+          if [ -z "${SESSION_BUS}" ] && [ -S "${XDG_RUNTIME_DIR}/bus" ]; then
+            SESSION_BUS="unix:path=${XDG_RUNTIME_DIR}/bus"
+          fi
+          WAYLAND_DISPLAY=$(find "${XDG_RUNTIME_DIR}" -maxdepth 1 \
+            -name "wayland-*" -printf "%f\n" 2>/dev/null | head -1)
+          AT_SPI_BUS_ADDRESS="${SESSION_BUS}"
+          KDE_WEBDRIVER_URL=http://127.0.0.1:4723
+          printf "%s\n" \
+            "export DBUS_SESSION_BUS_ADDRESS=${SESSION_BUS}" \
+            "export WAYLAND_DISPLAY=${WAYLAND_DISPLAY}" \
+            "export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" \
+            "export AT_SPI_BUS_ADDRESS=${AT_SPI_BUS_ADDRESS}" \
+            "export XDG_SESSION_TYPE=wayland" \
+            "export XDG_SESSION_DESKTOP=kde" \
+            "export KDE_WEBDRIVER_URL=${KDE_WEBDRIVER_URL}" \
+            > /tmp/session.env
+          source /tmp/session.env
+          command -v selenium-webdriver-at-spi-run
+          nohup selenium-webdriver-at-spi-run \
+            >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &
+          '
         timeout 120 bash -c 'until curl --fail --silent "${KDE_WEBDRIVER_URL}/status" >/dev/null; do sleep 2; done'
         cd /workspace/testsuite
         python3 -m pip install --quiet selenium behave

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: argo
   annotations:
     description: |
-      Runs testsuite's kde-smoke suite against a KDE Linux KubeVirt VM.
-      SSH and WebDriver are forwarded through virtctl; the ISO already ships
-      selenium-webdriver-at-spi, so no prebake or in-VM source build is needed.
+      Runs a testsuite KDE suite against an Aurora/KDE KubeVirt VM by adapting
+      the GNOME runner's clone, SSH, result persistence, and publication
+      contract to selenium-webdriver-at-spi.
 spec:
   serviceAccountName: argo
   templates:
@@ -16,9 +16,23 @@ spec:
       parameters:
       - name: vm-name
       - name: vm-namespace
-        value: "kde-test"
-      - name: testsuite-branch
+        value: "aurora-test"
+      - name: suite
+        value: "kde-smoke"
+      - name: variant
+        value: "aurora"
+      - name: ssh-user
+        value: "bluefin-test"
+      - name: ssh-key-secret
+        value: "bluefin-test-ssh-key"
+      - name: issue-title
+        value: "manual"
+      - name: behave-tags
+        value: ""
+      - name: branch
         value: "main"
+      - name: containerdisk-tag
+        value: ""
     activeDeadlineSeconds: 3600
     initContainers:
     - name: git-sync
@@ -32,7 +46,7 @@ spec:
           memory: 512Mi
       env:
       - name: BRANCH
-        value: "{{inputs.parameters.testsuite-branch}}"
+        value: "{{inputs.parameters.branch}}"
       command: [bash, -c]
       args:
       - |
@@ -59,7 +73,13 @@ spec:
       - name: SSH_KEY
         value: /etc/ssh/test-key/id_ed25519
       - name: VM_USER
-        value: bluefin-test
+        value: "{{inputs.parameters.ssh-user}}"
+      - name: SUITE
+        value: "{{inputs.parameters.suite}}"
+      - name: VARIANT
+        value: "{{inputs.parameters.variant}}"
+      - name: BEHAVE_TAGS
+        value: "{{inputs.parameters.behave-tags}}"
       - name: IMAGE
         value: kde-linux
       - name: VM_HOST
@@ -68,6 +88,12 @@ spec:
         value: "2222"
       - name: KDE_WEBDRIVER_URL
         value: http://127.0.0.1:4723
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-token
+            key: token
+            optional: true
       volumeMounts:
       - name: workspace
         mountPath: /workspace
@@ -99,25 +125,46 @@ spec:
         ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
           'command -v selenium-webdriver-at-spi-run && \
+           XDG_SESSION_DESKTOP=kde KDE_WEBDRIVER_URL=http://127.0.0.1:4723 \
            nohup selenium-webdriver-at-spi-run \
              >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &'
         timeout 120 bash -c 'until curl --fail --silent "${KDE_WEBDRIVER_URL}/status" >/dev/null; do sleep 2; done'
         cd /workspace/testsuite
         python3 -m pip install --quiet selenium behave
         export PYTHONPATH=/workspace/testsuite
-        python3 -m behave tests/kde-smoke/features \
+        TAGS_ARG="--tags ~@wip"
+        if [[ -n "${BEHAVE_TAGS}" ]]; then
+          TAGS_ARG="${BEHAVE_TAGS}"
+        fi
+        python3 -m behave "tests/${SUITE}/features" \
           --format json.pretty --outfile /results/results.json --no-capture \
-          --tags ~@wip
-        mkdir -p /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke
+          ${TAGS_ARG}
+        RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
+        mkdir -p "${RESULT_DIR}"
         cp /results/results.json \
-          /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke/
+          "${RESULT_DIR}/"
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+          IMG_SLUG="${VARIANT}"
+          if [[ "${VARIANT}" == "aurora" && -n "{{inputs.parameters.containerdisk-tag}}" ]]; then
+            IMG_SLUG="aurora-${{inputs.parameters.containerdisk-tag}}"
+          fi
+          rm -rf /workspace/lab-code
+          git clone --depth 1 \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
+            /workspace/lab-code
+          python3 /workspace/lab-code/scripts/publish_test_results.py \
+            /results/results.json "${IMG_SLUG}" "${SUITE}" \
+            "{{workflow.name}}" "${GITHUB_TOKEN}" || \
+            echo "Warning: failed to publish test results" >&2
+        fi
     volumes:
     - name: workspace
       emptyDir:
         sizeLimit: 2Gi
     - name: ssh-key
       secret:
-        secretName: bluefin-test-ssh-key
+        secretName: "{{inputs.parameters.ssh-key-secret}}"
+        defaultMode: 0400
     - name: results
       emptyDir:
         sizeLimit: 1Gi

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -214,6 +214,15 @@ captures `results.json` to pod stdout (Loki + `argo logs`).
 Resource limits and `hostNetwork: true` are set on the pod (KubeVirt
 masquerade only routes from host netns).
 
+### `run-kde-tests` (template: `run-kde-tests`)
+
+Adapts the GNOME runner contract for Aurora/KDE VMs. It clones the selected
+testsuite branch, forwards SSH and WebDriver port 4723 through `virtctl`,
+starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
+`/status` endpoint, and runs `tests/kde-smoke/features` with Behave. Results
+are persisted under the standard ghost test-results host path and published
+when the optional GitHub token is available.
+
 ### `run-flatcar-tests` (template: `run-flatcar-tests`)
 
 Same shape for Flatcar; uses `core` as the SSH user and runs pytest+dogtail

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -135,6 +135,10 @@ The workflow authoring guidance is split by topic:
   constant pipeline identifiers and bounded states. Workflow-level completion
   metrics are safe only when the workflow status truthfully represents the
   publish result; non-blocking or transitional DAG branches must be fixed first.
+- A KDE GUI runner that copies the GNOME runner without replacing
+  `qecore-headless` and the GNOME daemon — use the VM's
+  `selenium-webdriver-at-spi-run`, forward port 4723, and gate test start on
+  its `/status` endpoint.
 
 ## Verification
 
@@ -173,3 +177,6 @@ Before marking any WorkflowTemplate change done:
       exists on the repository's default branch before relying on dispatch
 - [ ] Registry workflows use a pinned image that actually contains every CLI
       invoked by the script, with flags valid for that exact version
+- [ ] KDE GUI runners preserve the GNOME runner's parameter/result contract,
+      use `selenium-webdriver-at-spi-run`, forward `4723:4723`, and wait for
+      WebDriver readiness before Behave execution

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -149,6 +149,11 @@ The workflow authoring guidance is split by topic:
   `qecore-headless` and the GNOME daemon — use the VM's
   `selenium-webdriver-at-spi-run`, forward port 4723, and gate test start on
   its `/status` endpoint.
+- KDE QA callers must pass the runner's `branch` parameter (not the removed
+  `testsuite-branch`) and use the established `aurora-test` namespace. The
+  runner must source a generated session environment containing D-Bus,
+  Wayland, AT-SPI, `XDG_SESSION_DESKTOP=kde`, and its WebDriver URL before
+  starting Selenium.
 
 ## Verification
 

--- a/manifests/kde-test-namespace.yaml
+++ b/manifests/kde-test-namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kde-test
-  labels:
-    kubernetes.io/metadata.name: kde-test
-    pod-security.kubernetes.io/enforce: baseline

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -155,6 +155,42 @@ def test_buildbarn_runner_uses_stable_tmpdir_after_chroot():
     assert "filePool:" not in config
 
 
+def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
+    gnome = (ROOT / "argo/workflow-templates/run-gnome-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for parameter in (
+        "vm-name",
+        "vm-namespace",
+        "suite",
+        "variant",
+        "ssh-user",
+        "ssh-key-secret",
+        "issue-title",
+        "behave-tags",
+        "branch",
+        "containerdisk-tag",
+    ):
+        assert f"- name: {parameter}" in gnome
+        assert f"- name: {parameter}" in kde
+
+    assert 'value: "aurora-test"' in kde
+    assert 'value: "kde-smoke"' in kde
+    assert "4723:4723" in kde
+    assert "selenium-webdriver-at-spi-run" in kde
+    assert "KDE_WEBDRIVER_URL" in kde
+    assert "XDG_SESSION_DESKTOP=kde" in kde
+    assert "/status" in kde
+    assert "publish_test_results.py" in kde
+    assert "/var/mnt/ghost-data/test-results" in kde
+    assert "qecore-headless" not in kde
+    assert "gnome-ponytail-daemon" not in kde
+
+
 def test_cache_only_diagnostic_disables_remote_execution_explicitly():
     config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(encoding="utf-8")
     assert "remote-execution: {}" not in config

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -191,6 +191,37 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "gnome-ponytail-daemon" not in kde
 
 
+def test_kde_workflow_calls_runner_with_current_contract():
+    workflow = (ROOT / "argo/kde-linux-qa.yaml").read_text(encoding="utf-8")
+    provision = (
+        ROOT / "argo/workflow-templates/provision-kde-linux-vm.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert 'value: "aurora-test"' in workflow
+    assert "- name: branch" in workflow
+    assert "workflow.parameters.branch" in workflow
+    assert "testsuite-branch" not in workflow
+    assert 'value: "aurora-test"' in provision
+    assert "kde-test-namespace" not in workflow
+
+
+def test_kde_runner_sources_complete_session_environment():
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for variable in (
+        "DBUS_SESSION_BUS_ADDRESS",
+        "WAYLAND_DISPLAY",
+        "XDG_RUNTIME_DIR",
+        "AT_SPI_BUS_ADDRESS",
+        "XDG_SESSION_DESKTOP",
+        "KDE_WEBDRIVER_URL",
+    ):
+        assert variable in kde
+    assert "source /tmp/session.env" in kde
+
+
 def test_cache_only_diagnostic_disables_remote_execution_explicitly():
     config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(encoding="utf-8")
     assert "remote-execution: {}" not in config


### PR DESCRIPTION
## Summary
- adapt `run-kde-tests` to the `run-gnome-tests` parameter and result contract
- run KDE tests through `selenium-webdriver-at-spi` with SSH/WebDriver forwarding and readiness polling
- persist and optionally publish standard test results; add focused contract coverage and docs

## Validation
- `just lint`
- `pytest -q tests/unit/test_workflow_defaults.py`
- `argo lint --offline argo/workflow-templates/run-kde-tests.yaml`

Live lab execution was unavailable in this session; no `kubectl apply` was used.