### PR TITLE
feat(argo): add Aurora KDE QA pipeline

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -142,6 +142,12 @@ run-kde-linux:
         -n {{ argo_ns }} \
         --watch
 
+# Run the mandatory red-path proof for the Aurora/KDE gate.
+run-aurora-kde-sabotage:
+    argo submit argo/aurora-kde-sabotage.yaml \
+        -n {{ argo_ns }} \
+        --watch
+
 # ── Observation ─────────────────────────────────────────────────────────────
 
 # List all test workflows

--- a/Justfile
+++ b/Justfile
@@ -148,6 +148,11 @@ run-aurora-kde-sabotage:
         -n {{ argo_ns }} \
         --watch
 
+# Evaluate the rolling KDE soak window. A qualified result still needs human
+# approval before the suite is promoted to CI gating.
+evaluate-kde-soak:
+    python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-smoke.json
+
 # ── Observation ─────────────────────────────────────────────────────────────
 
 # List all test workflows

--- a/argo/aurora-kde-sabotage.yaml
+++ b/argo/aurora-kde-sabotage.yaml
@@ -1,0 +1,127 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: aurora-kde-sabotage-
+  namespace: argo
+  annotations:
+    description: |
+      Mandatory Aurora/KDE gate proof. Runs the real kde-smoke suite twice,
+      first with a nonexistent launch binary and then with plasmashell killed.
+      Both runs must fail, publish red results, retain KDE faillogs, and clean
+      up the ephemeral VM.
+spec:
+  entrypoint: pipeline
+  serviceAccountName: argo
+  activeDeadlineSeconds: 5400
+  onExit: cleanup
+  arguments:
+    parameters:
+    - name: vm-name
+      value: "aurora-kde-sabotage-{{workflow.uid}}"
+    - name: namespace
+      value: "aurora-test"
+    - name: image-tag
+      value: "testing"
+    - name: branch
+      value: "main"
+  templates:
+  - name: pipeline
+    synchronization:
+      semaphores:
+      - configMapKeyRef:
+          name: workflow-semaphores
+          key: aurora-vm-qa
+    dag:
+      tasks:
+      - name: build
+        templateRef:
+          name: build-bluefin-migration-containerdisk
+          template: build-containerdisk
+        arguments:
+          parameters:
+          - name: image
+            value: ghcr.io/ublue-os/aurora
+          - name: image-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: containerdisk-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: disk-size
+            value: 30G
+          - name: containerdisk-repo
+            value: aurora-containerdisk
+          - name: prebake-kde-webdriver
+            value: "true"
+          - name: force
+            value: "true"
+      - name: provision
+        depends: build.Succeeded
+        templateRef:
+          name: provision-containerdisk-vm
+          template: provision-vm
+        arguments:
+          parameters:
+          - name: image-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: vm-name
+            value: "{{workflow.parameters.vm-name}}"
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: containerdisk-repo
+            value: aurora-containerdisk
+          - name: app-label
+            value: aurora-test
+          - name: label-prefix
+            value: aurora.io
+      - name: missing-binary
+        depends: provision.Succeeded
+        templateRef:
+          name: run-kde-tests
+          template: run-kde-tests
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "{{workflow.parameters.vm-name}}"
+          - name: vm-namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: variant
+            value: aurora
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
+          - name: containerdisk-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: sabotage-mode
+            value: missing-binary
+      - name: kill-plasmashell
+        depends: "(missing-binary.Succeeded || missing-binary.Failed || missing-binary.Errored)"
+        templateRef:
+          name: run-kde-tests
+          template: run-kde-tests
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "{{workflow.parameters.vm-name}}"
+          - name: vm-namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: variant
+            value: aurora
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
+          - name: containerdisk-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: sabotage-mode
+            value: kill-plasmashell
+  - name: cleanup
+    script:
+      image: cgr.dev/chainguard/kubectl:latest-dev
+      command: [bash]
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+      source: |
+        set -euo pipefail
+        kubectl delete vm "{{workflow.parameters.vm-name}}" \
+          -n "{{workflow.parameters.namespace}}" --ignore-not-found

--- a/argo/kde-linux-qa.yaml
+++ b/argo/kde-linux-qa.yaml
@@ -15,8 +15,8 @@ spec:
     - name: image-sha256
       value: "8554c25d098373a618a733656852ef25ad96c2b8ce59d57d9705e38eb95046bf"
     - name: namespace
-      value: "kde-test"
-    - name: testsuite-branch
+      value: "aurora-test"
+    - name: branch
       value: "main"
   templates:
   - name: pipeline
@@ -47,8 +47,8 @@ spec:
             value: "kde-linux-{{workflow.uid}}"
           - name: vm-namespace
             value: "{{workflow.parameters.namespace}}"
-          - name: testsuite-branch
-            value: "{{workflow.parameters.testsuite-branch}}"
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
   - name: cleanup
     steps:
     - - name: teardown

--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -1,0 +1,149 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: aurora-qa-pipeline
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: qa-pipeline
+    app.kubernetes.io/part-of: aurora-test-suite
+  annotations:
+    description: |
+      VM-based Aurora/KDE QA pipeline: build an Aurora containerDisk, provision
+      a KubeVirt VM, run KDE GUI tests, collect VM logs, and always tear down
+      the VM when the workflow completes.
+spec:
+  serviceAccountName: argo
+  entrypoint: aurora-qa
+  onExit: teardown
+  activeDeadlineSeconds: 3600
+  volumeClaimGC:
+    strategy: OnWorkflowCompletion
+  volumeClaimTemplates:
+    - metadata:
+        name: staging
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 100Gi
+  arguments:
+    parameters:
+      - name: image-tag
+        value: testing
+      - name: vm-name
+        value: aurora-qa-{{workflow.uid}}
+      - name: namespace
+        value: aurora-test
+      - name: containerdisk-repo
+        value: aurora-containerdisk
+      - name: disk-size
+        value: 30G
+      - name: suite
+        value: kde-smoke
+      - name: branch
+        value: main
+      - name: ssh-user
+        value: bluefin-test
+      - name: ssh-key-secret
+        value: bluefin-test-ssh-key
+  templates:
+    - name: aurora-qa
+      synchronization:
+        semaphores:
+          - configMapKeyRef:
+              name: workflow-semaphores
+              key: aurora-vm-qa
+      dag:
+        tasks:
+          - name: build-aurora-containerdisk
+            templateRef:
+              name: build-bluefin-migration-containerdisk
+              template: build-containerdisk
+            arguments:
+              parameters:
+                - name: image
+                  value: ghcr.io/ublue-os/aurora
+                - name: image-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: containerdisk-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: disk-size
+                  value: "{{workflow.parameters.disk-size}}"
+                - name: containerdisk-repo
+                  value: "{{workflow.parameters.containerdisk-repo}}"
+                - name: prebake-kde-webdriver
+                  value: "true"
+                - name: force
+                  value: "true"
+          - name: provision-containerdisk-vm
+            depends: build-aurora-containerdisk.Succeeded
+            templateRef:
+              name: provision-containerdisk-vm
+              template: provision-vm
+            arguments:
+              parameters:
+                - name: image-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: namespace
+                  value: "{{workflow.parameters.namespace}}"
+                - name: containerdisk-repo
+                  value: "{{workflow.parameters.containerdisk-repo}}"
+                - name: app-label
+                  value: aurora-test
+                - name: label-prefix
+                  value: aurora.io
+          - name: run-kde-tests
+            depends: provision-containerdisk-vm.Succeeded
+            templateRef:
+              name: run-kde-tests
+              template: run-kde-tests
+            arguments:
+              parameters:
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: vm-namespace
+                  value: "{{workflow.parameters.namespace}}"
+                - name: suite
+                  value: "{{workflow.parameters.suite}}"
+                - name: variant
+                  value: aurora
+                - name: ssh-user
+                  value: "{{workflow.parameters.ssh-user}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+                - name: containerdisk-tag
+                  value: "{{workflow.parameters.image-tag}}"
+          - name: collect-logs
+            depends: "(run-kde-tests.Succeeded || run-kde-tests.Failed)"
+            templateRef:
+              name: collect-vm-logs
+              template: collect-vm-logs
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{tasks.provision-containerdisk-vm.outputs.parameters.vm-ip}}"
+                - name: variant
+                  value: aurora:testing
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: ssh-user
+                  value: "{{workflow.parameters.ssh-user}}"
+    - name: teardown
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        source: |
+          set -e
+          kubectl delete vm "{{workflow.parameters.vm-name}}" \
+            -n "{{workflow.parameters.namespace}}" --ignore-not-found

--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -36,6 +36,8 @@ spec:
         value: aurora-test
       - name: containerdisk-repo
         value: aurora-containerdisk
+      - name: sabotage-mode
+        value: none
       - name: disk-size
         value: 30G
       - name: suite
@@ -99,6 +101,8 @@ spec:
                   value: "{{workflow.parameters.branch}}"
                 - name: containerdisk-tag
                   value: "{{workflow.parameters.image-tag}}"
+                - name: sabotage-mode
+                  value: "{{workflow.parameters.sabotage-mode}}"
           - name: collect-logs
             depends: "(run-kde-tests.Succeeded || run-kde-tests.Failed || run-kde-tests.Errored)"
             templateRef:

--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -56,25 +56,7 @@ spec:
       dag:
         tasks:
           - name: build-aurora-containerdisk
-            templateRef:
-              name: build-bluefin-migration-containerdisk
-              template: build-containerdisk
-            arguments:
-              parameters:
-                - name: image
-                  value: ghcr.io/ublue-os/aurora
-                - name: image-tag
-                  value: "{{workflow.parameters.image-tag}}"
-                - name: containerdisk-tag
-                  value: "{{workflow.parameters.image-tag}}"
-                - name: disk-size
-                  value: "{{workflow.parameters.disk-size}}"
-                - name: containerdisk-repo
-                  value: "{{workflow.parameters.containerdisk-repo}}"
-                - name: prebake-kde-webdriver
-                  value: "true"
-                - name: force
-                  value: "true"
+            template: build-aurora-containerdisk
           - name: provision-containerdisk-vm
             depends: build-aurora-containerdisk.Succeeded
             templateRef:
@@ -118,7 +100,7 @@ spec:
                 - name: containerdisk-tag
                   value: "{{workflow.parameters.image-tag}}"
           - name: collect-logs
-            depends: "(run-kde-tests.Succeeded || run-kde-tests.Failed)"
+            depends: "(run-kde-tests.Succeeded || run-kde-tests.Failed || run-kde-tests.Errored)"
             templateRef:
               name: collect-vm-logs
               template: collect-vm-logs
@@ -132,6 +114,33 @@ spec:
                   value: "{{workflow.parameters.ssh-key-secret}}"
                 - name: ssh-user
                   value: "{{workflow.parameters.ssh-user}}"
+    - name: build-aurora-containerdisk
+      synchronization:
+        semaphores:
+          - configMapKeyRef:
+              name: workflow-semaphores
+              key: migration-containerdisk-build
+      steps:
+        - - name: build
+            templateRef:
+              name: build-bluefin-migration-containerdisk
+              template: build-containerdisk
+            arguments:
+              parameters:
+                - name: image
+                  value: ghcr.io/ublue-os/aurora
+                - name: image-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: containerdisk-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: disk-size
+                  value: "{{workflow.parameters.disk-size}}"
+                - name: containerdisk-repo
+                  value: "{{workflow.parameters.containerdisk-repo}}"
+                - name: prebake-kde-webdriver
+                  value: "true"
+                - name: force
+                  value: "true"
     - name: teardown
       script:
         image: cgr.dev/chainguard/kubectl:latest-dev

--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -38,6 +38,10 @@ spec:
         value: aurora-containerdisk
       - name: sabotage-mode
         value: none
+      - name: failure-class
+        value: test
+      - name: failure-issue-url
+        value: ""
       - name: disk-size
         value: 30G
       - name: suite
@@ -103,6 +107,10 @@ spec:
                   value: "{{workflow.parameters.image-tag}}"
                 - name: sabotage-mode
                   value: "{{workflow.parameters.sabotage-mode}}"
+                - name: failure-class
+                  value: "{{workflow.parameters.failure-class}}"
+                - name: failure-issue-url
+                  value: "{{workflow.parameters.failure-issue-url}}"
           - name: collect-logs
             depends: "(run-kde-tests.Succeeded || run-kde-tests.Failed || run-kde-tests.Errored)"
             templateRef:

--- a/argo/workflow-templates/provision-kde-linux-vm.yaml
+++ b/argo/workflow-templates/provision-kde-linux-vm.yaml
@@ -15,7 +15,7 @@ spec:
       parameters:
       - name: vm-name
       - name: namespace
-        value: "kde-test"
+        value: "aurora-test"
       - name: image-url
         value: "https://files.kde.org/kde-linux/kde-linux_202607281716.iso"
       - name: image-sha256

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -175,11 +175,17 @@ spec:
           echo "Warning: failed to collect in-guest KDE artifacts" >&2
 
         # Keep both the directory and a portable tarball for each kde_faillog
-        # bundle produced by the testsuite failure hook.
+        # bundle produced by the testsuite failure hook. lab-runner does not
+        # provide tar, so use the guaranteed Python standard library tool.
+        ARTIFACT_RC=0
         while IFS= read -r -d '' bundle; do
-          tar -czf "${bundle}.tar.gz" -C "$(dirname "${bundle}")" \
-            "$(basename "${bundle}")" || \
-            echo "Warning: failed to archive ${bundle}" >&2
+          if ! (
+            cd "$(dirname "${bundle}")" &&
+            python3 -m tarfile -c "${bundle}.tar.gz" "$(basename "${bundle}")"
+          ); then
+            echo "ERROR: failed to archive KDE failure bundle ${bundle}" >&2
+            ARTIFACT_RC=1
+          fi
         done < <(find /tmp/results -type d -name 'faillog_*' -print0)
 
         RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
@@ -238,6 +244,10 @@ spec:
           echo "No GITHUB_TOKEN - skipping test results publication" >&2
         fi
 
+        if [[ "${ARTIFACT_RC}" -ne 0 ]]; then
+          echo "ERROR: one or more KDE failure bundles could not be archived" >&2
+          exit "${ARTIFACT_RC}"
+        fi
         exit "${BEHAVE_RC}"
     volumes:
     - name: workspace

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -133,12 +133,15 @@ spec:
         value: http://127.0.0.1:4723
       - name: SABOTAGE_MODE
         value: "{{inputs.parameters.sabotage-mode}}"
+      - name: FAILURE_CLASS
+        value: "{{inputs.parameters.failure-class}}"
+      - name: FAILURE_ISSUE_URL
+        value: "{{inputs.parameters.failure-issue-url}}"
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
             name: github-token
             key: token
-            optional: true
       volumeMounts:
       - name: workspace
         mountPath: /workspace
@@ -154,6 +157,12 @@ spec:
       args:
       - |
         set -euo pipefail
+        for tool in bash curl find git python3 scp ssh timeout; do
+          command -v "${tool}" >/dev/null ||
+            { echo "Required tool is missing: ${tool}" >&2; exit 2; }
+        done
+        [[ -n "${GITHUB_TOKEN:-}" ]] ||
+          { echo "Required credential is missing: GITHUB_TOKEN" >&2; exit 2; }
         mkdir -p /tmp/results
         VIRTCTL=/usr/local/bin/virtctl
         if [[ ! -x "${VIRTCTL}" ]]; then
@@ -236,15 +245,17 @@ spec:
 
         # KDE's failure hook writes screenshots and diagnostic directories inside
         # the guest session. Copy them back even when Behave reports failures.
-        scp -i "${SSH_KEY}" -P 2222 -o StrictHostKeyChecking=no \
+        ARTIFACT_RC=0
+        if ! scp -i "${SSH_KEY}" -P 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null -r \
-          "${VM_USER}@127.0.0.1:/tmp/results/." /tmp/results/ || \
-          echo "Warning: failed to collect in-guest KDE artifacts" >&2
+          "${VM_USER}@127.0.0.1:/tmp/results/." /tmp/results/; then
+          echo "ERROR: failed to collect in-guest KDE artifacts" >&2
+          ARTIFACT_RC=1
+        fi
 
         # Keep both the directory and a portable tarball for each kde_faillog
         # bundle produced by the testsuite failure hook. lab-runner does not
         # provide tar, so use the guaranteed Python standard library tool.
-        ARTIFACT_RC=0
         while IFS= read -r -d '' bundle; do
           if ! (
             cd "$(dirname "${bundle}")" &&
@@ -257,9 +268,18 @@ spec:
 
         RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
         mkdir -p "${RESULT_DIR}"
-        cp -r /tmp/results/. "${RESULT_DIR}/" 2>/dev/null || true
+        if ! cp -r /tmp/results/. "${RESULT_DIR}/"; then
+          echo "ERROR: failed to persist KDE results to ${RESULT_DIR}" >&2
+          ARTIFACT_RC=1
+        fi
         if [[ -f /results/results.json ]]; then
-          cp /results/results.json "${RESULT_DIR}/"
+          if ! cp /results/results.json "${RESULT_DIR}/"; then
+            echo "ERROR: failed to persist results.json to ${RESULT_DIR}" >&2
+            ARTIFACT_RC=1
+          fi
+        else
+          echo "ERROR: Behave did not produce /results/results.json" >&2
+          ARTIFACT_RC=1
         fi
         echo "Results and KDE artifacts saved to ${RESULT_DIR}" >&2
 
@@ -272,33 +292,42 @@ spec:
         # the dashboard. KubeVirt's virt-launcher exposes no QEMU monitor, so
         # QEMU-level screendumps are intentionally not part of this workflow.
         SHOT=$(find /tmp/results -type f -name '*.png' -print -quit)
-        if [[ -n "${SHOT}" && -f "${SHOT}" && -n "${GITHUB_TOKEN:-}" ]]; then
+        if [[ -z "${SHOT}" || ! -f "${SHOT}" ]]; then
+          echo "ERROR: KDE test did not produce a screenshot artifact" >&2
+          ARTIFACT_RC=1
+        else
           ORAS_BIN=/workspace/oras-bin/oras
           if [[ ! -x "${ORAS_BIN}" ]]; then
             mkdir -p "$(dirname "${ORAS_BIN}")"
+            ORAS_ARCHIVE=/workspace/oras-bin/oras.tar.gz
             curl --fail --silent --show-error --location \
-              "https://github.com/oras-project/oras/releases/download/v1.2.3/oras_1.2.3_linux_amd64.tar.gz" |
-              tar -xz -C "$(dirname "${ORAS_BIN}")" oras || \
-              echo "Warning: failed to install oras" >&2
+              --output "${ORAS_ARCHIVE}" \
+              "https://github.com/oras-project/oras/releases/download/v1.2.3/oras_1.2.3_linux_amd64.tar.gz"
+            python3 -m tarfile -e "${ORAS_ARCHIVE}" "$(dirname "${ORAS_BIN}")"
+            rm -f "${ORAS_ARCHIVE}"
           fi
-          if [[ -x "${ORAS_BIN}" ]]; then
+          if ! {
+            if [[ ! -x "${ORAS_BIN}" ]]; then
+              echo "Required tool is unavailable: ${ORAS_BIN}" >&2
+              false
+            fi
             export PATH="$(dirname "${ORAS_BIN}"):${PATH}"
             SCREENSHOT_IMAGE="ghcr.io/projectbluefin/testsuite/desktop-screenshot"
             PUSH_TAG="${IMG_SLUG}-${SUITE}-latest"
             echo "${GITHUB_TOKEN}" | oras login ghcr.io \
-              -u github-actions --password-stdin || \
-              echo "Warning: failed to authenticate oras to GHCR" >&2
+              -u github-actions --password-stdin
             oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
               --annotation "org.opencontainers.image.description=Bluefin KDE desktop screenshot from lab e2e suite: ${SUITE}" \
               --annotation "io.github.projectbluefin.caller_repo=projectbluefin/lab" \
-              "${SHOT}:image/png" || \
-              echo "Warning: failed to push KDE screenshot" >&2
+              "${SHOT}:image/png"
+          }; then
+            echo "ERROR: failed to publish KDE screenshot artifact" >&2
+            ARTIFACT_RC=1
           fi
-        elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
-          echo "No GITHUB_TOKEN - skipping GHCR screenshot push" >&2
         fi
 
-        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        PUBLISH_RC=0
+        if ! {
           rm -rf /workspace/lab-code
           git clone --depth 1 \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
@@ -306,15 +335,18 @@ spec:
           python3 /workspace/lab-code/scripts/publish_test_results.py \
             /results/results.json "${IMG_SLUG}" "${SUITE}" \
             "{{workflow.name}}" "${GITHUB_TOKEN}" "" \
-            "${FAILURE_CLASS}" "${FAILURE_ISSUE_URL}" || \
-            echo "Warning: failed to publish test results" >&2
-        else
-          echo "No GITHUB_TOKEN - skipping test results publication" >&2
+            "${FAILURE_CLASS}" "${FAILURE_ISSUE_URL}"
+        }; then
+          echo "ERROR: failed to publish KDE test results" >&2
+          PUBLISH_RC=1
         fi
 
         if [[ "${ARTIFACT_RC}" -ne 0 ]]; then
-          echo "ERROR: one or more KDE failure bundles could not be archived" >&2
+          echo "ERROR: KDE evidence artifacts were not fully retained" >&2
           exit "${ARTIFACT_RC}"
+        fi
+        if [[ "${PUBLISH_RC}" -ne 0 ]]; then
+          exit "${PUBLISH_RC}"
         fi
         if [[ "${SABOTAGE_MODE}" != "none" && "${BEHAVE_RC}" -eq 0 ]]; then
           echo "SABOTAGE FAILURE: ${SABOTAGE_MODE} unexpectedly passed" >&2

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -35,6 +35,12 @@ spec:
         value: ""
       - name: sabotage-mode
         value: "none"
+      - name: failure-class
+        value: "test"
+      - name: failure-issue-url
+        value: ""
+      - name: behave-retries
+        value: "2"
     activeDeadlineSeconds: 3600
     initContainers:
     - name: git-sync
@@ -51,10 +57,29 @@ spec:
         value: "{{inputs.parameters.branch}}"
       - name: SABOTAGE_MODE
         value: "{{inputs.parameters.sabotage-mode}}"
+      - name: BEHAVE_RETRIES
+        value: "{{inputs.parameters.behave-retries}}"
+      - name: FAILURE_CLASS
+        value: "{{inputs.parameters.failure-class}}"
+      - name: FAILURE_ISSUE_URL
+        value: "{{inputs.parameters.failure-issue-url}}"
       command: [bash, -c]
       args:
       - |
         set -euo pipefail
+        case "${FAILURE_CLASS}" in
+          test) ;;
+          infra)
+            [[ -n "${FAILURE_ISSUE_URL}" ]] ||
+              { echo "Infra failures require a filed issue URL" >&2; exit 2; }
+            ;;
+          *)
+            echo "Unsupported failure class: ${FAILURE_CLASS}" >&2
+            exit 2
+            ;;
+        esac
+        [[ "${BEHAVE_RETRIES}" == "2" ]] ||
+          { echo "KDE soak runs require BEHAVE_RETRIES=2" >&2; exit 2; }
         git clone --depth 1 --branch "${BRANCH}" \
           https://github.com/projectbluefin/testsuite /workspace/testsuite
         case "${SABOTAGE_MODE}" in
@@ -178,6 +203,7 @@ spec:
         python3 -m pip install --quiet selenium behave
         export PYTHONPATH=/workspace/testsuite
         export TESTSUITE_RESULTS_DIR=/tmp/results
+        export BEHAVE_RETRIES=2
         case "${SABOTAGE_MODE}" in
           none) ;;
           missing-binary)
@@ -279,7 +305,8 @@ spec:
             /workspace/lab-code
           python3 /workspace/lab-code/scripts/publish_test_results.py \
             /results/results.json "${IMG_SLUG}" "${SUITE}" \
-            "{{workflow.name}}" "${GITHUB_TOKEN}" || \
+            "{{workflow.name}}" "${GITHUB_TOKEN}" "" \
+            "${FAILURE_CLASS}" "${FAILURE_ISSUE_URL}" || \
             echo "Warning: failed to publish test results" >&2
         else
           echo "No GITHUB_TOKEN - skipping test results publication" >&2

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -109,6 +109,7 @@ spec:
       args:
       - |
         set -euo pipefail
+        mkdir -p /tmp/results
         VIRTCTL=/usr/local/bin/virtctl
         if [[ ! -x "${VIRTCTL}" ]]; then
           curl --fail --location --retry 3 --output "${VIRTCTL}" \
@@ -144,7 +145,9 @@ spec:
             "export XDG_SESSION_TYPE=wayland" \
             "export XDG_SESSION_DESKTOP=kde" \
             "export KDE_WEBDRIVER_URL=${KDE_WEBDRIVER_URL}" \
+            "export TESTSUITE_RESULTS_DIR=/tmp/results" \
             > /tmp/session.env
+          mkdir -p /tmp/results
           source /tmp/session.env
           command -v selenium-webdriver-at-spi-run
           nohup selenium-webdriver-at-spi-run \
@@ -154,22 +157,75 @@ spec:
         cd /workspace/testsuite
         python3 -m pip install --quiet selenium behave
         export PYTHONPATH=/workspace/testsuite
+        export TESTSUITE_RESULTS_DIR=/tmp/results
         TAGS_ARG="--tags ~@wip"
         if [[ -n "${BEHAVE_TAGS}" ]]; then
           TAGS_ARG="${BEHAVE_TAGS}"
         fi
+        BEHAVE_RC=0
         python3 -m behave "tests/${SUITE}/features" \
           --format json.pretty --outfile /results/results.json --no-capture \
-          ${TAGS_ARG}
+          ${TAGS_ARG} || BEHAVE_RC=$?
+
+        # KDE's failure hook writes screenshots and diagnostic directories inside
+        # the guest session. Copy them back even when Behave reports failures.
+        scp -i "${SSH_KEY}" -P 2222 -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null -r \
+          "${VM_USER}@127.0.0.1:/tmp/results/." /tmp/results/ || \
+          echo "Warning: failed to collect in-guest KDE artifacts" >&2
+
+        # Keep both the directory and a portable tarball for each kde_faillog
+        # bundle produced by the testsuite failure hook.
+        while IFS= read -r -d '' bundle; do
+          tar -czf "${bundle}.tar.gz" -C "$(dirname "${bundle}")" \
+            "$(basename "${bundle}")" || \
+            echo "Warning: failed to archive ${bundle}" >&2
+        done < <(find /tmp/results -type d -name 'faillog_*' -print0)
+
         RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
         mkdir -p "${RESULT_DIR}"
-        cp /results/results.json \
-          "${RESULT_DIR}/"
-        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-          IMG_SLUG="${VARIANT}"
-          if [[ "${VARIANT}" == "aurora" && -n "{{inputs.parameters.containerdisk-tag}}" ]]; then
-            IMG_SLUG="aurora-${{inputs.parameters.containerdisk-tag}}"
+        cp -r /tmp/results/. "${RESULT_DIR}/" 2>/dev/null || true
+        if [[ -f /results/results.json ]]; then
+          cp /results/results.json "${RESULT_DIR}/"
+        fi
+        echo "Results and KDE artifacts saved to ${RESULT_DIR}" >&2
+
+        IMG_SLUG="${VARIANT}"
+        if [[ "${VARIANT}" == "aurora" && -n "{{inputs.parameters.containerdisk-tag}}" ]]; then
+          IMG_SLUG="aurora-${{inputs.parameters.containerdisk-tag}}"
+        fi
+
+        # Push the first in-guest screenshot as the stable OCI artifact used by
+        # the dashboard. KubeVirt's virt-launcher exposes no QEMU monitor, so
+        # QEMU-level screendumps are intentionally not part of this workflow.
+        SHOT=$(find /tmp/results -type f -name '*.png' -print -quit)
+        if [[ -n "${SHOT}" && -f "${SHOT}" && -n "${GITHUB_TOKEN:-}" ]]; then
+          ORAS_BIN=/workspace/oras-bin/oras
+          if [[ ! -x "${ORAS_BIN}" ]]; then
+            mkdir -p "$(dirname "${ORAS_BIN}")"
+            curl --fail --silent --show-error --location \
+              "https://github.com/oras-project/oras/releases/download/v1.2.3/oras_1.2.3_linux_amd64.tar.gz" |
+              tar -xz -C "$(dirname "${ORAS_BIN}")" oras || \
+              echo "Warning: failed to install oras" >&2
           fi
+          if [[ -x "${ORAS_BIN}" ]]; then
+            export PATH="$(dirname "${ORAS_BIN}"):${PATH}"
+            SCREENSHOT_IMAGE="ghcr.io/projectbluefin/testsuite/desktop-screenshot"
+            PUSH_TAG="${IMG_SLUG}-${SUITE}-latest"
+            echo "${GITHUB_TOKEN}" | oras login ghcr.io \
+              -u github-actions --password-stdin || \
+              echo "Warning: failed to authenticate oras to GHCR" >&2
+            oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
+              --annotation "org.opencontainers.image.description=Bluefin KDE desktop screenshot from lab e2e suite: ${SUITE}" \
+              --annotation "io.github.projectbluefin.caller_repo=projectbluefin/lab" \
+              "${SHOT}:image/png" || \
+              echo "Warning: failed to push KDE screenshot" >&2
+          fi
+        elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
+          echo "No GITHUB_TOKEN - skipping GHCR screenshot push" >&2
+        fi
+
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
           rm -rf /workspace/lab-code
           git clone --depth 1 \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
@@ -178,7 +234,11 @@ spec:
             /results/results.json "${IMG_SLUG}" "${SUITE}" \
             "{{workflow.name}}" "${GITHUB_TOKEN}" || \
             echo "Warning: failed to publish test results" >&2
+        else
+          echo "No GITHUB_TOKEN - skipping test results publication" >&2
         fi
+
+        exit "${BEHAVE_RC}"
     volumes:
     - name: workspace
       emptyDir:

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -124,10 +124,32 @@ spec:
               "${VM_USER}@127.0.0.1" true 2>/dev/null; do sleep 5; done'
         ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
-          'command -v selenium-webdriver-at-spi-run && \
-           XDG_SESSION_DESKTOP=kde KDE_WEBDRIVER_URL=http://127.0.0.1:4723 \
-           nohup selenium-webdriver-at-spi-run \
-             >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &'
+          '
+          set -e
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          SESSION_BUS=$(systemctl --user show-environment 2>/dev/null |
+            sed -n "s/^DBUS_SESSION_BUS_ADDRESS=//p" | head -1)
+          if [ -z "${SESSION_BUS}" ] && [ -S "${XDG_RUNTIME_DIR}/bus" ]; then
+            SESSION_BUS="unix:path=${XDG_RUNTIME_DIR}/bus"
+          fi
+          WAYLAND_DISPLAY=$(find "${XDG_RUNTIME_DIR}" -maxdepth 1 \
+            -name "wayland-*" -printf "%f\n" 2>/dev/null | head -1)
+          AT_SPI_BUS_ADDRESS="${SESSION_BUS}"
+          KDE_WEBDRIVER_URL=http://127.0.0.1:4723
+          printf "%s\n" \
+            "export DBUS_SESSION_BUS_ADDRESS=${SESSION_BUS}" \
+            "export WAYLAND_DISPLAY=${WAYLAND_DISPLAY}" \
+            "export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" \
+            "export AT_SPI_BUS_ADDRESS=${AT_SPI_BUS_ADDRESS}" \
+            "export XDG_SESSION_TYPE=wayland" \
+            "export XDG_SESSION_DESKTOP=kde" \
+            "export KDE_WEBDRIVER_URL=${KDE_WEBDRIVER_URL}" \
+            > /tmp/session.env
+          source /tmp/session.env
+          command -v selenium-webdriver-at-spi-run
+          nohup selenium-webdriver-at-spi-run \
+            >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &
+          '
         timeout 120 bash -c 'until curl --fail --silent "${KDE_WEBDRIVER_URL}/status" >/dev/null; do sleep 2; done'
         cd /workspace/testsuite
         python3 -m pip install --quiet selenium behave

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -33,6 +33,8 @@ spec:
         value: "main"
       - name: containerdisk-tag
         value: ""
+      - name: sabotage-mode
+        value: "none"
     activeDeadlineSeconds: 3600
     initContainers:
     - name: git-sync
@@ -47,12 +49,28 @@ spec:
       env:
       - name: BRANCH
         value: "{{inputs.parameters.branch}}"
+      - name: SABOTAGE_MODE
+        value: "{{inputs.parameters.sabotage-mode}}"
       command: [bash, -c]
       args:
       - |
         set -euo pipefail
         git clone --depth 1 --branch "${BRANCH}" \
           https://github.com/projectbluefin/testsuite /workspace/testsuite
+        case "${SABOTAGE_MODE}" in
+          none) ;;
+          missing-binary)
+            sed -i '0,/Launch "kcmshell6 kcm_autostart"/s//Launch "\/usr\/bin\/this-does-not-exist kcm_autostart"/' \
+              /workspace/testsuite/tests/kde-smoke/features/kde_smoke.feature
+            grep -q '/usr/bin/this-does-not-exist' \
+              /workspace/testsuite/tests/kde-smoke/features/kde_smoke.feature
+            ;;
+          kill-plasmashell) ;;
+          *)
+            echo "Unsupported sabotage mode: ${SABOTAGE_MODE}" >&2
+            exit 2
+            ;;
+        esac
       volumeMounts:
       - name: workspace
         mountPath: /workspace
@@ -88,6 +106,8 @@ spec:
         value: "2222"
       - name: KDE_WEBDRIVER_URL
         value: http://127.0.0.1:4723
+      - name: SABOTAGE_MODE
+        value: "{{inputs.parameters.sabotage-mode}}"
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
@@ -158,6 +178,27 @@ spec:
         python3 -m pip install --quiet selenium behave
         export PYTHONPATH=/workspace/testsuite
         export TESTSUITE_RESULTS_DIR=/tmp/results
+        case "${SABOTAGE_MODE}" in
+          none) ;;
+          missing-binary)
+            [[ "${VM_NS}" == "aurora-test" ]] ||
+              { echo "Refusing sabotage outside aurora-test" >&2; exit 2; }
+            ;;
+          kill-plasmashell)
+            [[ "${VM_NS}" == "aurora-test" ]] ||
+              { echo "Refusing sabotage outside aurora-test" >&2; exit 2; }
+            ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
+              'pgrep -x plasmashell'
+            ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
+              'pkill -x plasmashell'
+            ;;
+          *)
+            echo "Unsupported sabotage mode: ${SABOTAGE_MODE}" >&2
+            exit 2
+            ;;
+        esac
         TAGS_ARG="--tags ~@wip"
         if [[ -n "${BEHAVE_TAGS}" ]]; then
           TAGS_ARG="${BEHAVE_TAGS}"
@@ -247,6 +288,10 @@ spec:
         if [[ "${ARTIFACT_RC}" -ne 0 ]]; then
           echo "ERROR: one or more KDE failure bundles could not be archived" >&2
           exit "${ARTIFACT_RC}"
+        fi
+        if [[ "${SABOTAGE_MODE}" != "none" && "${BEHAVE_RC}" -eq 0 ]]; then
+          echo "SABOTAGE FAILURE: ${SABOTAGE_MODE} unexpectedly passed" >&2
+          exit 1
         fi
         exit "${BEHAVE_RC}"
     volumes:

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: argo
   annotations:
     description: |
-      Runs testsuite's kde-smoke suite against a KDE Linux KubeVirt VM.
-      SSH and WebDriver are forwarded through virtctl; the ISO already ships
-      selenium-webdriver-at-spi, so no prebake or in-VM source build is needed.
+      Runs a testsuite KDE suite against an Aurora/KDE KubeVirt VM by adapting
+      the GNOME runner's clone, SSH, result persistence, and publication
+      contract to selenium-webdriver-at-spi.
 spec:
   serviceAccountName: argo
   templates:
@@ -16,9 +16,23 @@ spec:
       parameters:
       - name: vm-name
       - name: vm-namespace
-        value: "kde-test"
-      - name: testsuite-branch
+        value: "aurora-test"
+      - name: suite
+        value: "kde-smoke"
+      - name: variant
+        value: "aurora"
+      - name: ssh-user
+        value: "bluefin-test"
+      - name: ssh-key-secret
+        value: "bluefin-test-ssh-key"
+      - name: issue-title
+        value: "manual"
+      - name: behave-tags
+        value: ""
+      - name: branch
         value: "main"
+      - name: containerdisk-tag
+        value: ""
     activeDeadlineSeconds: 3600
     initContainers:
     - name: git-sync
@@ -32,7 +46,7 @@ spec:
           memory: 512Mi
       env:
       - name: BRANCH
-        value: "{{inputs.parameters.testsuite-branch}}"
+        value: "{{inputs.parameters.branch}}"
       command: [bash, -c]
       args:
       - |
@@ -59,7 +73,13 @@ spec:
       - name: SSH_KEY
         value: /etc/ssh/test-key/id_ed25519
       - name: VM_USER
-        value: bluefin-test
+        value: "{{inputs.parameters.ssh-user}}"
+      - name: SUITE
+        value: "{{inputs.parameters.suite}}"
+      - name: VARIANT
+        value: "{{inputs.parameters.variant}}"
+      - name: BEHAVE_TAGS
+        value: "{{inputs.parameters.behave-tags}}"
       - name: IMAGE
         value: kde-linux
       - name: VM_HOST
@@ -68,6 +88,12 @@ spec:
         value: "2222"
       - name: KDE_WEBDRIVER_URL
         value: http://127.0.0.1:4723
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-token
+            key: token
+            optional: true
       volumeMounts:
       - name: workspace
         mountPath: /workspace
@@ -99,25 +125,46 @@ spec:
         ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
           'command -v selenium-webdriver-at-spi-run && \
+           XDG_SESSION_DESKTOP=kde KDE_WEBDRIVER_URL=http://127.0.0.1:4723 \
            nohup selenium-webdriver-at-spi-run \
              >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &'
         timeout 120 bash -c 'until curl --fail --silent "${KDE_WEBDRIVER_URL}/status" >/dev/null; do sleep 2; done'
         cd /workspace/testsuite
         python3 -m pip install --quiet selenium behave
         export PYTHONPATH=/workspace/testsuite
-        python3 -m behave tests/kde-smoke/features \
+        TAGS_ARG="--tags ~@wip"
+        if [[ -n "${BEHAVE_TAGS}" ]]; then
+          TAGS_ARG="${BEHAVE_TAGS}"
+        fi
+        python3 -m behave "tests/${SUITE}/features" \
           --format json.pretty --outfile /results/results.json --no-capture \
-          --tags ~@wip
-        mkdir -p /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke
+          ${TAGS_ARG}
+        RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
+        mkdir -p "${RESULT_DIR}"
         cp /results/results.json \
-          /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke/
+          "${RESULT_DIR}/"
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+          IMG_SLUG="${VARIANT}"
+          if [[ "${VARIANT}" == "aurora" && -n "{{inputs.parameters.containerdisk-tag}}" ]]; then
+            IMG_SLUG="aurora-${{inputs.parameters.containerdisk-tag}}"
+          fi
+          rm -rf /workspace/lab-code
+          git clone --depth 1 \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
+            /workspace/lab-code
+          python3 /workspace/lab-code/scripts/publish_test_results.py \
+            /results/results.json "${IMG_SLUG}" "${SUITE}" \
+            "{{workflow.name}}" "${GITHUB_TOKEN}" || \
+            echo "Warning: failed to publish test results" >&2
+        fi
     volumes:
     - name: workspace
       emptyDir:
         sizeLimit: 2Gi
     - name: ssh-key
       secret:
-        secretName: bluefin-test-ssh-key
+        secretName: "{{inputs.parameters.ssh-key-secret}}"
+        defaultMode: 0400
     - name: results
       emptyDir:
         sizeLimit: 1Gi

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -227,6 +227,11 @@ is pushed as the stable `desktop-screenshot` OCI artifact when the optional
 GitHub token is available. QEMU-level screendumps are not used because
 KubeVirt's `virt-launcher` does not expose a QEMU monitor.
 
+The runner accepts `failure-class: test|infra` and `failure-issue-url`
+parameters. A failed run classified as infrastructure must include the URL of
+its separate tracking issue; otherwise it is counted as a test failure. Every
+run rejects a retry setting other than `BEHAVE_RETRIES=2`.
+
 ### `aurora-qa-pipeline` (template: `aurora-qa`)
 
 Runs the Aurora/KDE GUI suite against a KubeVirt VM in `aurora-test`:
@@ -244,6 +249,22 @@ existing KDE runner. It has a one-hour `activeDeadlineSeconds`, holds the
 `aurora-vm-qa` ConfigMap semaphore for the full run, and always deletes the VM
 from its `onExit: teardown` handler. The template is GitOps-managed; live lab
 evidence may require a run after the change is merged and reconciled.
+
+KDE soak evidence is a rolling window, not a consecutive streak. The publisher
+retains the newest 30 runs and records `failure_class` (`test` or `infra`) plus
+the filed issue URL for infrastructure flakes. `BEHAVE_RETRIES=2` is enforced
+for every run. The window is qualified only after 30 runs with either at least
+29 passes, or at least 28 passes and no more than two classified infrastructure
+flakes:
+
+```bash
+just evaluate-kde-soak
+```
+
+The command reports `pending` until 30 runs exist and exits non-zero for an
+unqualified window. Qualification is evidence only; promotion to CI gating
+remains a human decision, and each infrastructure flake must have a separate
+filed issue.
 
 ### `aurora-kde-sabotage`
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -214,6 +214,15 @@ captures `results.json` to pod stdout (Loki + `argo logs`).
 Resource limits and `hostNetwork: true` are set on the pod (KubeVirt
 masquerade only routes from host netns).
 
+### `run-kde-tests` (template: `run-kde-tests`)
+
+Adapts the GNOME runner contract for Aurora/KDE VMs. It clones the selected
+testsuite branch, forwards SSH and WebDriver port 4723 through `virtctl`,
+starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
+`/status` endpoint, and runs `tests/kde-smoke/features` with Behave. Results
+are persisted under the standard ghost test-results host path and published
+when the optional GitHub token is available.
+
 ### `run-flatcar-tests` (template: `run-flatcar-tests`)
 
 Same shape for Flatcar; uses `core` as the SSH user and runs pytest+dogtail

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -223,6 +223,24 @@ starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
 are persisted under the standard ghost test-results host path and published
 when the optional GitHub token is available.
 
+### `aurora-qa-pipeline` (template: `aurora-qa`)
+
+Runs the Aurora/KDE GUI suite against a KubeVirt VM in `aurora-test`:
+
+```text
+build Aurora containerDisk
+  → provision VM
+    → run-kde-tests
+      → collect-vm-logs
+```
+
+The pipeline builds `ghcr.io/ublue-os/aurora` into the
+`aurora-containerdisk` repository with a 30G disk, then passes the VM to the
+existing KDE runner. It has a one-hour `activeDeadlineSeconds`, holds the
+`aurora-vm-qa` ConfigMap semaphore for the full run, and always deletes the VM
+from its `onExit: teardown` handler. The template is GitOps-managed; live lab
+evidence may require a run after the change is merged and reconciled.
+
 ### `run-flatcar-tests` (template: `run-flatcar-tests`)
 
 Same shape for Flatcar; uses `core` as the SSH user and runs pytest+dogtail

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -220,8 +220,12 @@ Adapts the GNOME runner contract for Aurora/KDE VMs. It clones the selected
 testsuite branch, forwards SSH and WebDriver port 4723 through `virtctl`,
 starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
 `/status` endpoint, and runs `tests/kde-smoke/features` with Behave. Results
-are persisted under the standard ghost test-results host path and published
-when the optional GitHub token is available.
+and in-guest PNG screenshots are copied back even when Behave fails, then
+persisted under the standard ghost test-results host path. `faillog_*`
+directories are retained alongside `.tar.gz` bundles, and the first screenshot
+is pushed as the stable `desktop-screenshot` OCI artifact when the optional
+GitHub token is available. QEMU-level screendumps are not used because
+KubeVirt's `virt-launcher` does not expose a QEMU monitor.
 
 ### `aurora-qa-pipeline` (template: `aurora-qa`)
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -245,6 +245,19 @@ existing KDE runner. It has a one-hour `activeDeadlineSeconds`, holds the
 from its `onExit: teardown` handler. The template is GitOps-managed; live lab
 evidence may require a run after the change is merged and reconciled.
 
+### `aurora-kde-sabotage`
+
+Runs the mandatory red-path proof in the isolated `aurora-test` namespace. It
+reuses the real VM and KDE runner, first replacing one launch target with
+`/usr/bin/this-does-not-exist`, then killing `plasmashell`. Both runs must
+fail, publish failed results, retain `kde_faillog` bundles, and leave no VM
+after `onExit` cleanup. Normal Aurora runs default to `sabotage-mode: none`;
+the runner rejects sabotage modes outside `aurora-test`.
+
+```bash
+just run-aurora-kde-sabotage
+```
+
 ### `run-flatcar-tests` (template: `run-flatcar-tests`)
 
 Same shape for Flatcar; uses `core` as the SSH user and runs pytest+dogtail

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -223,8 +223,10 @@ starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
 and in-guest PNG screenshots are copied back even when Behave fails, then
 persisted under the standard ghost test-results host path. `faillog_*`
 directories are retained alongside `.tar.gz` bundles, and the first screenshot
-is pushed as the stable `desktop-screenshot` OCI artifact when the optional
-GitHub token is available. QEMU-level screendumps are not used because
+is pushed as the stable `desktop-screenshot` OCI artifact. The GitHub
+credential, ORAS tool, screenshot, artifact persistence, and result publication
+are required and fail the runner when unavailable. QEMU-level screendumps are
+not used because
 KubeVirt's `virt-launcher` does not expose a QEMU monitor.
 
 The runner accepts `failure-class: test|infra` and `failure-issue-url`

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -63,6 +63,10 @@ The workflow authoring guidance is split by topic:
   workflow `parallelism` — that limit does not cover simultaneous workflows.
   Put a template-level `synchronization.semaphores` reference on the shared
   template and define its capacity in the GitOps-managed ConfigMap.
+- A `synchronization` block placed directly on a `dag.tasks[]` entry — Argo's
+  schema rejects it. Wrap the `templateRef` in a local `steps` template and put
+  the ConfigMap-backed semaphore on that wrapper when only one DAG task needs
+  cross-workflow serialization.
 - A `steps` or `dag` task calling a sub-template without `arguments:`
 - `{{steps.X.outputs...}}` or `{{tasks.X.outputs...}}` used as an input
   parameter *default inside a leaf template* — that scope only exists at
@@ -171,6 +175,9 @@ Before marking any WorkflowTemplate change done:
 - [ ] All pod-running templates have `resources:` requests and limits
 - [ ] Every node-pinned, high-memory shared template has a ConfigMap-backed
       template-level semaphore sized to the node's allocatable capacity
+- [ ] Any semaphore intended for one DAG task is attached to a wrapper template,
+      not directly to `dag.tasks[]`; the wrapper's `steps` call the external
+      `templateRef`
 - [ ] VM pipelines are scheduler-managed by default; if cross-workflow memory
       contention requires serialization, use a documented template-level
       ConfigMap semaphore with an explicit capacity

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -135,6 +135,10 @@ The workflow authoring guidance is split by topic:
   constant pipeline identifiers and bounded states. Workflow-level completion
   metrics are safe only when the workflow status truthfully represents the
   publish result; non-blocking or transitional DAG branches must be fixed first.
+- A KDE GUI runner that copies the GNOME runner without replacing
+  `qecore-headless` and the GNOME daemon — use the VM's
+  `selenium-webdriver-at-spi-run`, forward port 4723, and gate test start on
+  its `/status` endpoint.
 
 ## Verification
 
@@ -173,3 +177,6 @@ Before marking any WorkflowTemplate change done:
       exists on the repository's default branch before relying on dispatch
 - [ ] Registry workflows use a pinned image that actually contains every CLI
       invoked by the script, with flags valid for that exact version
+- [ ] KDE GUI runners preserve the GNOME runner's parameter/result contract,
+      use `selenium-webdriver-at-spi-run`, forward `4723:4723`, and wait for
+      WebDriver readiness before Behave execution

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -149,6 +149,11 @@ The workflow authoring guidance is split by topic:
   `qecore-headless` and the GNOME daemon — use the VM's
   `selenium-webdriver-at-spi-run`, forward port 4723, and gate test start on
   its `/status` endpoint.
+- KDE QA callers must pass the runner's `branch` parameter (not the removed
+  `testsuite-branch`) and use the established `aurora-test` namespace. The
+  runner must source a generated session environment containing D-Bus,
+  Wayland, AT-SPI, `XDG_SESSION_DESKTOP=kde`, and its WebDriver URL before
+  starting Selenium.
 
 ## Verification
 

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -213,3 +213,6 @@ Before marking any WorkflowTemplate change done:
       exercise both the nonexistent-binary and killed-`plasmashell` red paths;
       failure results and `kde_faillog` artifacts must be retained before
       teardown
+- [ ] KDE soak evidence uses the newest 30 persisted runs and a two-flake
+      infrastructure budget, never a consecutive-green streak; promotion
+      remains a human decision

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -209,3 +209,7 @@ Before marking any WorkflowTemplate change done:
 - [ ] KDE GUI runners preserve the GNOME runner's parameter/result contract,
       use `selenium-webdriver-at-spi-run`, forward `4723:4723`, and wait for
       WebDriver readiness before Behave execution
+- [ ] Aurora/KDE sabotage runs are explicit, restricted to `aurora-test`, and
+      exercise both the nonexistent-binary and killed-`plasmashell` red paths;
+      failure results and `kde_faillog` artifacts must be retained before
+      teardown

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -54,7 +54,11 @@ The workflow authoring guidance is split by topic:
 - `synchronization.semaphore:` (singular) in any pipeline — deprecated, rejected by ArgoCD schema. Use `synchronization.semaphores:` (list with `- configMapKeyRef:` item)
 - `spec.schedule:` (singular) on a CronWorkflow — field does not exist in CRD schema; use `spec.schedules:` (array)
 - A pipeline with VMs and no `spec.activeDeadlineSeconds` — a stuck VM holds its semaphore slot forever
-- A pipeline with VMs that adds `spec.synchronization.semaphores` — semaphores are removed; k8s scheduler handles concurrency via virt-launcher memory requests
+- A VM pipeline that adds a semaphore without a documented cross-workflow
+  capacity need — ordinary VM concurrency is handled by virt-launcher memory
+  requests and does not need a lock
+- A memory-constrained VM pipeline that omits a documented template-level
+  semaphore — concurrent virt-launcher and runner pods can exhaust node memory
 - A template that consumes a scarce, node-pinned resource relying only on
   workflow `parallelism` — that limit does not cover simultaneous workflows.
   Put a template-level `synchronization.semaphores` reference on the shared
@@ -166,12 +170,15 @@ Before marking any WorkflowTemplate change done:
 - [ ] Pipeline has `onExit: cleanup` handler
 - [ ] All pod-running templates have `resources:` requests and limits
 - [ ] Every node-pinned, high-memory shared template has a ConfigMap-backed
-      template-level semaphore sized to the node's allocatable capacity; VM
-      pipelines remain scheduler-managed
+      template-level semaphore sized to the node's allocatable capacity
+- [ ] VM pipelines are scheduler-managed by default; if cross-workflow memory
+      contention requires serialization, use a documented template-level
+      ConfigMap semaphore with an explicit capacity
 - [ ] Change is committed and pushed — not manually applied to cluster
 - [ ] `description:` annotation present on the new/modified template
 - [ ] File name matches `metadata.name` (e.g. `provision-containerdisk-vm.yaml` for `name: provision-containerdisk-vm`)
-- [ ] VM pipeline spec has NO `synchronization.semaphores` block — k8s scheduler handles VM concurrency
+- [ ] Any VM pipeline semaphore is justified by documented cross-workflow
+      memory contention and is attached at template level, not workflow scope
 - [ ] VM pipeline spec has `activeDeadlineSeconds` (1h or 2h) so stuck VMs self-evict
 - [ ] No `nodeSelector: kubernetes.io/hostname: ghost` in VM specs — VMs float to any KubeVirt-capable node
 - [ ] GitHub Contents API write-backs use curl+jq, not inline Python; output is

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -152,10 +152,11 @@ However, for complex updates (such as parsing BDD/behave test results, merging w
 KDE GUI tests run through a WebDriver service inside the VM, so screenshots and
 `faillog_*` diagnostics are written in the guest session. Set the shared
 results directory in both environments, copy it back with `scp` after Behave
-returns (including non-zero returns), archive each failure directory, then copy
-the complete directory to the runner's `/var/mnt/ghost-data/test-results`
-hostPath. Re-raise the saved Behave status only after persistence and
-best-effort publication complete.
+returns (including non-zero returns), archive each failure directory with
+`python3 -m tarfile` (the runner has no `tar`), then copy the complete directory
+to the runner's `/var/mnt/ghost-data/test-results` hostPath. Surface archive
+failures after persistence and publication instead of silently dropping them;
+re-raise the saved Behave status only after that cleanup.
 
 When a PNG is present and registry credentials are available, publish the
 in-guest screenshot with the ORAS CLI's `path:media-type` syntax (verified

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -158,9 +158,10 @@ to the runner's `/var/mnt/ghost-data/test-results` hostPath. Surface archive
 failures after persistence and publication instead of silently dropping them;
 re-raise the saved Behave status only after that cleanup.
 
-When a PNG is present and registry credentials are available, publish the
-in-guest screenshot with the ORAS CLI's `path:media-type` syntax (verified
-against Context7 `/oras-project/oras`):
+Require the GitHub credential, screenshot, and ORAS CLI. Publish the in-guest
+screenshot with the ORAS CLI's `path:media-type` syntax (verified against
+Context7 `/oras-project/oras`); missing inputs or a failed upload must fail the
+runner after artifact persistence:
 
 ```bash
 oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
@@ -218,7 +219,8 @@ systemd starts.
 1. Install tooling if it is missing: `command -v skopeo >/dev/null || dnf install -y skopeo` and `command -v git >/dev/null || dnf install -y git-core`.
 2. Resolve the digest of `{{inputs.parameters.image}}:{{inputs.parameters.image-tag}}` with `skopeo inspect --no-tags --format '{{.Digest}}' "docker://${IMAGE}"`. Treat a missing digest as a non-fatal warning.
 3. Compute the image slug as `IMG_SLUG="${VARIANT}-${IMAGE_TAG}"` so the result file name matches the contract used by `run-gnome-tests` (e.g. `bluefin-stable-smoke.json`).
-4. Perform the git push-back in a best-effort block: log a warning if `git clone` or `publish_test_results.py` fails, but do not let a publication error fail the test workflow.
+4. Treat the git clone and `publish_test_results.py` as required evidence
+   publication. Their failures must fail the test workflow after cleanup.
 5. Pass the resolved digest as the optional sixth positional argument to `publish_test_results.py` so the collector can match QA evidence to the currently published image digest.
 
 

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -147,6 +147,29 @@ However, for complex updates (such as parsing BDD/behave test results, merging w
         fi
 ```
 
+#### KDE GUI runner: persist guest artifacts before re-raising failures
+
+KDE GUI tests run through a WebDriver service inside the VM, so screenshots and
+`faillog_*` diagnostics are written in the guest session. Set the shared
+results directory in both environments, copy it back with `scp` after Behave
+returns (including non-zero returns), archive each failure directory, then copy
+the complete directory to the runner's `/var/mnt/ghost-data/test-results`
+hostPath. Re-raise the saved Behave status only after persistence and
+best-effort publication complete.
+
+When a PNG is present and registry credentials are available, publish the
+in-guest screenshot with the ORAS CLI's `path:media-type` syntax (verified
+against Context7 `/oras-project/oras`):
+
+```bash
+oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
+  --annotation "io.github.projectbluefin.caller_repo=projectbluefin/lab" \
+  "${SHOT}:image/png"
+```
+
+Use guest-side screenshots for KubeVirt. `virt-launcher` does not expose a
+QEMU monitor, so QEMU-level screendump helpers are not a valid fallback.
+
 **Contents API Pattern (for simple single-file writes, verified against Context7 `/websites/github_en_rest`):**
 ```bash
 # GET current file sha (required for updates)

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -95,6 +95,40 @@ activeDeadlineSeconds: 3600   # 1h for containerdisk, 7200 for knuckle
 
 **VMs float to any KubeVirt-capable node** — no `nodeSelector: kubernetes.io/hostname: ghost` in VM specs. The registry-mirror-config DaemonSet writes the Zot HTTP registry config to all nodes.
 
+### 15a. Locking one DAG build task
+
+`synchronization` is a template-level field; it is not valid on an individual
+`dag.tasks[]` entry. When one task must share a cross-workflow semaphore with
+another builder, invoke a local wrapper template from the DAG and put the
+semaphore on that wrapper:
+
+```yaml
+tasks:
+  - name: build
+    template: serialized-build
+templates:
+  - name: serialized-build
+    synchronization:
+      semaphores:
+        - configMapKeyRef:
+            name: workflow-semaphores
+            key: migration-containerdisk-build
+    steps:
+      - - name: invoke-builder
+          templateRef:
+            name: shared-builder
+            template: build
+          arguments:
+            parameters:
+              - name: image
+                value: "{{workflow.parameters.image}}"
+```
+
+This keeps the lock around only the build task while preserving the
+cross-WorkflowTemplate `templateRef`. For diagnostic collection, include all
+terminal upstream states when appropriate:
+`(tests.Succeeded || tests.Failed || tests.Errored)`.
+
 ### 16. GitHub Contents API or Standalone Git Push-back — Prefer Standalone Python for Complex Files
 
 When a workflow pod needs to push a simple file to a GitHub repo, use `curl` + `jq` inside the bash script (Contents API).

--- a/manifests/kde-test-namespace.yaml
+++ b/manifests/kde-test-namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kde-test
-  labels:
-    kubernetes.io/metadata.name: kde-test
-    pod-security.kubernetes.io/enforce: baseline

--- a/manifests/workflow-semaphores.yaml
+++ b/manifests/workflow-semaphores.yaml
@@ -23,6 +23,9 @@
 #                        while preserving enough parallelism for the suite fan-out.
 #                        VMs are still scheduled natively and must not use this
 #                        semaphore (see docs/skills/argo-workflows/patterns.md).
+#   aurora-vm-qa       — Serializes Aurora/KDE VM pipelines. Each VM requests 8Gi
+#                        plus virt-launcher overhead and a runner pod, so one
+#                        workflow at a time avoids contention with container QA.
 #   dakota-publish      — Serializes Zot-to-GHCR Dakota publication workflows
 #                        while both image lanes run independently inside one slot.
 apiVersion: v1
@@ -37,4 +40,5 @@ data:
   bst-cache-warm: "1"
   migration-containerdisk-build: "1"
   ghost-container-qa: "6"
+  aurora-vm-qa: "1"
   dakota-publish: "1"

--- a/scripts/evaluate_kde_soak.py
+++ b/scripts/evaluate_kde_soak.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Evaluate the KDE rolling soak gate without requiring a consecutive streak."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+WINDOW_SIZE = 30
+MAX_INFRA_FLAKES = 2
+
+
+def evaluate_kde_soak(
+    history: list[dict[str, Any]],
+    *,
+    window_size: int = WINDOW_SIZE,
+    max_infra_flakes: int = MAX_INFRA_FLAKES,
+) -> dict[str, Any]:
+    window = history[:window_size]
+    passed = sum(entry.get("status") == "passed" for entry in window)
+    failed = len(window) - passed
+    infra_flakes = sum(
+        entry.get("status") == "failed"
+        and entry.get("failure_class", "test") == "infra"
+        for entry in window
+    )
+    test_failures = failed - infra_flakes
+    pass_rate = (passed / len(window) * 100) if window else None
+    qualified = len(window) >= window_size and (
+        passed >= window_size - 1
+        or (
+            passed >= window_size - 2
+            and failed == infra_flakes
+            and infra_flakes <= max_infra_flakes
+        )
+    )
+
+    if len(window) < window_size:
+        state = "pending"
+    elif qualified:
+        state = "qualified"
+    else:
+        state = "unqualified"
+
+    return {
+        "state": state,
+        "window_size": window_size,
+        "runs_recorded": len(window),
+        "passed_runs": passed,
+        "failed_runs": failed,
+        "infra_flakes": infra_flakes,
+        "test_failures": test_failures,
+        "pass_rate": round(pass_rate, 2) if pass_rate is not None else None,
+        "max_infra_flakes": max_infra_flakes,
+        "human_approval_required": qualified,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results_file", type=Path)
+    parser.add_argument("--window-size", type=int, default=WINDOW_SIZE)
+    parser.add_argument("--max-infra-flakes", type=int, default=MAX_INFRA_FLAKES)
+    args = parser.parse_args()
+
+    data = json.loads(args.results_file.read_text(encoding="utf-8"))
+    summary = evaluate_kde_soak(
+        data.get("history", []),
+        window_size=args.window_size,
+        max_infra_flakes=args.max_infra_flakes,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["state"] == "qualified" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_test_results.py
+++ b/scripts/publish_test_results.py
@@ -7,6 +7,11 @@ import shutil
 import urllib.request
 from datetime import datetime, timezone
 
+from evaluate_kde_soak import evaluate_kde_soak
+
+
+VALID_FAILURE_CLASSES = {"test", "infra"}
+
 def ghcr_digest(repository, tag):
     """Resolve a public GHCR tag to its manifest digest anonymously."""
     try:
@@ -59,7 +64,20 @@ def run_cmd(cmd, cwd=None, env=None, check=True):
         sys.exit(result.returncode)
     return result
 
-def parse_results_and_build_update(data, existing_data, current_utc, workflow_name, img_slug, suite, digest=None):
+def parse_results_and_build_update(
+    data,
+    existing_data,
+    current_utc,
+    workflow_name,
+    img_slug,
+    suite,
+    digest=None,
+    failure_class="test",
+    failure_issue_url=None,
+):
+    if failure_class not in VALID_FAILURE_CLASSES:
+        raise ValueError(f"failure_class must be one of {sorted(VALID_FAILURE_CLASSES)}")
+
     failed_scenarios = []
     failed_scenarios_detailed = []
     scenarios_total = 0
@@ -107,6 +125,11 @@ def parse_results_and_build_update(data, existing_data, current_utc, workflow_na
                     })
 
     status = "passed" if scenarios_failed == 0 else "failed"
+    if status == "passed":
+        failure_class = "none"
+        failure_issue_url = None
+    elif failure_class == "infra" and not failure_issue_url:
+        raise ValueError("failure_issue_url is required for an infra failure")
 
     history = []
     if existing_data:
@@ -125,13 +148,21 @@ def parse_results_and_build_update(data, existing_data, current_utc, workflow_na
         new_history_entry["digest"] = digest
         
     history.insert(0, new_history_entry)
-    # Keep history capped to last 15 runs
-    history = history[:15]
+    # Keep the complete soak window; the evaluator uses the newest 30 entries.
+    history = history[:30]
 
     # Ensure all pre-existing entries in history also have a "duration_seconds" key (default to 0.0 if not present)
     for entry in history:
         if "duration_seconds" not in entry:
             entry["duration_seconds"] = 0.0
+        if entry.get("status") == "passed":
+            entry.setdefault("failure_class", "none")
+        else:
+            entry.setdefault("failure_class", "test")
+        entry.setdefault("failure_issue_url", None)
+
+    new_history_entry["failure_class"] = failure_class
+    new_history_entry["failure_issue_url"] = failure_issue_url
 
     # Construct updated structure
     screenshot_url = f"https://projectbluefin.github.io/lab/screenshots/{img_slug}-{suite}-latest.png"
@@ -149,6 +180,7 @@ def parse_results_and_build_update(data, existing_data, current_utc, workflow_na
         "screenshot_url": screenshot_url,
         "history": history
     }
+    updated_data["soak"] = evaluate_kde_soak(history)
     if digest:
         updated_data["digest"] = digest
     return updated_data
@@ -164,6 +196,8 @@ def main():
     workflow_name = sys.argv[4]
     github_token = sys.argv[5]
     digest = sys.argv[6] if len(sys.argv) > 6 else None
+    failure_class = sys.argv[7] if len(sys.argv) > 7 else "test"
+    failure_issue_url = sys.argv[8] if len(sys.argv) > 8 else None
 
     if not digest:
         print(f"No digest provided. Attempting anonymous resolution for slug {img_slug}...")
@@ -220,7 +254,9 @@ def main():
         workflow_name=workflow_name,
         img_slug=img_slug,
         suite=suite,
-        digest=digest
+        digest=digest,
+        failure_class=failure_class,
+        failure_issue_url=failure_issue_url,
     )
 
     with open(result_filepath, 'w') as f:

--- a/scripts/publish_test_results.py
+++ b/scripts/publish_test_results.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import json
+import re
 import subprocess
 import shutil
 import urllib.request
@@ -55,7 +56,11 @@ def resolve_digest_for_slug(img_slug):
     return None
 
 def run_cmd(cmd, cwd=None, env=None, check=True):
-    print(f"Running command: {' '.join(cmd)}")
+    safe_cmd = [
+        re.sub(r"(https://x-access-token:)[^@]+@", r"\1***@", arg)
+        for arg in cmd
+    ]
+    print(f"Running command: {' '.join(safe_cmd)}")
     result = subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
     if check and result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
@@ -187,7 +192,7 @@ def parse_results_and_build_update(
 
 def main():
     if len(sys.argv) < 6:
-        print("Usage: publish_test_results.py <results_json_path> <img_slug> <suite> <workflow_name> <github_token> [digest]")
+        print("Usage: publish_test_results.py <results_json_path> <img_slug> <suite> <workflow_name> <github_token> [digest] [failure_class] [failure_issue_url]")
         sys.exit(1)
 
     results_json_path = sys.argv[1]
@@ -208,12 +213,12 @@ def main():
             print("Digest resolution skipped or failed.")
 
     if not github_token:
-        print("ERROR: github_token is empty. Skipping publication.")
-        sys.exit(0)
+        print("ERROR: github_token is empty.", file=sys.stderr)
+        sys.exit(2)
 
     if not os.path.exists(results_json_path):
-        print(f"WARNING: {results_json_path} not found. Skipping publication.")
-        sys.exit(0)
+        print(f"ERROR: {results_json_path} not found.", file=sys.stderr)
+        sys.exit(2)
 
     # 1. Parse behave results.json
     try:
@@ -221,12 +226,12 @@ def main():
             data = json.load(f)
     except Exception as e:
         print(f"ERROR: Failed to parse {results_json_path}: {e}")
-        sys.exit(0)
+        sys.exit(2)
 
     current_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # 2. Clone projectbluefin/lab to a temporary directory
-    temp_dir = "/tmp/lab-repo-clone"
+    temp_dir = os.path.join(os.getcwd(), ".lab-repo-clone")
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
 
@@ -245,7 +250,8 @@ def main():
             with open(result_filepath, 'r') as f:
                 existing_data = json.load(f)
         except Exception as e:
-            print(f"WARNING: Failed to parse existing results file {result_filepath}: {e}")
+            print(f"ERROR: Failed to parse existing results file {result_filepath}: {e}", file=sys.stderr)
+            sys.exit(2)
 
     updated_data = parse_results_and_build_update(
         data=data,

--- a/tests/unit/test_publish_test_results.py
+++ b/tests/unit/test_publish_test_results.py
@@ -1,4 +1,5 @@
 import sys
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -194,6 +195,29 @@ def test_infrastructure_failure_requires_a_filed_issue():
             suite="smoke",
             failure_class="infra",
         )
+
+
+def test_publication_input_failures_are_nonzero():
+    script = scripts_path / "publish_test_results.py"
+    missing = scripts_path / "does-not-exist.json"
+
+    missing_token = subprocess.run(
+        [sys.executable, str(script), str(missing), "aurora", "smoke", "wf", ""],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    missing_results = subprocess.run(
+        [sys.executable, str(script), str(missing), "aurora", "smoke", "wf", "token"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert missing_token.returncode != 0
+    assert missing_results.returncode != 0
+    assert "Skipping" not in missing_token.stderr
+    assert "Skipping" not in missing_results.stderr
 
 def test_parse_real_sample_results():
     import json

--- a/tests/unit/test_publish_test_results.py
+++ b/tests/unit/test_publish_test_results.py
@@ -1,11 +1,14 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add scripts directory to path to import publish_test_results
 scripts_path = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_path))
 
 from publish_test_results import parse_results_and_build_update  # noqa: E402
+from evaluate_kde_soak import evaluate_kde_soak  # noqa: E402
 
 def test_parse_results_and_build_update():
     # Sample behave JSON
@@ -124,6 +127,73 @@ def test_parse_results_and_build_update():
     old_entry = updated["history"][1]
     assert old_entry["workflow_name"] == "previous-workflow"
     assert old_entry["duration_seconds"] == 0.0
+    assert new_entry["failure_class"] == "test"
+    assert updated["soak"]["state"] == "pending"
+
+
+def test_kde_soak_allows_two_classified_infrastructure_flakes():
+    history = [
+        {
+            "status": "failed" if index < 2 else "passed",
+            "failure_class": "infra" if index < 2 else "none",
+        }
+        for index in range(30)
+    ]
+
+    summary = evaluate_kde_soak(history)
+
+    assert summary == {
+        "state": "qualified",
+        "window_size": 30,
+        "runs_recorded": 30,
+        "passed_runs": 28,
+        "failed_runs": 2,
+        "infra_flakes": 2,
+        "test_failures": 0,
+        "pass_rate": 93.33,
+        "max_infra_flakes": 2,
+        "human_approval_required": True,
+    }
+
+
+def test_kde_soak_rejects_two_test_failures():
+    history = [
+        {
+            "status": "failed" if index < 2 else "passed",
+            "failure_class": "test" if index < 2 else "none",
+        }
+        for index in range(30)
+    ]
+
+    assert evaluate_kde_soak(history)["state"] == "unqualified"
+
+
+def test_kde_soak_is_pending_before_thirty_runs():
+    assert evaluate_kde_soak([{"status": "passed"}] * 29)["state"] == "pending"
+
+
+def test_infrastructure_failure_requires_a_filed_issue():
+    with pytest.raises(ValueError, match="failure_issue_url"):
+        parse_results_and_build_update(
+            data=[
+                {
+                    "elements": [
+                        {
+                            "type": "scenario",
+                            "status": "failed",
+                            "name": "infra failure",
+                            "steps": [],
+                        }
+                    ]
+                }
+            ],
+            existing_data=None,
+            current_utc="2026-07-10T01:00:00Z",
+            workflow_name="infra-workflow",
+            img_slug="aurora-testing",
+            suite="smoke",
+            failure_class="infra",
+        )
 
 def test_parse_real_sample_results():
     import json
@@ -157,4 +227,3 @@ def test_parse_real_sample_results():
         assert isinstance(item["error_message"], str)
         assert len(item["failing_step"]) > 0
         assert len(item["error_message"]) > 0
-

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -183,6 +183,58 @@ def test_aurora_containerdisk_builder_isolated_and_prebaked():
     assert "storage: 100Gi" in aurora
 
 
+def test_aurora_qa_pipeline_is_vm_based_and_serialized():
+    pipeline_path = ROOT / "argo/workflow-templates/aurora-qa-pipeline.yaml"
+    assert pipeline_path.exists()
+    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+    spec = pipeline["spec"]
+
+    assert pipeline["metadata"]["name"] == "aurora-qa-pipeline"
+    assert spec["entrypoint"] == "aurora-qa"
+    assert spec["onExit"] == "teardown"
+    assert spec["activeDeadlineSeconds"] == 3600
+    assert spec["templates"][0]["name"] == "aurora-qa"
+    assert spec["templates"][0]["synchronization"]["semaphores"][0]["configMapKeyRef"] == {
+        "name": "workflow-semaphores",
+        "key": "aurora-vm-qa",
+    }
+
+    tasks = spec["templates"][0]["dag"]["tasks"]
+    assert [task["name"] for task in tasks] == [
+        "build-aurora-containerdisk",
+        "provision-containerdisk-vm",
+        "run-kde-tests",
+        "collect-logs",
+    ]
+    assert tasks[0]["templateRef"] == {
+        "name": "build-bluefin-migration-containerdisk",
+        "template": "build-containerdisk",
+    }
+    assert tasks[1]["templateRef"] == {
+        "name": "provision-containerdisk-vm",
+        "template": "provision-vm",
+    }
+    assert tasks[2]["templateRef"] == {
+        "name": "run-kde-tests",
+        "template": "run-kde-tests",
+    }
+    assert tasks[3]["templateRef"] == {
+        "name": "collect-vm-logs",
+        "template": "collect-vm-logs",
+    }
+
+    content = pipeline_path.read_text(encoding="utf-8")
+    assert "containerdisk-repo" in content
+    assert "value: aurora-containerdisk" in content
+    assert "value: aurora-test" in content
+    assert "value: 30G" in content
+
+    semaphores = yaml.safe_load(
+        (ROOT / "manifests/workflow-semaphores.yaml").read_text(encoding="utf-8")
+    )
+    assert semaphores["data"]["aurora-vm-qa"] == "1"
+
+
 def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     gnome = (ROOT / "argo/workflow-templates/run-gnome-tests.yaml").read_text(
         encoding="utf-8"

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -155,6 +155,42 @@ def test_buildbarn_runner_uses_stable_tmpdir_after_chroot():
     assert "filePool:" not in config
 
 
+def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
+    gnome = (ROOT / "argo/workflow-templates/run-gnome-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for parameter in (
+        "vm-name",
+        "vm-namespace",
+        "suite",
+        "variant",
+        "ssh-user",
+        "ssh-key-secret",
+        "issue-title",
+        "behave-tags",
+        "branch",
+        "containerdisk-tag",
+    ):
+        assert f"- name: {parameter}" in gnome
+        assert f"- name: {parameter}" in kde
+
+    assert 'value: "aurora-test"' in kde
+    assert 'value: "kde-smoke"' in kde
+    assert "4723:4723" in kde
+    assert "selenium-webdriver-at-spi-run" in kde
+    assert "KDE_WEBDRIVER_URL" in kde
+    assert "XDG_SESSION_DESKTOP=kde" in kde
+    assert "/status" in kde
+    assert "publish_test_results.py" in kde
+    assert "/var/mnt/ghost-data/test-results" in kde
+    assert "qecore-headless" not in kde
+    assert "gnome-ponytail-daemon" not in kde
+
+
 def test_cache_only_diagnostic_disables_remote_execution_explicitly():
     config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(encoding="utf-8")
     assert "remote-execution: {}" not in config

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -317,6 +317,11 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "/status" in kde
     assert "publish_test_results.py" in kde
     assert "/var/mnt/ghost-data/test-results" in kde
+    assert "- name: failure-class" in kde
+    assert "- name: failure-issue-url" in kde
+    assert "- name: behave-retries" in kde
+    assert 'value: "2"' in kde
+    assert "BEHAVE_RETRIES=2" in kde
     assert "qecore-headless" not in kde
     assert "gnome-ponytail-daemon" not in kde
 

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -206,7 +206,17 @@ def test_aurora_qa_pipeline_is_vm_based_and_serialized():
         "run-kde-tests",
         "collect-logs",
     ]
-    assert tasks[0]["templateRef"] == {
+    assert tasks[0]["template"] == "build-aurora-containerdisk"
+    build_template = next(
+        template
+        for template in spec["templates"]
+        if template["name"] == "build-aurora-containerdisk"
+    )
+    assert build_template["synchronization"]["semaphores"][0]["configMapKeyRef"] == {
+        "name": "workflow-semaphores",
+        "key": "migration-containerdisk-build",
+    }
+    assert build_template["steps"][0][0]["templateRef"] == {
         "name": "build-bluefin-migration-containerdisk",
         "template": "build-containerdisk",
     }
@@ -228,6 +238,7 @@ def test_aurora_qa_pipeline_is_vm_based_and_serialized():
     assert "value: aurora-containerdisk" in content
     assert "value: aurora-test" in content
     assert "value: 30G" in content
+    assert "run-kde-tests.Errored" in content
 
     semaphores = yaml.safe_load(
         (ROOT / "manifests/workflow-semaphores.yaml").read_text(encoding="utf-8")

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -322,6 +322,9 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "- name: behave-retries" in kde
     assert 'value: "2"' in kde
     assert "BEHAVE_RETRIES=2" in kde
+    assert "Required credential is missing: GITHUB_TOKEN" in kde
+    assert "optional: true" not in kde
+    assert "ERROR: failed to publish KDE test results" in kde
     assert "qecore-headless" not in kde
     assert "gnome-ponytail-daemon" not in kde
 
@@ -335,11 +338,13 @@ def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
     assert "python3 -m tarfile -c" in kde
     assert "tar -czf" not in kde
     assert "ARTIFACT_RC=1" in kde
-    assert "could not be archived" in kde
+    assert "evidence artifacts were not fully retained" in kde
     assert "scp" in kde
     assert "BEHAVE_RC=0" in kde
     assert "SCREENSHOT_IMAGE=" in kde
     assert "oras push" in kde
+    assert "ERROR: failed to publish KDE screenshot artifact" in kde
+    assert "Warning: failed" not in kde
     assert "TESTSUITE_RESULTS_DIR" in kde
     assert "qemu_screendump" not in kde
 

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -191,6 +191,37 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "gnome-ponytail-daemon" not in kde
 
 
+def test_kde_workflow_calls_runner_with_current_contract():
+    workflow = (ROOT / "argo/kde-linux-qa.yaml").read_text(encoding="utf-8")
+    provision = (
+        ROOT / "argo/workflow-templates/provision-kde-linux-vm.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert 'value: "aurora-test"' in workflow
+    assert "- name: branch" in workflow
+    assert "workflow.parameters.branch" in workflow
+    assert "testsuite-branch" not in workflow
+    assert 'value: "aurora-test"' in provision
+    assert "kde-test-namespace" not in workflow
+
+
+def test_kde_runner_sources_complete_session_environment():
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for variable in (
+        "DBUS_SESSION_BUS_ADDRESS",
+        "WAYLAND_DISPLAY",
+        "XDG_RUNTIME_DIR",
+        "AT_SPI_BUS_ADDRESS",
+        "XDG_SESSION_DESKTOP",
+        "KDE_WEBDRIVER_URL",
+    ):
+        assert variable in kde
+    assert "source /tmp/session.env" in kde
+
+
 def test_cache_only_diagnostic_disables_remote_execution_explicitly():
     config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(encoding="utf-8")
     assert "remote-execution: {}" not in config

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -288,7 +288,10 @@ def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
     )
 
     assert "faillog_" in kde
-    assert "tar -czf" in kde
+    assert "python3 -m tarfile -c" in kde
+    assert "tar -czf" not in kde
+    assert "ARTIFACT_RC=1" in kde
+    assert "could not be archived" in kde
     assert "scp" in kde
     assert "BEHAVE_RC=0" in kde
     assert "SCREENSHOT_IMAGE=" in kde

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -282,6 +282,21 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "gnome-ponytail-daemon" not in kde
 
 
+def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "faillog_" in kde
+    assert "tar -czf" in kde
+    assert "scp" in kde
+    assert "BEHAVE_RC=0" in kde
+    assert "SCREENSHOT_IMAGE=" in kde
+    assert "oras push" in kde
+    assert "TESTSUITE_RESULTS_DIR" in kde
+    assert "qemu_screendump" not in kde
+
+
 def test_kde_workflow_calls_runner_with_current_contract():
     workflow = (ROOT / "argo/kde-linux-qa.yaml").read_text(encoding="utf-8")
     provision = (

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -246,6 +246,45 @@ def test_aurora_qa_pipeline_is_vm_based_and_serialized():
     assert semaphores["data"]["aurora-vm-qa"] == "1"
 
 
+def test_aurora_qa_pipeline_exposes_safe_kde_sabotage_modes():
+    pipeline_path = ROOT / "argo/workflow-templates/aurora-qa-pipeline.yaml"
+    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+    parameters = {
+        parameter["name"]: parameter.get("value")
+        for parameter in pipeline["spec"]["arguments"]["parameters"]
+    }
+    assert parameters["sabotage-mode"] == "none"
+    assert "sabotage-mode" in pipeline_path.read_text(encoding="utf-8")
+
+    runner = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "missing-binary" in runner
+    assert "kill-plasmashell" in runner
+    assert "this-does-not-exist" in runner
+    assert "pkill -x plasmashell" in runner
+    assert "unexpectedly passed" in runner
+    assert "aurora-test" in runner
+
+
+def test_aurora_kde_sabotage_workflow_runs_both_controlled_failures():
+    path = ROOT / "argo/aurora-kde-sabotage.yaml"
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert workflow["spec"]["onExit"] == "cleanup"
+    tasks = workflow["spec"]["templates"][0]["dag"]["tasks"]
+    sabotage_tasks = [
+        task for task in tasks if task["name"] in {"missing-binary", "kill-plasmashell"}
+    ]
+    assert [task["name"] for task in sabotage_tasks] == [
+        "missing-binary",
+        "kill-plasmashell",
+    ]
+    content = path.read_text(encoding="utf-8")
+    assert "sabotage-mode" in content
+    assert "aurora-test" in content
+    assert "delete vm" in content.lower()
+
+
 def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     gnome = (ROOT / "argo/workflow-templates/run-gnome-tests.yaml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- add VM-based Aurora QA DAG: build → provision → KDE tests → collect logs
- persist KDE `results.json`, in-guest screenshots, and `kde_faillog` bundles on the ghost hostPath
- archive failure bundles and publish the first screenshot as the stable GHCR OCI artifact with oras
- keep Aurora/KDE runner result publication best-effort and omit unsupported QEMU screendumps

## Validation
- `just lint` (includes offline Argo lint)
- `argo lint --offline argo/workflow-templates/run-kde-tests.yaml argo/workflow-templates/aurora-qa-pipeline.yaml` (targeted command reports the existing unresolved cross-template reference; full `just lint` passes)
- `pytest -q tests/unit/test_workflow_defaults.py tests/unit/test_publish_test_results.py`

Live lab evidence is unavailable in this session: no workflow was submitted and no persistent VM was used. The template is GitOps-managed; verify after merge and ArgoCD reconciliation.

Closes #463
Closes #464