### PR TITLE
feat(kde): add nightly soak CronWorkflow

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -142,6 +142,17 @@ run-kde-linux:
         -n {{ argo_ns }} \
         --watch
 
+# Run the mandatory red-path proof for the Aurora/KDE gate.
+run-aurora-kde-sabotage:
+    argo submit argo/aurora-kde-sabotage.yaml \
+        -n {{ argo_ns }} \
+        --watch
+
+# Evaluate the rolling KDE soak window. A qualified result still needs human
+# approval before the suite is promoted to CI gating.
+evaluate-kde-soak:
+    python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-smoke.json
+
 # ── Observation ─────────────────────────────────────────────────────────────
 
 # List all test workflows

--- a/argo/aurora-kde-sabotage.yaml
+++ b/argo/aurora-kde-sabotage.yaml
@@ -1,0 +1,127 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: aurora-kde-sabotage-
+  namespace: argo
+  annotations:
+    description: |
+      Mandatory Aurora/KDE gate proof. Runs the real kde-smoke suite twice,
+      first with a nonexistent launch binary and then with plasmashell killed.
+      Both runs must fail, publish red results, retain KDE faillogs, and clean
+      up the ephemeral VM.
+spec:
+  entrypoint: pipeline
+  serviceAccountName: argo
+  activeDeadlineSeconds: 5400
+  onExit: cleanup
+  arguments:
+    parameters:
+    - name: vm-name
+      value: "aurora-kde-sabotage-{{workflow.uid}}"
+    - name: namespace
+      value: "aurora-test"
+    - name: image-tag
+      value: "testing"
+    - name: branch
+      value: "main"
+  templates:
+  - name: pipeline
+    synchronization:
+      semaphores:
+      - configMapKeyRef:
+          name: workflow-semaphores
+          key: aurora-vm-qa
+    dag:
+      tasks:
+      - name: build
+        templateRef:
+          name: build-bluefin-migration-containerdisk
+          template: build-containerdisk
+        arguments:
+          parameters:
+          - name: image
+            value: ghcr.io/ublue-os/aurora
+          - name: image-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: containerdisk-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: disk-size
+            value: 30G
+          - name: containerdisk-repo
+            value: aurora-containerdisk
+          - name: prebake-kde-webdriver
+            value: "true"
+          - name: force
+            value: "true"
+      - name: provision
+        depends: build.Succeeded
+        templateRef:
+          name: provision-containerdisk-vm
+          template: provision-vm
+        arguments:
+          parameters:
+          - name: image-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: vm-name
+            value: "{{workflow.parameters.vm-name}}"
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: containerdisk-repo
+            value: aurora-containerdisk
+          - name: app-label
+            value: aurora-test
+          - name: label-prefix
+            value: aurora.io
+      - name: missing-binary
+        depends: provision.Succeeded
+        templateRef:
+          name: run-kde-tests
+          template: run-kde-tests
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "{{workflow.parameters.vm-name}}"
+          - name: vm-namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: variant
+            value: aurora
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
+          - name: containerdisk-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: sabotage-mode
+            value: missing-binary
+      - name: kill-plasmashell
+        depends: "(missing-binary.Succeeded || missing-binary.Failed || missing-binary.Errored)"
+        templateRef:
+          name: run-kde-tests
+          template: run-kde-tests
+        arguments:
+          parameters:
+          - name: vm-name
+            value: "{{workflow.parameters.vm-name}}"
+          - name: vm-namespace
+            value: "{{workflow.parameters.namespace}}"
+          - name: variant
+            value: aurora
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
+          - name: containerdisk-tag
+            value: "{{workflow.parameters.image-tag}}"
+          - name: sabotage-mode
+            value: kill-plasmashell
+  - name: cleanup
+    script:
+      image: cgr.dev/chainguard/kubectl@sha256:b9f35eaf9cd6eeff77e5cab057398af90a6b6ce785ef06fdfca8b948074e17c5
+      command: [bash]
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+      source: |
+        set -euo pipefail
+        kubectl delete vm "{{workflow.parameters.vm-name}}" \
+          -n "{{workflow.parameters.namespace}}" --ignore-not-found

--- a/argo/kde-linux-qa.yaml
+++ b/argo/kde-linux-qa.yaml
@@ -15,8 +15,8 @@ spec:
     - name: image-sha256
       value: "8554c25d098373a618a733656852ef25ad96c2b8ce59d57d9705e38eb95046bf"
     - name: namespace
-      value: "kde-test"
-    - name: testsuite-branch
+      value: "aurora-test"
+    - name: branch
       value: "main"
   templates:
   - name: pipeline
@@ -47,8 +47,8 @@ spec:
             value: "kde-linux-{{workflow.uid}}"
           - name: vm-namespace
             value: "{{workflow.parameters.namespace}}"
-          - name: testsuite-branch
-            value: "{{workflow.parameters.testsuite-branch}}"
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
   - name: cleanup
     steps:
     - - name: teardown

--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -155,7 +155,7 @@ spec:
                   value: "true"
     - name: teardown
       script:
-        image: cgr.dev/chainguard/kubectl:latest-dev
+        image: cgr.dev/chainguard/kubectl@sha256:b9f35eaf9cd6eeff77e5cab057398af90a6b6ce785ef06fdfca8b948074e17c5
         command: [bash]
         resources:
           requests:

--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -1,0 +1,170 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: aurora-qa-pipeline
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: qa-pipeline
+    app.kubernetes.io/part-of: aurora-test-suite
+  annotations:
+    description: |
+      VM-based Aurora/KDE QA pipeline: build an Aurora containerDisk, provision
+      a KubeVirt VM, run KDE GUI tests, collect VM logs, and always tear down
+      the VM when the workflow completes.
+spec:
+  serviceAccountName: argo
+  entrypoint: aurora-qa
+  onExit: teardown
+  activeDeadlineSeconds: 3600
+  volumeClaimGC:
+    strategy: OnWorkflowCompletion
+  volumeClaimTemplates:
+    - metadata:
+        name: staging
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 100Gi
+  arguments:
+    parameters:
+      - name: image-tag
+        value: testing
+      - name: vm-name
+        value: aurora-qa-{{workflow.uid}}
+      - name: namespace
+        value: aurora-test
+      - name: containerdisk-repo
+        value: aurora-containerdisk
+      - name: sabotage-mode
+        value: none
+      - name: failure-class
+        value: test
+      - name: failure-issue-url
+        value: ""
+      - name: disk-size
+        value: 30G
+      - name: suite
+        value: kde-smoke
+      - name: branch
+        value: main
+      - name: ssh-user
+        value: bluefin-test
+      - name: ssh-key-secret
+        value: bluefin-test-ssh-key
+  templates:
+    - name: aurora-qa
+      synchronization:
+        semaphores:
+          - configMapKeyRef:
+              name: workflow-semaphores
+              key: aurora-vm-qa
+      dag:
+        tasks:
+          - name: build-aurora-containerdisk
+            template: build-aurora-containerdisk
+          - name: provision-containerdisk-vm
+            depends: build-aurora-containerdisk.Succeeded
+            templateRef:
+              name: provision-containerdisk-vm
+              template: provision-vm
+            arguments:
+              parameters:
+                - name: image-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: namespace
+                  value: "{{workflow.parameters.namespace}}"
+                - name: containerdisk-repo
+                  value: "{{workflow.parameters.containerdisk-repo}}"
+                - name: app-label
+                  value: aurora-test
+                - name: label-prefix
+                  value: aurora.io
+          - name: run-kde-tests
+            depends: provision-containerdisk-vm.Succeeded
+            templateRef:
+              name: run-kde-tests
+              template: run-kde-tests
+            arguments:
+              parameters:
+                - name: vm-name
+                  value: "{{workflow.parameters.vm-name}}"
+                - name: vm-namespace
+                  value: "{{workflow.parameters.namespace}}"
+                - name: suite
+                  value: "{{workflow.parameters.suite}}"
+                - name: variant
+                  value: aurora
+                - name: ssh-user
+                  value: "{{workflow.parameters.ssh-user}}"
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+                - name: containerdisk-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: sabotage-mode
+                  value: "{{workflow.parameters.sabotage-mode}}"
+                - name: failure-class
+                  value: "{{workflow.parameters.failure-class}}"
+                - name: failure-issue-url
+                  value: "{{workflow.parameters.failure-issue-url}}"
+          - name: collect-logs
+            depends: "(run-kde-tests.Succeeded || run-kde-tests.Failed || run-kde-tests.Errored)"
+            templateRef:
+              name: collect-vm-logs
+              template: collect-vm-logs
+            arguments:
+              parameters:
+                - name: vm-ip
+                  value: "{{tasks.provision-containerdisk-vm.outputs.parameters.vm-ip}}"
+                - name: variant
+                  value: aurora:testing
+                - name: ssh-key-secret
+                  value: "{{workflow.parameters.ssh-key-secret}}"
+                - name: ssh-user
+                  value: "{{workflow.parameters.ssh-user}}"
+    - name: build-aurora-containerdisk
+      synchronization:
+        semaphores:
+          - configMapKeyRef:
+              name: workflow-semaphores
+              key: migration-containerdisk-build
+      steps:
+        - - name: build
+            templateRef:
+              name: build-bluefin-migration-containerdisk
+              template: build-containerdisk
+            arguments:
+              parameters:
+                - name: image
+                  value: ghcr.io/ublue-os/aurora
+                - name: image-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: containerdisk-tag
+                  value: "{{workflow.parameters.image-tag}}"
+                - name: disk-size
+                  value: "{{workflow.parameters.disk-size}}"
+                - name: containerdisk-repo
+                  value: "{{workflow.parameters.containerdisk-repo}}"
+                - name: prebake-kde-webdriver
+                  value: "true"
+                - name: force
+                  value: "true"
+    - name: teardown
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        source: |
+          set -e
+          kubectl delete vm "{{workflow.parameters.vm-name}}" \
+            -n "{{workflow.parameters.namespace}}" --ignore-not-found

--- a/argo/workflow-templates/provision-kde-linux-vm.yaml
+++ b/argo/workflow-templates/provision-kde-linux-vm.yaml
@@ -42,6 +42,8 @@ spec:
             value: "{{inputs.parameters.vm-name}}"
           - name: namespace
             value: "{{inputs.parameters.namespace}}"
+          - name: containerdisk-digest
+            value: "{{steps.prepare-disk.outputs.parameters.containerdisk-digest}}"
     - - name: wait-for-vm
         template: wait-for-vm
         arguments:
@@ -56,12 +58,17 @@ spec:
       parameters:
       - name: image-url
       - name: image-sha256
+    outputs:
+      parameters:
+      - name: containerdisk-digest
+        valueFrom:
+          path: /mnt/work/containerdisk-digest.txt
     volumes:
     - name: work
       emptyDir:
         sizeLimit: 12Gi
     script:
-      image: quay.io/buildah/stable:latest
+      image: quay.io/buildah/stable@sha256:7bb110e1d8b761d08e87d004ea4086e295a52319f3ea70ecef65da6dff7ceef0
       command: [bash]
       securityContext:
         privileged: true
@@ -82,7 +89,7 @@ spec:
         SHA="{{inputs.parameters.image-sha256}}"
         WORK=/mnt/work
         IMAGE="${WORK}/kde-linux.iso"
-        CONTAINERDISK="192.168.1.102:30500/kde-linux-containerdisk:latest"
+        CONTAINERDISK="192.168.1.102:30500/kde-linux-containerdisk:{{workflow.uid}}"
 
         [[ "${SHA}" =~ ^[[:xdigit:]]{64}$ ]] || {
           echo "image-sha256 must be a 64-character hexadecimal digest" >&2
@@ -100,13 +107,15 @@ spec:
           > "${WORK}/containerDisk.json"
         buildah copy "${ctr}" "${WORK}/containerDisk.json" /containerDisk.json
         buildah commit "${ctr}" "${CONTAINERDISK}"
-        buildah push --tls-verify=false "${CONTAINERDISK}"
+        buildah push --tls-verify=false \
+          --digestfile "${WORK}/containerdisk-digest.txt" "${CONTAINERDISK}"
 
   - name: create-vm
     inputs:
       parameters:
       - name: vm-name
       - name: namespace
+      - name: containerdisk-digest
     resource:
       action: apply
       manifest: |
@@ -155,7 +164,7 @@ spec:
               volumes:
               - name: rootdisk
                 containerDisk:
-                  image: 192.168.1.102:30500/kde-linux-containerdisk:latest
+                  image: 192.168.1.102:30500/kde-linux-containerdisk@{{inputs.parameters.containerdisk-digest}}
               - name: cloudinit
                 cloudInitNoCloud:
                   userData: |

--- a/argo/workflow-templates/provision-kde-linux-vm.yaml
+++ b/argo/workflow-templates/provision-kde-linux-vm.yaml
@@ -15,7 +15,7 @@ spec:
       parameters:
       - name: vm-name
       - name: namespace
-        value: "kde-test"
+        value: "aurora-test"
       - name: image-url
         value: "https://files.kde.org/kde-linux/kde-linux_202607281716.iso"
       - name: image-sha256
@@ -174,7 +174,7 @@ spec:
       - name: vm-name
       - name: namespace
     script:
-      image: ghcr.io/projectbluefin/lab-runner:latest
+      image: ghcr.io/projectbluefin/lab-runner@sha256:fe097bb3b85a126b9a16093fbc498b4b6fb7b24e0f74162ad3d91a402dcfa940
       command: [bash]
       resources:
         requests:

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -133,12 +133,15 @@ spec:
         value: http://127.0.0.1:4723
       - name: SABOTAGE_MODE
         value: "{{inputs.parameters.sabotage-mode}}"
+      - name: FAILURE_CLASS
+        value: "{{inputs.parameters.failure-class}}"
+      - name: FAILURE_ISSUE_URL
+        value: "{{inputs.parameters.failure-issue-url}}"
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
             name: github-token
             key: token
-            optional: true
       volumeMounts:
       - name: workspace
         mountPath: /workspace
@@ -154,6 +157,12 @@ spec:
       args:
       - |
         set -euo pipefail
+        for tool in bash curl find git python3 scp ssh timeout; do
+          command -v "${tool}" >/dev/null ||
+            { echo "Required tool is missing: ${tool}" >&2; exit 2; }
+        done
+        [[ -n "${GITHUB_TOKEN:-}" ]] ||
+          { echo "Required credential is missing: GITHUB_TOKEN" >&2; exit 2; }
         mkdir -p /tmp/results
         VIRTCTL=/usr/local/bin/virtctl
         if [[ ! -x "${VIRTCTL}" ]]; then
@@ -236,15 +245,17 @@ spec:
 
         # KDE's failure hook writes screenshots and diagnostic directories inside
         # the guest session. Copy them back even when Behave reports failures.
-        scp -i "${SSH_KEY}" -P 2222 -o StrictHostKeyChecking=no \
+        ARTIFACT_RC=0
+        if ! scp -i "${SSH_KEY}" -P 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null -r \
-          "${VM_USER}@127.0.0.1:/tmp/results/." /tmp/results/ || \
-          echo "Warning: failed to collect in-guest KDE artifacts" >&2
+          "${VM_USER}@127.0.0.1:/tmp/results/." /tmp/results/; then
+          echo "ERROR: failed to collect in-guest KDE artifacts" >&2
+          ARTIFACT_RC=1
+        fi
 
         # Keep both the directory and a portable tarball for each kde_faillog
         # bundle produced by the testsuite failure hook. lab-runner does not
         # provide tar, so use the guaranteed Python standard library tool.
-        ARTIFACT_RC=0
         while IFS= read -r -d '' bundle; do
           if ! (
             cd "$(dirname "${bundle}")" &&
@@ -257,9 +268,18 @@ spec:
 
         RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
         mkdir -p "${RESULT_DIR}"
-        cp -r /tmp/results/. "${RESULT_DIR}/" 2>/dev/null || true
+        if ! cp -r /tmp/results/. "${RESULT_DIR}/"; then
+          echo "ERROR: failed to persist KDE results to ${RESULT_DIR}" >&2
+          ARTIFACT_RC=1
+        fi
         if [[ -f /results/results.json ]]; then
-          cp /results/results.json "${RESULT_DIR}/"
+          if ! cp /results/results.json "${RESULT_DIR}/"; then
+            echo "ERROR: failed to persist results.json to ${RESULT_DIR}" >&2
+            ARTIFACT_RC=1
+          fi
+        else
+          echo "ERROR: Behave did not produce /results/results.json" >&2
+          ARTIFACT_RC=1
         fi
         echo "Results and KDE artifacts saved to ${RESULT_DIR}" >&2
 
@@ -272,33 +292,42 @@ spec:
         # the dashboard. KubeVirt's virt-launcher exposes no QEMU monitor, so
         # QEMU-level screendumps are intentionally not part of this workflow.
         SHOT=$(find /tmp/results -type f -name '*.png' -print -quit)
-        if [[ -n "${SHOT}" && -f "${SHOT}" && -n "${GITHUB_TOKEN:-}" ]]; then
+        if [[ -z "${SHOT}" || ! -f "${SHOT}" ]]; then
+          echo "ERROR: KDE test did not produce a screenshot artifact" >&2
+          ARTIFACT_RC=1
+        else
           ORAS_BIN=/workspace/oras-bin/oras
           if [[ ! -x "${ORAS_BIN}" ]]; then
             mkdir -p "$(dirname "${ORAS_BIN}")"
+            ORAS_ARCHIVE=/workspace/oras-bin/oras.tar.gz
             curl --fail --silent --show-error --location \
-              "https://github.com/oras-project/oras/releases/download/v1.2.3/oras_1.2.3_linux_amd64.tar.gz" |
-              tar -xz -C "$(dirname "${ORAS_BIN}")" oras || \
-              echo "Warning: failed to install oras" >&2
+              --output "${ORAS_ARCHIVE}" \
+              "https://github.com/oras-project/oras/releases/download/v1.2.3/oras_1.2.3_linux_amd64.tar.gz"
+            python3 -m tarfile -e "${ORAS_ARCHIVE}" "$(dirname "${ORAS_BIN}")"
+            rm -f "${ORAS_ARCHIVE}"
           fi
-          if [[ -x "${ORAS_BIN}" ]]; then
+          if ! {
+            if [[ ! -x "${ORAS_BIN}" ]]; then
+              echo "Required tool is unavailable: ${ORAS_BIN}" >&2
+              false
+            fi
             export PATH="$(dirname "${ORAS_BIN}"):${PATH}"
             SCREENSHOT_IMAGE="ghcr.io/projectbluefin/testsuite/desktop-screenshot"
             PUSH_TAG="${IMG_SLUG}-${SUITE}-latest"
             echo "${GITHUB_TOKEN}" | oras login ghcr.io \
-              -u github-actions --password-stdin || \
-              echo "Warning: failed to authenticate oras to GHCR" >&2
+              -u github-actions --password-stdin
             oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
               --annotation "org.opencontainers.image.description=Bluefin KDE desktop screenshot from lab e2e suite: ${SUITE}" \
               --annotation "io.github.projectbluefin.caller_repo=projectbluefin/lab" \
-              "${SHOT}:image/png" || \
-              echo "Warning: failed to push KDE screenshot" >&2
+              "${SHOT}:image/png"
+          }; then
+            echo "ERROR: failed to publish KDE screenshot artifact" >&2
+            ARTIFACT_RC=1
           fi
-        elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
-          echo "No GITHUB_TOKEN - skipping GHCR screenshot push" >&2
         fi
 
-        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        PUBLISH_RC=0
+        if ! {
           rm -rf /workspace/lab-code
           git clone --depth 1 \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
@@ -306,15 +335,18 @@ spec:
           python3 /workspace/lab-code/scripts/publish_test_results.py \
             /results/results.json "${IMG_SLUG}" "${SUITE}" \
             "{{workflow.name}}" "${GITHUB_TOKEN}" "" \
-            "${FAILURE_CLASS}" "${FAILURE_ISSUE_URL}" || \
-            echo "Warning: failed to publish test results" >&2
-        else
-          echo "No GITHUB_TOKEN - skipping test results publication" >&2
+            "${FAILURE_CLASS}" "${FAILURE_ISSUE_URL}"
+        }; then
+          echo "ERROR: failed to publish KDE test results" >&2
+          PUBLISH_RC=1
         fi
 
         if [[ "${ARTIFACT_RC}" -ne 0 ]]; then
-          echo "ERROR: one or more KDE failure bundles could not be archived" >&2
+          echo "ERROR: KDE evidence artifacts were not fully retained" >&2
           exit "${ARTIFACT_RC}"
+        fi
+        if [[ "${PUBLISH_RC}" -ne 0 ]]; then
+          exit "${PUBLISH_RC}"
         fi
         if [[ "${SABOTAGE_MODE}" != "none" && "${BEHAVE_RC}" -eq 0 ]]; then
           echo "SABOTAGE FAILURE: ${SABOTAGE_MODE} unexpectedly passed" >&2

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: argo
   annotations:
     description: |
-      Runs testsuite's kde-smoke suite against a KDE Linux KubeVirt VM.
-      SSH and WebDriver are forwarded through virtctl; the ISO already ships
-      selenium-webdriver-at-spi, so no prebake or in-VM source build is needed.
+      Runs a testsuite KDE suite against an Aurora/KDE KubeVirt VM by adapting
+      the GNOME runner's clone, SSH, result persistence, and publication
+      contract to selenium-webdriver-at-spi.
 spec:
   serviceAccountName: argo
   templates:
@@ -16,9 +16,31 @@ spec:
       parameters:
       - name: vm-name
       - name: vm-namespace
-        value: "kde-test"
-      - name: testsuite-branch
+        value: "aurora-test"
+      - name: suite
+        value: "kde-smoke"
+      - name: variant
+        value: "aurora"
+      - name: ssh-user
+        value: "bluefin-test"
+      - name: ssh-key-secret
+        value: "bluefin-test-ssh-key"
+      - name: issue-title
+        value: "manual"
+      - name: behave-tags
+        value: ""
+      - name: branch
         value: "main"
+      - name: containerdisk-tag
+        value: ""
+      - name: sabotage-mode
+        value: "none"
+      - name: failure-class
+        value: "test"
+      - name: failure-issue-url
+        value: ""
+      - name: behave-retries
+        value: "2"
     activeDeadlineSeconds: 3600
     initContainers:
     - name: git-sync
@@ -32,13 +54,48 @@ spec:
           memory: 512Mi
       env:
       - name: BRANCH
-        value: "{{inputs.parameters.testsuite-branch}}"
+        value: "{{inputs.parameters.branch}}"
+      - name: SABOTAGE_MODE
+        value: "{{inputs.parameters.sabotage-mode}}"
+      - name: BEHAVE_RETRIES
+        value: "{{inputs.parameters.behave-retries}}"
+      - name: FAILURE_CLASS
+        value: "{{inputs.parameters.failure-class}}"
+      - name: FAILURE_ISSUE_URL
+        value: "{{inputs.parameters.failure-issue-url}}"
       command: [bash, -c]
       args:
       - |
         set -euo pipefail
+        case "${FAILURE_CLASS}" in
+          test) ;;
+          infra)
+            [[ -n "${FAILURE_ISSUE_URL}" ]] ||
+              { echo "Infra failures require a filed issue URL" >&2; exit 2; }
+            ;;
+          *)
+            echo "Unsupported failure class: ${FAILURE_CLASS}" >&2
+            exit 2
+            ;;
+        esac
+        [[ "${BEHAVE_RETRIES}" == "2" ]] ||
+          { echo "KDE soak runs require BEHAVE_RETRIES=2" >&2; exit 2; }
         git clone --depth 1 --branch "${BRANCH}" \
           https://github.com/projectbluefin/testsuite /workspace/testsuite
+        case "${SABOTAGE_MODE}" in
+          none) ;;
+          missing-binary)
+            sed -i '0,/Launch "kcmshell6 kcm_autostart"/s//Launch "\/usr\/bin\/this-does-not-exist kcm_autostart"/' \
+              /workspace/testsuite/tests/kde-smoke/features/kde_smoke.feature
+            grep -q '/usr/bin/this-does-not-exist' \
+              /workspace/testsuite/tests/kde-smoke/features/kde_smoke.feature
+            ;;
+          kill-plasmashell) ;;
+          *)
+            echo "Unsupported sabotage mode: ${SABOTAGE_MODE}" >&2
+            exit 2
+            ;;
+        esac
       volumeMounts:
       - name: workspace
         mountPath: /workspace
@@ -59,7 +116,13 @@ spec:
       - name: SSH_KEY
         value: /etc/ssh/test-key/id_ed25519
       - name: VM_USER
-        value: bluefin-test
+        value: "{{inputs.parameters.ssh-user}}"
+      - name: SUITE
+        value: "{{inputs.parameters.suite}}"
+      - name: VARIANT
+        value: "{{inputs.parameters.variant}}"
+      - name: BEHAVE_TAGS
+        value: "{{inputs.parameters.behave-tags}}"
       - name: IMAGE
         value: kde-linux
       - name: VM_HOST
@@ -68,6 +131,14 @@ spec:
         value: "2222"
       - name: KDE_WEBDRIVER_URL
         value: http://127.0.0.1:4723
+      - name: SABOTAGE_MODE
+        value: "{{inputs.parameters.sabotage-mode}}"
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-token
+            key: token
+            optional: true
       volumeMounts:
       - name: workspace
         mountPath: /workspace
@@ -83,6 +154,7 @@ spec:
       args:
       - |
         set -euo pipefail
+        mkdir -p /tmp/results
         VIRTCTL=/usr/local/bin/virtctl
         if [[ ! -x "${VIRTCTL}" ]]; then
           curl --fail --location --retry 3 --output "${VIRTCTL}" \
@@ -98,26 +170,165 @@ spec:
               "${VM_USER}@127.0.0.1" true 2>/dev/null; do sleep 5; done'
         ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
-          'command -v selenium-webdriver-at-spi-run && \
-           nohup selenium-webdriver-at-spi-run \
-             >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &'
+          '
+          set -e
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          SESSION_BUS=$(systemctl --user show-environment 2>/dev/null |
+            sed -n "s/^DBUS_SESSION_BUS_ADDRESS=//p" | head -1)
+          if [ -z "${SESSION_BUS}" ] && [ -S "${XDG_RUNTIME_DIR}/bus" ]; then
+            SESSION_BUS="unix:path=${XDG_RUNTIME_DIR}/bus"
+          fi
+          WAYLAND_DISPLAY=$(find "${XDG_RUNTIME_DIR}" -maxdepth 1 \
+            -name "wayland-*" -printf "%f\n" 2>/dev/null | head -1)
+          AT_SPI_BUS_ADDRESS="${SESSION_BUS}"
+          KDE_WEBDRIVER_URL=http://127.0.0.1:4723
+          printf "%s\n" \
+            "export DBUS_SESSION_BUS_ADDRESS=${SESSION_BUS}" \
+            "export WAYLAND_DISPLAY=${WAYLAND_DISPLAY}" \
+            "export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" \
+            "export AT_SPI_BUS_ADDRESS=${AT_SPI_BUS_ADDRESS}" \
+            "export XDG_SESSION_TYPE=wayland" \
+            "export XDG_SESSION_DESKTOP=kde" \
+            "export KDE_WEBDRIVER_URL=${KDE_WEBDRIVER_URL}" \
+            "export TESTSUITE_RESULTS_DIR=/tmp/results" \
+            > /tmp/session.env
+          mkdir -p /tmp/results
+          source /tmp/session.env
+          command -v selenium-webdriver-at-spi-run
+          nohup selenium-webdriver-at-spi-run \
+            >/tmp/selenium-webdriver-at-spi.log 2>&1 </dev/null &
+          '
         timeout 120 bash -c 'until curl --fail --silent "${KDE_WEBDRIVER_URL}/status" >/dev/null; do sleep 2; done'
         cd /workspace/testsuite
         python3 -m pip install --quiet selenium behave
         export PYTHONPATH=/workspace/testsuite
-        python3 -m behave tests/kde-smoke/features \
+        export TESTSUITE_RESULTS_DIR=/tmp/results
+        export BEHAVE_RETRIES=2
+        case "${SABOTAGE_MODE}" in
+          none) ;;
+          missing-binary)
+            [[ "${VM_NS}" == "aurora-test" ]] ||
+              { echo "Refusing sabotage outside aurora-test" >&2; exit 2; }
+            ;;
+          kill-plasmashell)
+            [[ "${VM_NS}" == "aurora-test" ]] ||
+              { echo "Refusing sabotage outside aurora-test" >&2; exit 2; }
+            ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
+              'pgrep -x plasmashell'
+            ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
+              'pkill -x plasmashell'
+            ;;
+          *)
+            echo "Unsupported sabotage mode: ${SABOTAGE_MODE}" >&2
+            exit 2
+            ;;
+        esac
+        TAGS_ARG="--tags ~@wip"
+        if [[ -n "${BEHAVE_TAGS}" ]]; then
+          TAGS_ARG="${BEHAVE_TAGS}"
+        fi
+        BEHAVE_RC=0
+        python3 -m behave "tests/${SUITE}/features" \
           --format json.pretty --outfile /results/results.json --no-capture \
-          --tags ~@wip
-        mkdir -p /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke
-        cp /results/results.json \
-          /var/mnt/ghost-data/test-results/"{{workflow.name}}"/kde-smoke/
+          ${TAGS_ARG} || BEHAVE_RC=$?
+
+        # KDE's failure hook writes screenshots and diagnostic directories inside
+        # the guest session. Copy them back even when Behave reports failures.
+        scp -i "${SSH_KEY}" -P 2222 -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null -r \
+          "${VM_USER}@127.0.0.1:/tmp/results/." /tmp/results/ || \
+          echo "Warning: failed to collect in-guest KDE artifacts" >&2
+
+        # Keep both the directory and a portable tarball for each kde_faillog
+        # bundle produced by the testsuite failure hook. lab-runner does not
+        # provide tar, so use the guaranteed Python standard library tool.
+        ARTIFACT_RC=0
+        while IFS= read -r -d '' bundle; do
+          if ! (
+            cd "$(dirname "${bundle}")" &&
+            python3 -m tarfile -c "${bundle}.tar.gz" "$(basename "${bundle}")"
+          ); then
+            echo "ERROR: failed to archive KDE failure bundle ${bundle}" >&2
+            ARTIFACT_RC=1
+          fi
+        done < <(find /tmp/results -type d -name 'faillog_*' -print0)
+
+        RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
+        mkdir -p "${RESULT_DIR}"
+        cp -r /tmp/results/. "${RESULT_DIR}/" 2>/dev/null || true
+        if [[ -f /results/results.json ]]; then
+          cp /results/results.json "${RESULT_DIR}/"
+        fi
+        echo "Results and KDE artifacts saved to ${RESULT_DIR}" >&2
+
+        IMG_SLUG="${VARIANT}"
+        if [[ "${VARIANT}" == "aurora" && -n "{{inputs.parameters.containerdisk-tag}}" ]]; then
+          IMG_SLUG="aurora-${{inputs.parameters.containerdisk-tag}}"
+        fi
+
+        # Push the first in-guest screenshot as the stable OCI artifact used by
+        # the dashboard. KubeVirt's virt-launcher exposes no QEMU monitor, so
+        # QEMU-level screendumps are intentionally not part of this workflow.
+        SHOT=$(find /tmp/results -type f -name '*.png' -print -quit)
+        if [[ -n "${SHOT}" && -f "${SHOT}" && -n "${GITHUB_TOKEN:-}" ]]; then
+          ORAS_BIN=/workspace/oras-bin/oras
+          if [[ ! -x "${ORAS_BIN}" ]]; then
+            mkdir -p "$(dirname "${ORAS_BIN}")"
+            curl --fail --silent --show-error --location \
+              "https://github.com/oras-project/oras/releases/download/v1.2.3/oras_1.2.3_linux_amd64.tar.gz" |
+              tar -xz -C "$(dirname "${ORAS_BIN}")" oras || \
+              echo "Warning: failed to install oras" >&2
+          fi
+          if [[ -x "${ORAS_BIN}" ]]; then
+            export PATH="$(dirname "${ORAS_BIN}"):${PATH}"
+            SCREENSHOT_IMAGE="ghcr.io/projectbluefin/testsuite/desktop-screenshot"
+            PUSH_TAG="${IMG_SLUG}-${SUITE}-latest"
+            echo "${GITHUB_TOKEN}" | oras login ghcr.io \
+              -u github-actions --password-stdin || \
+              echo "Warning: failed to authenticate oras to GHCR" >&2
+            oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
+              --annotation "org.opencontainers.image.description=Bluefin KDE desktop screenshot from lab e2e suite: ${SUITE}" \
+              --annotation "io.github.projectbluefin.caller_repo=projectbluefin/lab" \
+              "${SHOT}:image/png" || \
+              echo "Warning: failed to push KDE screenshot" >&2
+          fi
+        elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
+          echo "No GITHUB_TOKEN - skipping GHCR screenshot push" >&2
+        fi
+
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+          rm -rf /workspace/lab-code
+          git clone --depth 1 \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
+            /workspace/lab-code
+          python3 /workspace/lab-code/scripts/publish_test_results.py \
+            /results/results.json "${IMG_SLUG}" "${SUITE}" \
+            "{{workflow.name}}" "${GITHUB_TOKEN}" "" \
+            "${FAILURE_CLASS}" "${FAILURE_ISSUE_URL}" || \
+            echo "Warning: failed to publish test results" >&2
+        else
+          echo "No GITHUB_TOKEN - skipping test results publication" >&2
+        fi
+
+        if [[ "${ARTIFACT_RC}" -ne 0 ]]; then
+          echo "ERROR: one or more KDE failure bundles could not be archived" >&2
+          exit "${ARTIFACT_RC}"
+        fi
+        if [[ "${SABOTAGE_MODE}" != "none" && "${BEHAVE_RC}" -eq 0 ]]; then
+          echo "SABOTAGE FAILURE: ${SABOTAGE_MODE} unexpectedly passed" >&2
+          exit 1
+        fi
+        exit "${BEHAVE_RC}"
     volumes:
     - name: workspace
       emptyDir:
         sizeLimit: 2Gi
     - name: ssh-key
       secret:
-        secretName: bluefin-test-ssh-key
+        secretName: "{{inputs.parameters.ssh-key-secret}}"
+        defaultMode: 0400
     - name: results
       emptyDir:
         sizeLimit: 1Gi

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -44,7 +44,7 @@ spec:
     activeDeadlineSeconds: 3600
     initContainers:
     - name: git-sync
-      image: ghcr.io/projectbluefin/lab-runner:latest
+      image: ghcr.io/projectbluefin/lab-runner@sha256:fe097bb3b85a126b9a16093fbc498b4b6fb7b24e0f74162ad3d91a402dcfa940
       resources:
         requests:
           cpu: 100m
@@ -100,7 +100,7 @@ spec:
       - name: workspace
         mountPath: /workspace
     container:
-      image: ghcr.io/projectbluefin/lab-runner:latest
+      image: ghcr.io/projectbluefin/lab-runner@sha256:fe097bb3b85a126b9a16093fbc498b4b6fb7b24e0f74162ad3d91a402dcfa940
       resources:
         requests:
           cpu: "1"

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -214,6 +214,71 @@ captures `results.json` to pod stdout (Loki + `argo logs`).
 Resource limits and `hostNetwork: true` are set on the pod (KubeVirt
 masquerade only routes from host netns).
 
+### `run-kde-tests` (template: `run-kde-tests`)
+
+Adapts the GNOME runner contract for Aurora/KDE VMs. It clones the selected
+testsuite branch, forwards SSH and WebDriver port 4723 through `virtctl`,
+starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
+`/status` endpoint, and runs `tests/kde-smoke/features` with Behave. Results
+and in-guest PNG screenshots are copied back even when Behave fails, then
+persisted under the standard ghost test-results host path. `faillog_*`
+directories are retained alongside `.tar.gz` bundles, and the first screenshot
+is pushed as the stable `desktop-screenshot` OCI artifact when the optional
+GitHub token is available. QEMU-level screendumps are not used because
+KubeVirt's `virt-launcher` does not expose a QEMU monitor.
+
+The runner accepts `failure-class: test|infra` and `failure-issue-url`
+parameters. A failed run classified as infrastructure must include the URL of
+its separate tracking issue; otherwise it is counted as a test failure. Every
+run rejects a retry setting other than `BEHAVE_RETRIES=2`.
+
+### `aurora-qa-pipeline` (template: `aurora-qa`)
+
+Runs the Aurora/KDE GUI suite against a KubeVirt VM in `aurora-test`:
+
+```text
+build Aurora containerDisk
+  → provision VM
+    → run-kde-tests
+      → collect-vm-logs
+```
+
+The pipeline builds `ghcr.io/ublue-os/aurora` into the
+`aurora-containerdisk` repository with a 30G disk, then passes the VM to the
+existing KDE runner. It has a one-hour `activeDeadlineSeconds`, holds the
+`aurora-vm-qa` ConfigMap semaphore for the full run, and always deletes the VM
+from its `onExit: teardown` handler. The template is GitOps-managed; live lab
+evidence may require a run after the change is merged and reconciled.
+
+KDE soak evidence is a rolling window, not a consecutive streak. The publisher
+retains the newest 30 runs and records `failure_class` (`test` or `infra`) plus
+the filed issue URL for infrastructure flakes. `BEHAVE_RETRIES=2` is enforced
+for every run. The window is qualified only after 30 runs with either at least
+29 passes, or at least 28 passes and no more than two classified infrastructure
+flakes:
+
+```bash
+just evaluate-kde-soak
+```
+
+The command reports `pending` until 30 runs exist and exits non-zero for an
+unqualified window. Qualification is evidence only; promotion to CI gating
+remains a human decision, and each infrastructure flake must have a separate
+filed issue.
+
+### `aurora-kde-sabotage`
+
+Runs the mandatory red-path proof in the isolated `aurora-test` namespace. It
+reuses the real VM and KDE runner, first replacing one launch target with
+`/usr/bin/this-does-not-exist`, then killing `plasmashell`. Both runs must
+fail, publish failed results, retain `kde_faillog` bundles, and leave no VM
+after `onExit` cleanup. Normal Aurora runs default to `sabotage-mode: none`;
+the runner rejects sabotage modes outside `aurora-test`.
+
+```bash
+just run-aurora-kde-sabotage
+```
+
 ### `run-flatcar-tests` (template: `run-flatcar-tests`)
 
 Same shape for Flatcar; uses `core` as the SSH user and runs pytest+dogtail

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -256,8 +256,8 @@ KDE soak evidence is a rolling window, not a consecutive streak. The publisher
 retains the newest 30 runs and records `failure_class` (`test` or `infra`) plus
 the filed issue URL for infrastructure flakes. `BEHAVE_RETRIES=2` is enforced
 for every run. The window is qualified only after 30 runs with either at least
-29 passes, or at least 28 passes and no more than two classified infrastructure
-flakes:
+29 passes, or at least 28 passes and no more than two infrastructure flakes that
+each have a filed issue URL. The two-flake budget is fixed and not configurable:
 
 ```bash
 just evaluate-kde-soak

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -252,6 +252,11 @@ existing KDE runner. It has a one-hour `activeDeadlineSeconds`, holds the
 from its `onExit: teardown` handler. The template is GitOps-managed; live lab
 evidence may require a run after the change is merged and reconciled.
 
+Before submitting a live run, confirm that both `aurora-qa-pipeline` and
+`run-kde-tests` exist in the `argo` namespace. If either template is absent,
+wait for ArgoCD reconciliation; local lint and merged Git history are not live
+lab evidence.
+
 KDE soak evidence is a rolling window, not a consecutive streak. The publisher
 retains the newest 30 runs and records `failure_class` (`test` or `infra`) plus
 the filed issue URL for infrastructure flakes. `BEHAVE_RETRIES=2` is enforced

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -268,6 +268,23 @@ unqualified window. Qualification is evidence only; promotion to CI gating
 remains a human decision, and each infrastructure flake must have a separate
 filed issue.
 
+### `nightly-kde`
+
+The `nightly-kde` CronWorkflow schedules the `aurora-qa-pipeline` at 04:00 UTC.
+The schedule is only a trigger: the pipeline's `aurora-vm-qa` key in the
+GitOps-managed `workflow-semaphores` ConfigMap is the serialization guard, so
+the soak remains safe if another nightly schedule is enabled or delayed.
+The CronWorkflow sets a 90-minute deadline, uses `Forbid` for duplicate
+triggers, and retains failed workflows for seven days.
+
+Each live run must publish the structured result and screenshot through
+`run-kde-tests`, and persist the result/artifact bundle before teardown. A
+qualified 30-run window is evidence only: retain the Argo workflow URL, the
+published `docs/results/aurora-testing-smoke.json` history, screenshot URL,
+and any filed issue URL for every classified infrastructure flake. Live-run
+evidence is required after ArgoCD reconciles the Git change; local lint cannot
+substitute for that evidence.
+
 ### `aurora-kde-sabotage`
 
 Runs the mandatory red-path proof in the isolated `aurora-test` namespace. It

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -223,8 +223,10 @@ starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
 and in-guest PNG screenshots are copied back even when Behave fails, then
 persisted under the standard ghost test-results host path. `faillog_*`
 directories are retained alongside `.tar.gz` bundles, and the first screenshot
-is pushed as the stable `desktop-screenshot` OCI artifact when the optional
-GitHub token is available. QEMU-level screendumps are not used because
+is pushed as the stable `desktop-screenshot` OCI artifact. The GitHub
+credential, ORAS tool, screenshot, artifact persistence, and result publication
+are required and fail the runner when unavailable. QEMU-level screendumps are
+not used because
 KubeVirt's `virt-launcher` does not expose a QEMU monitor.
 
 The runner accepts `failure-class: test|infra` and `failure-issue-url`

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -54,11 +54,19 @@ The workflow authoring guidance is split by topic:
 - `synchronization.semaphore:` (singular) in any pipeline — deprecated, rejected by ArgoCD schema. Use `synchronization.semaphores:` (list with `- configMapKeyRef:` item)
 - `spec.schedule:` (singular) on a CronWorkflow — field does not exist in CRD schema; use `spec.schedules:` (array)
 - A pipeline with VMs and no `spec.activeDeadlineSeconds` — a stuck VM holds its semaphore slot forever
-- A pipeline with VMs that adds `spec.synchronization.semaphores` — semaphores are removed; k8s scheduler handles concurrency via virt-launcher memory requests
+- A VM pipeline that adds a semaphore without a documented cross-workflow
+  capacity need — ordinary VM concurrency is handled by virt-launcher memory
+  requests and does not need a lock
+- A memory-constrained VM pipeline that omits a documented template-level
+  semaphore — concurrent virt-launcher and runner pods can exhaust node memory
 - A template that consumes a scarce, node-pinned resource relying only on
   workflow `parallelism` — that limit does not cover simultaneous workflows.
   Put a template-level `synchronization.semaphores` reference on the shared
   template and define its capacity in the GitOps-managed ConfigMap.
+- A `synchronization` block placed directly on a `dag.tasks[]` entry — Argo's
+  schema rejects it. Wrap the `templateRef` in a local `steps` template and put
+  the ConfigMap-backed semaphore on that wrapper when only one DAG task needs
+  cross-workflow serialization.
 - A `steps` or `dag` task calling a sub-template without `arguments:`
 - `{{steps.X.outputs...}}` or `{{tasks.X.outputs...}}` used as an input
   parameter *default inside a leaf template* — that scope only exists at
@@ -145,6 +153,15 @@ The workflow authoring guidance is split by topic:
   constant pipeline identifiers and bounded states. Workflow-level completion
   metrics are safe only when the workflow status truthfully represents the
   publish result; non-blocking or transitional DAG branches must be fixed first.
+- A KDE GUI runner that copies the GNOME runner without replacing
+  `qecore-headless` and the GNOME daemon — use the VM's
+  `selenium-webdriver-at-spi-run`, forward port 4723, and gate test start on
+  its `/status` endpoint.
+- KDE QA callers must pass the runner's `branch` parameter (not the removed
+  `testsuite-branch`) and use the established `aurora-test` namespace. The
+  runner must source a generated session environment containing D-Bus,
+  Wayland, AT-SPI, `XDG_SESSION_DESKTOP=kde`, and its WebDriver URL before
+  starting Selenium.
 
 ## Verification
 
@@ -157,12 +174,18 @@ Before marking any WorkflowTemplate change done:
 - [ ] Pipeline has `onExit: cleanup` handler
 - [ ] All pod-running templates have `resources:` requests and limits
 - [ ] Every node-pinned, high-memory shared template has a ConfigMap-backed
-      template-level semaphore sized to the node's allocatable capacity; VM
-      pipelines remain scheduler-managed
+      template-level semaphore sized to the node's allocatable capacity
+- [ ] Any semaphore intended for one DAG task is attached to a wrapper template,
+      not directly to `dag.tasks[]`; the wrapper's `steps` call the external
+      `templateRef`
+- [ ] VM pipelines are scheduler-managed by default; if cross-workflow memory
+      contention requires serialization, use a documented template-level
+      ConfigMap semaphore with an explicit capacity
 - [ ] Change is committed and pushed — not manually applied to cluster
 - [ ] `description:` annotation present on the new/modified template
 - [ ] File name matches `metadata.name` (e.g. `provision-containerdisk-vm.yaml` for `name: provision-containerdisk-vm`)
-- [ ] VM pipeline spec has NO `synchronization.semaphores` block — k8s scheduler handles VM concurrency
+- [ ] Any VM pipeline semaphore is justified by documented cross-workflow
+      memory contention and is attached at template level, not workflow scope
 - [ ] VM pipeline spec has `activeDeadlineSeconds` (1h or 2h) so stuck VMs self-evict
 - [ ] No `nodeSelector: kubernetes.io/hostname: ghost` in VM specs — VMs float to any KubeVirt-capable node
 - [ ] GitHub Contents API write-backs use curl+jq, not inline Python; output is
@@ -183,3 +206,13 @@ Before marking any WorkflowTemplate change done:
       exists on the repository's default branch before relying on dispatch
 - [ ] Registry workflows use a pinned image that actually contains every CLI
       invoked by the script, with flags valid for that exact version
+- [ ] KDE GUI runners preserve the GNOME runner's parameter/result contract,
+      use `selenium-webdriver-at-spi-run`, forward `4723:4723`, and wait for
+      WebDriver readiness before Behave execution
+- [ ] Aurora/KDE sabotage runs are explicit, restricted to `aurora-test`, and
+      exercise both the nonexistent-binary and killed-`plasmashell` red paths;
+      failure results and `kde_faillog` artifacts must be retained before
+      teardown
+- [ ] KDE soak evidence uses the newest 30 persisted runs and a two-flake
+      infrastructure budget, never a consecutive-green streak; promotion
+      remains a human decision

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -163,6 +163,9 @@ The workflow authoring guidance is split by topic:
   runner must source a generated session environment containing D-Bus,
   Wayland, AT-SPI, `XDG_SESSION_DESKTOP=kde`, and its WebDriver URL before
   starting Selenium.
+- KDE runner and teardown containers must use the repository-approved
+  digest-pinned `lab-runner` and shell-capable `kubectl` references; never
+  reintroduce floating `:latest` or `:latest-dev` tags in those workflows.
 
 ## Verification
 

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -166,6 +166,12 @@ The workflow authoring guidance is split by topic:
 - KDE runner and teardown containers must use the repository-approved
   digest-pinned `lab-runner` and shell-capable `kubectl` references; never
   reintroduce floating `:latest` or `:latest-dev` tags in those workflows.
+- When a workflow builds a containerDisk at runtime, publish it under a
+  workflow-unique tag, write the pushed digest to an output-parameter file, and
+  pass that output into the VM manifest as an `image@sha256:...` reference.
+  Argo output parameters use `valueFrom.path` and are consumed as
+  `{{steps.<step>.outputs.parameters.<name>}}` (source:
+  `/argoproj/argo-workflows`).
 
 ## Verification
 

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -213,6 +213,7 @@ Before marking any WorkflowTemplate change done:
       exercise both the nonexistent-binary and killed-`plasmashell` red paths;
       failure results and `kde_faillog` artifacts must be retained before
       teardown
-- [ ] KDE soak evidence uses the newest 30 persisted runs and a two-flake
-      infrastructure budget, never a consecutive-green streak; promotion
-      remains a human decision
+- [ ] KDE soak evidence uses the newest 30 persisted runs and a fixed two-flake
+      infrastructure budget; each counted flake has a filed issue URL; the gate
+      never requires a consecutive-green streak; promotion remains a human
+      decision

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -132,6 +132,7 @@ The workflow authoring guidance is split by topic:
 - A digest-comparison poller (`digest-watch`, `dakota-commit-poller`, etc.) treated as a guarantee that a downstream artifact exists — it only reacts to source digest *changes*, not to the artifact disappearing out-of-band (disk wipe, registry GC). After any disk/registry event, force-rebuild manually; don't wait for the poller.
 - A BuildStream poller relying only on the `bst-build` semaphore — execution is serialized, but waiting workflows can still grow without bound. Automated callers must enforce the two-workflow `bluefin.io/bst-workload=true` admission ceiling before submission.
 - **Queue Starvation / `activeDeadlineSeconds` Trap**: Leaving a workflow's `activeDeadlineSeconds` at default (or unspecified) when it queues under a template-level semaphore or resource limit. The workflow-level deadline starts ticking upon *submission/creation*, not *execution/scheduling*. If a workflow queues for longer than the global default deadline (e.g., 2h), it gets instantly canceled with `DeadlineExceeded` as soon as it begins running. Always set a generous workflow-level deadline (e.g., 4h/14400s) on queueable templates and dynamic API submission specs.
+- **Clock-only Cron serialization**: Spacing a CronWorkflow away from other schedules is not a concurrency guard. When a scheduled workflow shares a scarce VM namespace or runner, reference a ConfigMap-backed template semaphore and document the key; keep the schedule as a trigger only.
 - **Secret leakage via shell tracing**: Never use `set -x`/`set -eux` in a script that invokes authenticated APIs or expands secret-bearing variables. Argo retains command output in workflow logs. Disable tracing for the whole script or bracket only non-secret diagnostics with explicit `set +x`/`set -x` boundaries, then inspect logs for credentials before publishing evidence.
 - **Assuming registry tools exist in `lab-runner`**: the image does not include
   ORAS or skopeo. Use a pinned tool image (or an explicit, checked bootstrap),
@@ -170,6 +171,9 @@ Before marking any WorkflowTemplate change done:
 - [ ] All VM-running pipelines have `spec.activeDeadlineSeconds` set
 - [ ] All queueable templates/dynamic workflows (e.g. `build-containerdisk` and `digest-watch` submit payloads) have a generous workflow-level `activeDeadlineSeconds` (e.g., 14400s / 4h) to avoid queue starvation
 - [ ] Any new CronWorkflow uses `spec.schedules:` (array), not `spec.schedule:` (singular)
+- [ ] Any scheduled workflow sharing a VM namespace or scarce runner uses a
+      documented ConfigMap-backed template semaphore; clock separation alone is
+      not treated as serialization
 - [ ] All sub-template calls include explicit `arguments:` blocks
 - [ ] Pipeline has `onExit: cleanup` handler
 - [ ] All pod-running templates have `resources:` requests and limits

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -95,6 +95,40 @@ activeDeadlineSeconds: 3600   # 1h for containerdisk, 7200 for knuckle
 
 **VMs float to any KubeVirt-capable node** — no `nodeSelector: kubernetes.io/hostname: ghost` in VM specs. The registry-mirror-config DaemonSet writes the Zot HTTP registry config to all nodes.
 
+### 15a. Locking one DAG build task
+
+`synchronization` is a template-level field; it is not valid on an individual
+`dag.tasks[]` entry. When one task must share a cross-workflow semaphore with
+another builder, invoke a local wrapper template from the DAG and put the
+semaphore on that wrapper:
+
+```yaml
+tasks:
+  - name: build
+    template: serialized-build
+templates:
+  - name: serialized-build
+    synchronization:
+      semaphores:
+        - configMapKeyRef:
+            name: workflow-semaphores
+            key: migration-containerdisk-build
+    steps:
+      - - name: invoke-builder
+          templateRef:
+            name: shared-builder
+            template: build
+          arguments:
+            parameters:
+              - name: image
+                value: "{{workflow.parameters.image}}"
+```
+
+This keeps the lock around only the build task while preserving the
+cross-WorkflowTemplate `templateRef`. For diagnostic collection, include all
+terminal upstream states when appropriate:
+`(tests.Succeeded || tests.Failed || tests.Errored)`.
+
 ### 16. GitHub Contents API or Standalone Git Push-back — Prefer Standalone Python for Complex Files
 
 When a workflow pod needs to push a simple file to a GitHub repo, use `curl` + `jq` inside the bash script (Contents API).
@@ -112,6 +146,31 @@ However, for complex updates (such as parsing BDD/behave test results, merging w
           echo "No GITHUB_TOKEN - skipping test results publication" >&2
         fi
 ```
+
+#### KDE GUI runner: persist guest artifacts before re-raising failures
+
+KDE GUI tests run through a WebDriver service inside the VM, so screenshots and
+`faillog_*` diagnostics are written in the guest session. Set the shared
+results directory in both environments, copy it back with `scp` after Behave
+returns (including non-zero returns), archive each failure directory with
+`python3 -m tarfile` (the runner has no `tar`), then copy the complete directory
+to the runner's `/var/mnt/ghost-data/test-results` hostPath. Surface archive
+failures after persistence and publication instead of silently dropping them;
+re-raise the saved Behave status only after that cleanup.
+
+Require the GitHub credential, screenshot, and ORAS CLI. Publish the in-guest
+screenshot with the ORAS CLI's `path:media-type` syntax (verified against
+Context7 `/oras-project/oras`); missing inputs or a failed upload must fail the
+runner after artifact persistence:
+
+```bash
+oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
+  --annotation "io.github.projectbluefin.caller_repo=projectbluefin/lab" \
+  "${SHOT}:image/png"
+```
+
+Use guest-side screenshots for KubeVirt. `virt-launcher` does not expose a
+QEMU monitor, so QEMU-level screendump helpers are not a valid fallback.
 
 **Contents API Pattern (for simple single-file writes, verified against Context7 `/websites/github_en_rest`):**
 ```bash
@@ -160,7 +219,8 @@ systemd starts.
 1. Install tooling if it is missing: `command -v skopeo >/dev/null || dnf install -y skopeo` and `command -v git >/dev/null || dnf install -y git-core`.
 2. Resolve the digest of `{{inputs.parameters.image}}:{{inputs.parameters.image-tag}}` with `skopeo inspect --no-tags --format '{{.Digest}}' "docker://${IMAGE}"`. Treat a missing digest as a non-fatal warning.
 3. Compute the image slug as `IMG_SLUG="${VARIANT}-${IMAGE_TAG}"` so the result file name matches the contract used by `run-gnome-tests` (e.g. `bluefin-stable-smoke.json`).
-4. Perform the git push-back in a best-effort block: log a warning if `git clone` or `publish_test_results.py` fails, but do not let a publication error fail the test workflow.
+4. Treat the git clone and `publish_test_results.py` as required evidence
+   publication. Their failures must fail the test workflow after cleanup.
 5. Pass the resolved digest as the optional sixth positional argument to `publish_test_results.py` so the collector can match QA evidence to the currently published image digest.
 
 

--- a/manifests/nightly-kde.yaml
+++ b/manifests/nightly-kde.yaml
@@ -1,0 +1,52 @@
+# CronWorkflow: run the Aurora/KDE soak suite nightly at 04:00 UTC.
+#
+# The referenced pipeline owns the VM lifecycle, result publication, and the
+# aurora-vm-qa ConfigMap semaphore. The semaphore, not this schedule, is the
+# cross-workflow serialization guard.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: nightly-kde
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  suspend: false
+  schedules:
+    - "0 4 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  workflowMetadata:
+    labels:
+      app.kubernetes.io/part-of: aurora-test-suite
+      bluefin.io/trigger: nightly
+      bluefin.io/suite: kde-soak
+  workflowSpec:
+    serviceAccountName: argo
+    activeDeadlineSeconds: 5400
+    podGC:
+      strategy: OnWorkflowCompletion
+    ttlStrategy:
+      secondsAfterSuccess: 86400
+      secondsAfterFailure: 604800
+    workflowTemplateRef:
+      name: aurora-qa-pipeline
+    arguments:
+      parameters:
+        - name: image-tag
+          value: "testing"
+        - name: vm-name
+          value: "aurora-kde-{{workflow.uid}}"
+        - name: namespace
+          value: "aurora-test"
+        - name: containerdisk-repo
+          value: "aurora-containerdisk"
+        - name: suite
+          value: "kde-smoke"
+        - name: branch
+          value: "main"
+        - name: ssh-user
+          value: "bluefin-test"
+        - name: ssh-key-secret
+          value: "bluefin-test-ssh-key"

--- a/manifests/workflow-semaphores.yaml
+++ b/manifests/workflow-semaphores.yaml
@@ -25,6 +25,8 @@
 #                        semaphore (see docs/skills/argo-workflows/patterns.md).
 #   dakota-publish      — Serializes Zot-to-GHCR Dakota publication workflows
 #                        while both image lanes run independently inside one slot.
+#   aurora-vm-qa        — Serializes Aurora/KDE VM soak runs with other
+#                        workflows using the shared Aurora test namespace.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -38,3 +40,4 @@ data:
   migration-containerdisk-build: "1"
   ghost-container-qa: "6"
   dakota-publish: "1"
+  aurora-vm-qa: "1"

--- a/scripts/evaluate_kde_soak.py
+++ b/scripts/evaluate_kde_soak.py
@@ -7,10 +7,35 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
+import re
 
 
 WINDOW_SIZE = 30
 MAX_INFRA_FLAKES = 2
+GITHUB_ISSUE_PATH = re.compile(
+    r"^/[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?/"
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?/issues/[1-9][0-9]*/?$"
+)
+
+
+def is_trusted_github_issue_url(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return (
+        parsed.scheme == "https"
+        and parsed.hostname == "github.com"
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.port is None
+        and not parsed.query
+        and not parsed.fragment
+        and bool(GITHUB_ISSUE_PATH.fullmatch(parsed.path))
+    )
 
 
 def evaluate_kde_soak(
@@ -24,7 +49,7 @@ def evaluate_kde_soak(
     infra_flakes = sum(
         entry.get("status") == "failed"
         and entry.get("failure_class", "test") == "infra"
-        and bool(entry.get("failure_issue_url"))
+        and is_trusted_github_issue_url(entry.get("failure_issue_url"))
         for entry in window
     )
     test_failures = failed - infra_flakes

--- a/scripts/evaluate_kde_soak.py
+++ b/scripts/evaluate_kde_soak.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Evaluate the KDE rolling soak gate without requiring a consecutive streak."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+WINDOW_SIZE = 30
+MAX_INFRA_FLAKES = 2
+
+
+def evaluate_kde_soak(
+    history: list[dict[str, Any]],
+    *,
+    window_size: int = WINDOW_SIZE,
+    max_infra_flakes: int = MAX_INFRA_FLAKES,
+) -> dict[str, Any]:
+    window = history[:window_size]
+    passed = sum(entry.get("status") == "passed" for entry in window)
+    failed = len(window) - passed
+    infra_flakes = sum(
+        entry.get("status") == "failed"
+        and entry.get("failure_class", "test") == "infra"
+        for entry in window
+    )
+    test_failures = failed - infra_flakes
+    pass_rate = (passed / len(window) * 100) if window else None
+    qualified = len(window) >= window_size and (
+        passed >= window_size - 1
+        or (
+            passed >= window_size - 2
+            and failed == infra_flakes
+            and infra_flakes <= max_infra_flakes
+        )
+    )
+
+    if len(window) < window_size:
+        state = "pending"
+    elif qualified:
+        state = "qualified"
+    else:
+        state = "unqualified"
+
+    return {
+        "state": state,
+        "window_size": window_size,
+        "runs_recorded": len(window),
+        "passed_runs": passed,
+        "failed_runs": failed,
+        "infra_flakes": infra_flakes,
+        "test_failures": test_failures,
+        "pass_rate": round(pass_rate, 2) if pass_rate is not None else None,
+        "max_infra_flakes": max_infra_flakes,
+        "human_approval_required": qualified,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results_file", type=Path)
+    parser.add_argument("--window-size", type=int, default=WINDOW_SIZE)
+    parser.add_argument("--max-infra-flakes", type=int, default=MAX_INFRA_FLAKES)
+    args = parser.parse_args()
+
+    data = json.loads(args.results_file.read_text(encoding="utf-8"))
+    summary = evaluate_kde_soak(
+        data.get("history", []),
+        window_size=args.window_size,
+        max_infra_flakes=args.max_infra_flakes,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["state"] == "qualified" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_kde_soak.py
+++ b/scripts/evaluate_kde_soak.py
@@ -17,7 +17,6 @@ def evaluate_kde_soak(
     history: list[dict[str, Any]],
     *,
     window_size: int = WINDOW_SIZE,
-    max_infra_flakes: int = MAX_INFRA_FLAKES,
 ) -> dict[str, Any]:
     window = history[:window_size]
     passed = sum(entry.get("status") == "passed" for entry in window)
@@ -25,6 +24,7 @@ def evaluate_kde_soak(
     infra_flakes = sum(
         entry.get("status") == "failed"
         and entry.get("failure_class", "test") == "infra"
+        and bool(entry.get("failure_issue_url"))
         for entry in window
     )
     test_failures = failed - infra_flakes
@@ -34,7 +34,7 @@ def evaluate_kde_soak(
         or (
             passed >= window_size - 2
             and failed == infra_flakes
-            and infra_flakes <= max_infra_flakes
+            and infra_flakes <= MAX_INFRA_FLAKES
         )
     )
 
@@ -54,7 +54,7 @@ def evaluate_kde_soak(
         "infra_flakes": infra_flakes,
         "test_failures": test_failures,
         "pass_rate": round(pass_rate, 2) if pass_rate is not None else None,
-        "max_infra_flakes": max_infra_flakes,
+        "max_infra_flakes": MAX_INFRA_FLAKES,
         "human_approval_required": qualified,
     }
 
@@ -63,14 +63,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("results_file", type=Path)
     parser.add_argument("--window-size", type=int, default=WINDOW_SIZE)
-    parser.add_argument("--max-infra-flakes", type=int, default=MAX_INFRA_FLAKES)
     args = parser.parse_args()
 
     data = json.loads(args.results_file.read_text(encoding="utf-8"))
     summary = evaluate_kde_soak(
         data.get("history", []),
         window_size=args.window_size,
-        max_infra_flakes=args.max_infra_flakes,
     )
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0 if summary["state"] == "qualified" else 1

--- a/scripts/publish_test_results.py
+++ b/scripts/publish_test_results.py
@@ -7,6 +7,11 @@ import shutil
 import urllib.request
 from datetime import datetime, timezone
 
+from evaluate_kde_soak import evaluate_kde_soak
+
+
+VALID_FAILURE_CLASSES = {"test", "infra"}
+
 def ghcr_digest(repository, tag):
     """Resolve a public GHCR tag to its manifest digest anonymously."""
     try:
@@ -59,7 +64,20 @@ def run_cmd(cmd, cwd=None, env=None, check=True):
         sys.exit(result.returncode)
     return result
 
-def parse_results_and_build_update(data, existing_data, current_utc, workflow_name, img_slug, suite, digest=None):
+def parse_results_and_build_update(
+    data,
+    existing_data,
+    current_utc,
+    workflow_name,
+    img_slug,
+    suite,
+    digest=None,
+    failure_class="test",
+    failure_issue_url=None,
+):
+    if failure_class not in VALID_FAILURE_CLASSES:
+        raise ValueError(f"failure_class must be one of {sorted(VALID_FAILURE_CLASSES)}")
+
     failed_scenarios = []
     failed_scenarios_detailed = []
     scenarios_total = 0
@@ -107,6 +125,11 @@ def parse_results_and_build_update(data, existing_data, current_utc, workflow_na
                     })
 
     status = "passed" if scenarios_failed == 0 else "failed"
+    if status == "passed":
+        failure_class = "none"
+        failure_issue_url = None
+    elif failure_class == "infra" and not failure_issue_url:
+        raise ValueError("failure_issue_url is required for an infra failure")
 
     history = []
     if existing_data:
@@ -125,13 +148,21 @@ def parse_results_and_build_update(data, existing_data, current_utc, workflow_na
         new_history_entry["digest"] = digest
         
     history.insert(0, new_history_entry)
-    # Keep history capped to last 15 runs
-    history = history[:15]
+    # Keep the complete soak window; the evaluator uses the newest 30 entries.
+    history = history[:30]
 
     # Ensure all pre-existing entries in history also have a "duration_seconds" key (default to 0.0 if not present)
     for entry in history:
         if "duration_seconds" not in entry:
             entry["duration_seconds"] = 0.0
+        if entry.get("status") == "passed":
+            entry.setdefault("failure_class", "none")
+        else:
+            entry.setdefault("failure_class", "test")
+        entry.setdefault("failure_issue_url", None)
+
+    new_history_entry["failure_class"] = failure_class
+    new_history_entry["failure_issue_url"] = failure_issue_url
 
     # Construct updated structure
     screenshot_url = f"https://projectbluefin.github.io/lab/screenshots/{img_slug}-{suite}-latest.png"
@@ -149,6 +180,7 @@ def parse_results_and_build_update(data, existing_data, current_utc, workflow_na
         "screenshot_url": screenshot_url,
         "history": history
     }
+    updated_data["soak"] = evaluate_kde_soak(history)
     if digest:
         updated_data["digest"] = digest
     return updated_data
@@ -164,6 +196,8 @@ def main():
     workflow_name = sys.argv[4]
     github_token = sys.argv[5]
     digest = sys.argv[6] if len(sys.argv) > 6 else None
+    failure_class = sys.argv[7] if len(sys.argv) > 7 else "test"
+    failure_issue_url = sys.argv[8] if len(sys.argv) > 8 else None
 
     if not digest:
         print(f"No digest provided. Attempting anonymous resolution for slug {img_slug}...")
@@ -220,7 +254,9 @@ def main():
         workflow_name=workflow_name,
         img_slug=img_slug,
         suite=suite,
-        digest=digest
+        digest=digest,
+        failure_class=failure_class,
+        failure_issue_url=failure_issue_url,
     )
 
     with open(result_filepath, 'w') as f:

--- a/scripts/publish_test_results.py
+++ b/scripts/publish_test_results.py
@@ -8,7 +8,7 @@ import shutil
 import urllib.request
 from datetime import datetime, timezone
 
-from evaluate_kde_soak import evaluate_kde_soak
+from evaluate_kde_soak import evaluate_kde_soak, is_trusted_github_issue_url
 
 
 VALID_FAILURE_CLASSES = {"test", "infra"}
@@ -133,8 +133,8 @@ def parse_results_and_build_update(
     if status == "passed":
         failure_class = "none"
         failure_issue_url = None
-    elif failure_class == "infra" and not failure_issue_url:
-        raise ValueError("failure_issue_url is required for an infra failure")
+    elif failure_class == "infra" and not is_trusted_github_issue_url(failure_issue_url):
+        raise ValueError("failure_issue_url must be a trusted GitHub issue URL for an infra failure")
 
     history = []
     if existing_data:

--- a/scripts/publish_test_results.py
+++ b/scripts/publish_test_results.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import json
+import re
 import subprocess
 import shutil
 import urllib.request
@@ -55,7 +56,11 @@ def resolve_digest_for_slug(img_slug):
     return None
 
 def run_cmd(cmd, cwd=None, env=None, check=True):
-    print(f"Running command: {' '.join(cmd)}")
+    safe_cmd = [
+        re.sub(r"(https://x-access-token:)[^@]+@", r"\1***@", arg)
+        for arg in cmd
+    ]
+    print(f"Running command: {' '.join(safe_cmd)}")
     result = subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
     if check and result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
@@ -187,7 +192,7 @@ def parse_results_and_build_update(
 
 def main():
     if len(sys.argv) < 6:
-        print("Usage: publish_test_results.py <results_json_path> <img_slug> <suite> <workflow_name> <github_token> [digest]")
+        print("Usage: publish_test_results.py <results_json_path> <img_slug> <suite> <workflow_name> <github_token> [digest] [failure_class] [failure_issue_url]")
         sys.exit(1)
 
     results_json_path = sys.argv[1]
@@ -208,12 +213,12 @@ def main():
             print("Digest resolution skipped or failed.")
 
     if not github_token:
-        print("ERROR: github_token is empty. Skipping publication.")
-        sys.exit(0)
+        print("ERROR: github_token is empty.", file=sys.stderr)
+        sys.exit(2)
 
     if not os.path.exists(results_json_path):
-        print(f"WARNING: {results_json_path} not found. Skipping publication.")
-        sys.exit(0)
+        print(f"ERROR: {results_json_path} not found.", file=sys.stderr)
+        sys.exit(2)
 
     # 1. Parse behave results.json
     try:
@@ -221,12 +226,12 @@ def main():
             data = json.load(f)
     except Exception as e:
         print(f"ERROR: Failed to parse {results_json_path}: {e}")
-        sys.exit(0)
+        sys.exit(2)
 
     current_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # 2. Clone projectbluefin/lab to a temporary directory
-    temp_dir = "/tmp/lab-repo-clone"
+    temp_dir = os.path.join(os.getcwd(), ".lab-repo-clone")
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
 
@@ -245,7 +250,8 @@ def main():
             with open(result_filepath, 'r') as f:
                 existing_data = json.load(f)
         except Exception as e:
-            print(f"WARNING: Failed to parse existing results file {result_filepath}: {e}")
+            print(f"ERROR: Failed to parse existing results file {result_filepath}: {e}", file=sys.stderr)
+            sys.exit(2)
 
     updated_data = parse_results_and_build_update(
         data=data,

--- a/tests/unit/test_publish_test_results.py
+++ b/tests/unit/test_publish_test_results.py
@@ -9,7 +9,10 @@ scripts_path = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_path))
 
 from publish_test_results import parse_results_and_build_update  # noqa: E402
-from evaluate_kde_soak import evaluate_kde_soak  # noqa: E402
+from evaluate_kde_soak import (  # noqa: E402
+    evaluate_kde_soak,
+    is_trusted_github_issue_url,
+)
 
 def test_parse_results_and_build_update():
     # Sample behave JSON
@@ -180,6 +183,74 @@ def test_kde_soak_does_not_accept_infra_flakes_without_issue_urls():
             "status": "failed" if index < 2 else "passed",
             "failure_class": "infra" if index < 2 else "none",
             "failure_issue_url": None,
+        }
+        for index in range(30)
+    ]
+
+    assert evaluate_kde_soak(history)["state"] == "unqualified"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/projectbluefin/lab/issues/492",
+        "https://github.com/projectbluefin/lab/issues/492/",
+    ],
+)
+def test_trusted_github_issue_urls_are_accepted(url):
+    assert is_trusted_github_issue_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not a URL",
+        "https://example.com/projectbluefin/lab/issues/492",
+        "http://github.com/projectbluefin/lab/issues/492",
+        "https://github.com/projectbluefin/lab/pull/492",
+        "https://github.com/projectbluefin/lab/issues/",
+        "https://github.com/projectbluefin/lab/issues/492?redirect=example.com",
+        "https://github.com.evil.example/projectbluefin/lab/issues/492",
+    ],
+)
+def test_issue_url_bypass_attempts_are_rejected(url):
+    assert not is_trusted_github_issue_url(url)
+
+
+def test_infrastructure_failure_rejects_untrusted_issue_url():
+    with pytest.raises(ValueError, match="trusted GitHub issue URL"):
+        parse_results_and_build_update(
+            data=[
+                {
+                    "elements": [
+                        {
+                            "type": "scenario",
+                            "status": "failed",
+                            "name": "infra failure",
+                            "steps": [],
+                        }
+                    ]
+                }
+            ],
+            existing_data=None,
+            current_utc="2026-07-10T01:00:00Z",
+            workflow_name="infra-workflow",
+            img_slug="aurora-testing",
+            suite="smoke",
+            failure_class="infra",
+            failure_issue_url="https://example.com/fake-issue",
+        )
+
+
+def test_soak_does_not_count_untrusted_issue_url_as_infrastructure_flake():
+    history = [
+        {
+            "status": "failed" if index < 2 else "passed",
+            "failure_class": "infra" if index < 2 else "none",
+            "failure_issue_url": (
+                "https://example.com/fake-issue" if index < 2 else None
+            ),
         }
         for index in range(30)
     ]

--- a/tests/unit/test_publish_test_results.py
+++ b/tests/unit/test_publish_test_results.py
@@ -137,6 +137,11 @@ def test_kde_soak_allows_two_classified_infrastructure_flakes():
         {
             "status": "failed" if index < 2 else "passed",
             "failure_class": "infra" if index < 2 else "none",
+            "failure_issue_url": (
+                "https://github.com/projectbluefin/lab/issues/466"
+                if index < 2
+                else None
+            ),
         }
         for index in range(30)
     ]
@@ -167,6 +172,37 @@ def test_kde_soak_rejects_two_test_failures():
     ]
 
     assert evaluate_kde_soak(history)["state"] == "unqualified"
+
+
+def test_kde_soak_does_not_accept_infra_flakes_without_issue_urls():
+    history = [
+        {
+            "status": "failed" if index < 2 else "passed",
+            "failure_class": "infra" if index < 2 else "none",
+            "failure_issue_url": None,
+        }
+        for index in range(30)
+    ]
+
+    assert evaluate_kde_soak(history)["state"] == "unqualified"
+
+
+def test_kde_soak_keeps_fixed_two_flake_budget():
+    history = [
+        {
+            "status": "failed" if index < 3 else "passed",
+            "failure_class": "infra" if index < 3 else "none",
+            "failure_issue_url": "https://github.com/projectbluefin/lab/issues/466"
+            if index < 3
+            else None,
+        }
+        for index in range(30)
+    ]
+
+    summary = evaluate_kde_soak(history)
+
+    assert summary["state"] == "unqualified"
+    assert summary["max_infra_flakes"] == 2
 
 
 def test_kde_soak_is_pending_before_thirty_runs():

--- a/tests/unit/test_publish_test_results.py
+++ b/tests/unit/test_publish_test_results.py
@@ -1,4 +1,5 @@
 import sys
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -194,6 +195,29 @@ def test_infrastructure_failure_requires_a_filed_issue():
             suite="smoke",
             failure_class="infra",
         )
+
+
+def test_publication_input_failures_are_nonzero():
+    script = scripts_path / "publish_test_results.py"
+    missing = scripts_path / "does-not-exist.json"
+
+    missing_token = subprocess.run(
+        [sys.executable, str(script), str(missing), "aurora", "smoke", "wf", ""],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    missing_results = subprocess.run(
+        [sys.executable, str(script), str(missing), "aurora", "smoke", "wf", "token"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert missing_token.returncode != 0
+    assert missing_results.returncode != 0
+    assert "Skipping" not in missing_token.stderr
+    assert "Skipping" not in missing_results.stderr
 
 def test_parse_real_sample_results():
     import json

--- a/tests/unit/test_publish_test_results.py
+++ b/tests/unit/test_publish_test_results.py
@@ -1,11 +1,14 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add scripts directory to path to import publish_test_results
 scripts_path = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_path))
 
 from publish_test_results import parse_results_and_build_update  # noqa: E402
+from evaluate_kde_soak import evaluate_kde_soak  # noqa: E402
 
 def test_parse_results_and_build_update():
     # Sample behave JSON
@@ -124,6 +127,73 @@ def test_parse_results_and_build_update():
     old_entry = updated["history"][1]
     assert old_entry["workflow_name"] == "previous-workflow"
     assert old_entry["duration_seconds"] == 0.0
+    assert new_entry["failure_class"] == "test"
+    assert updated["soak"]["state"] == "pending"
+
+
+def test_kde_soak_allows_two_classified_infrastructure_flakes():
+    history = [
+        {
+            "status": "failed" if index < 2 else "passed",
+            "failure_class": "infra" if index < 2 else "none",
+        }
+        for index in range(30)
+    ]
+
+    summary = evaluate_kde_soak(history)
+
+    assert summary == {
+        "state": "qualified",
+        "window_size": 30,
+        "runs_recorded": 30,
+        "passed_runs": 28,
+        "failed_runs": 2,
+        "infra_flakes": 2,
+        "test_failures": 0,
+        "pass_rate": 93.33,
+        "max_infra_flakes": 2,
+        "human_approval_required": True,
+    }
+
+
+def test_kde_soak_rejects_two_test_failures():
+    history = [
+        {
+            "status": "failed" if index < 2 else "passed",
+            "failure_class": "test" if index < 2 else "none",
+        }
+        for index in range(30)
+    ]
+
+    assert evaluate_kde_soak(history)["state"] == "unqualified"
+
+
+def test_kde_soak_is_pending_before_thirty_runs():
+    assert evaluate_kde_soak([{"status": "passed"}] * 29)["state"] == "pending"
+
+
+def test_infrastructure_failure_requires_a_filed_issue():
+    with pytest.raises(ValueError, match="failure_issue_url"):
+        parse_results_and_build_update(
+            data=[
+                {
+                    "elements": [
+                        {
+                            "type": "scenario",
+                            "status": "failed",
+                            "name": "infra failure",
+                            "steps": [],
+                        }
+                    ]
+                }
+            ],
+            existing_data=None,
+            current_utc="2026-07-10T01:00:00Z",
+            workflow_name="infra-workflow",
+            img_slug="aurora-testing",
+            suite="smoke",
+            failure_class="infra",
+        )
 
 def test_parse_real_sample_results():
     import json
@@ -157,4 +227,3 @@ def test_parse_real_sample_results():
         assert isinstance(item["error_message"], str)
         assert len(item["failing_step"]) > 0
         assert len(item["error_message"]) > 0
-

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -246,6 +246,29 @@ def test_aurora_qa_pipeline_is_vm_based_and_serialized():
     assert semaphores["data"]["aurora-vm-qa"] == "1"
 
 
+def test_nightly_kde_cron_uses_aurora_pipeline_and_shared_semaphore():
+    cron_path = ROOT / "manifests/nightly-kde.yaml"
+    cron = yaml.safe_load(cron_path.read_text(encoding="utf-8"))
+    spec = cron["spec"]
+    workflow_spec = spec["workflowSpec"]
+
+    assert cron["metadata"]["name"] == "nightly-kde"
+    assert spec["schedules"] == ["0 4 * * *"]
+    assert spec["concurrencyPolicy"] == "Forbid"
+    assert workflow_spec["activeDeadlineSeconds"] == 5400
+    assert workflow_spec["workflowTemplateRef"] == {"name": "aurora-qa-pipeline"}
+    assert {
+        parameter["name"]: parameter["value"]
+        for parameter in workflow_spec["arguments"]["parameters"]
+    }["namespace"] == "aurora-test"
+
+    semaphore = yaml.safe_load(
+        (ROOT / "manifests/workflow-semaphores.yaml").read_text(encoding="utf-8")
+    )
+    assert semaphore["data"]["aurora-vm-qa"] == "1"
+    assert "semaphore" in cron_path.read_text(encoding="utf-8")
+
+
 def test_aurora_qa_pipeline_exposes_safe_kde_sabotage_modes():
     pipeline_path = ROOT / "argo/workflow-templates/aurora-qa-pipeline.yaml"
     pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -322,6 +322,9 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "- name: behave-retries" in kde
     assert 'value: "2"' in kde
     assert "BEHAVE_RETRIES=2" in kde
+    assert "Required credential is missing: GITHUB_TOKEN" in kde
+    assert "optional: true" not in kde
+    assert "ERROR: failed to publish KDE test results" in kde
     assert "qecore-headless" not in kde
     assert "gnome-ponytail-daemon" not in kde
 
@@ -335,11 +338,13 @@ def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
     assert "python3 -m tarfile -c" in kde
     assert "tar -czf" not in kde
     assert "ARTIFACT_RC=1" in kde
-    assert "could not be archived" in kde
+    assert "evidence artifacts were not fully retained" in kde
     assert "scp" in kde
     assert "BEHAVE_RC=0" in kde
     assert "SCREENSHOT_IMAGE=" in kde
     assert "oras push" in kde
+    assert "ERROR: failed to publish KDE screenshot artifact" in kde
+    assert "Warning: failed" not in kde
     assert "TESTSUITE_RESULTS_DIR" in kde
     assert "qemu_screendump" not in kde
 

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -372,7 +372,7 @@ def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
     assert "qemu_screendump" not in kde
 
 
-def test_kde_workflow_calls_runner_with_current_contract():
+def test_kde_linux_workflow_calls_native_runner_with_current_contract():
     workflow = (ROOT / "argo/kde-linux-qa.yaml").read_text(encoding="utf-8")
     provision = (
         ROOT / "argo/workflow-templates/provision-kde-linux-vm.yaml"
@@ -384,6 +384,20 @@ def test_kde_workflow_calls_runner_with_current_contract():
     assert "testsuite-branch" not in workflow
     assert 'value: "aurora-test"' in provision
     assert "kde-test-namespace" not in workflow
+
+
+def test_kde_workflow_images_are_digest_pinned():
+    paths = (
+        ROOT / "argo/kde-linux-qa.yaml",
+        ROOT / "argo/aurora-kde-sabotage.yaml",
+        ROOT / "argo/workflow-templates/aurora-qa-pipeline.yaml",
+        ROOT / "argo/workflow-templates/provision-kde-linux-vm.yaml",
+        ROOT / "argo/workflow-templates/run-kde-tests.yaml",
+    )
+    for path in paths:
+        content = path.read_text(encoding="utf-8")
+        assert "ghcr.io/projectbluefin/lab-runner:latest" not in content
+        assert "cgr.dev/chainguard/kubectl:latest-dev" not in content
 
 
 def test_kde_runner_sources_complete_session_environment():

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -183,6 +183,198 @@ def test_aurora_containerdisk_builder_isolated_and_prebaked():
     assert "storage: 100Gi" in aurora
 
 
+def test_aurora_qa_pipeline_is_vm_based_and_serialized():
+    pipeline_path = ROOT / "argo/workflow-templates/aurora-qa-pipeline.yaml"
+    assert pipeline_path.exists()
+    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+    spec = pipeline["spec"]
+
+    assert pipeline["metadata"]["name"] == "aurora-qa-pipeline"
+    assert spec["entrypoint"] == "aurora-qa"
+    assert spec["onExit"] == "teardown"
+    assert spec["activeDeadlineSeconds"] == 3600
+    assert spec["templates"][0]["name"] == "aurora-qa"
+    assert spec["templates"][0]["synchronization"]["semaphores"][0]["configMapKeyRef"] == {
+        "name": "workflow-semaphores",
+        "key": "aurora-vm-qa",
+    }
+
+    tasks = spec["templates"][0]["dag"]["tasks"]
+    assert [task["name"] for task in tasks] == [
+        "build-aurora-containerdisk",
+        "provision-containerdisk-vm",
+        "run-kde-tests",
+        "collect-logs",
+    ]
+    assert tasks[0]["template"] == "build-aurora-containerdisk"
+    build_template = next(
+        template
+        for template in spec["templates"]
+        if template["name"] == "build-aurora-containerdisk"
+    )
+    assert build_template["synchronization"]["semaphores"][0]["configMapKeyRef"] == {
+        "name": "workflow-semaphores",
+        "key": "migration-containerdisk-build",
+    }
+    assert build_template["steps"][0][0]["templateRef"] == {
+        "name": "build-bluefin-migration-containerdisk",
+        "template": "build-containerdisk",
+    }
+    assert tasks[1]["templateRef"] == {
+        "name": "provision-containerdisk-vm",
+        "template": "provision-vm",
+    }
+    assert tasks[2]["templateRef"] == {
+        "name": "run-kde-tests",
+        "template": "run-kde-tests",
+    }
+    assert tasks[3]["templateRef"] == {
+        "name": "collect-vm-logs",
+        "template": "collect-vm-logs",
+    }
+
+    content = pipeline_path.read_text(encoding="utf-8")
+    assert "containerdisk-repo" in content
+    assert "value: aurora-containerdisk" in content
+    assert "value: aurora-test" in content
+    assert "value: 30G" in content
+    assert "run-kde-tests.Errored" in content
+
+    semaphores = yaml.safe_load(
+        (ROOT / "manifests/workflow-semaphores.yaml").read_text(encoding="utf-8")
+    )
+    assert semaphores["data"]["aurora-vm-qa"] == "1"
+
+
+def test_aurora_qa_pipeline_exposes_safe_kde_sabotage_modes():
+    pipeline_path = ROOT / "argo/workflow-templates/aurora-qa-pipeline.yaml"
+    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+    parameters = {
+        parameter["name"]: parameter.get("value")
+        for parameter in pipeline["spec"]["arguments"]["parameters"]
+    }
+    assert parameters["sabotage-mode"] == "none"
+    assert "sabotage-mode" in pipeline_path.read_text(encoding="utf-8")
+
+    runner = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "missing-binary" in runner
+    assert "kill-plasmashell" in runner
+    assert "this-does-not-exist" in runner
+    assert "pkill -x plasmashell" in runner
+    assert "unexpectedly passed" in runner
+    assert "aurora-test" in runner
+
+
+def test_aurora_kde_sabotage_workflow_runs_both_controlled_failures():
+    path = ROOT / "argo/aurora-kde-sabotage.yaml"
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert workflow["spec"]["onExit"] == "cleanup"
+    tasks = workflow["spec"]["templates"][0]["dag"]["tasks"]
+    sabotage_tasks = [
+        task for task in tasks if task["name"] in {"missing-binary", "kill-plasmashell"}
+    ]
+    assert [task["name"] for task in sabotage_tasks] == [
+        "missing-binary",
+        "kill-plasmashell",
+    ]
+    content = path.read_text(encoding="utf-8")
+    assert "sabotage-mode" in content
+    assert "aurora-test" in content
+    assert "delete vm" in content.lower()
+
+
+def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
+    gnome = (ROOT / "argo/workflow-templates/run-gnome-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for parameter in (
+        "vm-name",
+        "vm-namespace",
+        "suite",
+        "variant",
+        "ssh-user",
+        "ssh-key-secret",
+        "issue-title",
+        "behave-tags",
+        "branch",
+        "containerdisk-tag",
+    ):
+        assert f"- name: {parameter}" in gnome
+        assert f"- name: {parameter}" in kde
+
+    assert 'value: "aurora-test"' in kde
+    assert 'value: "kde-smoke"' in kde
+    assert "4723:4723" in kde
+    assert "selenium-webdriver-at-spi-run" in kde
+    assert "KDE_WEBDRIVER_URL" in kde
+    assert "XDG_SESSION_DESKTOP=kde" in kde
+    assert "/status" in kde
+    assert "publish_test_results.py" in kde
+    assert "/var/mnt/ghost-data/test-results" in kde
+    assert "- name: failure-class" in kde
+    assert "- name: failure-issue-url" in kde
+    assert "- name: behave-retries" in kde
+    assert 'value: "2"' in kde
+    assert "BEHAVE_RETRIES=2" in kde
+    assert "qecore-headless" not in kde
+    assert "gnome-ponytail-daemon" not in kde
+
+
+def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "faillog_" in kde
+    assert "python3 -m tarfile -c" in kde
+    assert "tar -czf" not in kde
+    assert "ARTIFACT_RC=1" in kde
+    assert "could not be archived" in kde
+    assert "scp" in kde
+    assert "BEHAVE_RC=0" in kde
+    assert "SCREENSHOT_IMAGE=" in kde
+    assert "oras push" in kde
+    assert "TESTSUITE_RESULTS_DIR" in kde
+    assert "qemu_screendump" not in kde
+
+
+def test_kde_workflow_calls_runner_with_current_contract():
+    workflow = (ROOT / "argo/kde-linux-qa.yaml").read_text(encoding="utf-8")
+    provision = (
+        ROOT / "argo/workflow-templates/provision-kde-linux-vm.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert 'value: "aurora-test"' in workflow
+    assert "- name: branch" in workflow
+    assert "workflow.parameters.branch" in workflow
+    assert "testsuite-branch" not in workflow
+    assert 'value: "aurora-test"' in provision
+    assert "kde-test-namespace" not in workflow
+
+
+def test_kde_runner_sources_complete_session_environment():
+    kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for variable in (
+        "DBUS_SESSION_BUS_ADDRESS",
+        "WAYLAND_DISPLAY",
+        "XDG_RUNTIME_DIR",
+        "AT_SPI_BUS_ADDRESS",
+        "XDG_SESSION_DESKTOP",
+        "KDE_WEBDRIVER_URL",
+    ):
+        assert variable in kde
+    assert "source /tmp/session.env" in kde
+
+
 def test_cache_only_diagnostic_disables_remote_execution_explicitly():
     config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(encoding="utf-8")
     assert "remote-execution: {}" not in config

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -398,6 +398,7 @@ def test_kde_workflow_images_are_digest_pinned():
         content = path.read_text(encoding="utf-8")
         assert "ghcr.io/projectbluefin/lab-runner:latest" not in content
         assert "cgr.dev/chainguard/kubectl:latest-dev" not in content
+        assert "kde-linux-containerdisk:latest" not in content
 
     provision = yaml.safe_load(
         (ROOT / "argo/workflow-templates/provision-kde-linux-vm.yaml").read_text(
@@ -414,6 +415,29 @@ def test_kde_workflow_images_are_digest_pinned():
         "fe097bb3b85a126b9a16093fbc498b4b6fb7b24e0f74162ad3d91a402dcfa940"
     )
     assert wait_for_vm["script"]["command"] == ["bash"]
+    prepare_disk = next(
+        template
+        for template in provision["spec"]["templates"]
+        if template["name"] == "prepare-disk"
+    )
+    assert prepare_disk["script"]["image"] == (
+        "quay.io/buildah/stable@sha256:"
+        "7bb110e1d8b761d08e87d004ea4086e295a52319f3ea70ecef65da6dff7ceef0"
+    )
+    assert "outputs" in prepare_disk
+    assert "containerdisk-digest" in {
+        output["name"] for output in prepare_disk["outputs"]["parameters"]
+    }
+    create_vm = next(
+        template
+        for template in provision["spec"]["templates"]
+        if template["name"] == "create-vm"
+    )
+    assert (
+        "image: 192.168.1.102:30500/kde-linux-containerdisk@"
+        "{{inputs.parameters.containerdisk-digest}}"
+        in create_vm["resource"]["manifest"]
+    )
 
 
 def test_kde_runner_sources_complete_session_environment():

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -399,6 +399,22 @@ def test_kde_workflow_images_are_digest_pinned():
         assert "ghcr.io/projectbluefin/lab-runner:latest" not in content
         assert "cgr.dev/chainguard/kubectl:latest-dev" not in content
 
+    provision = yaml.safe_load(
+        (ROOT / "argo/workflow-templates/provision-kde-linux-vm.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    wait_for_vm = next(
+        template
+        for template in provision["spec"]["templates"]
+        if template["name"] == "wait-for-vm"
+    )
+    assert wait_for_vm["script"]["image"] == (
+        "ghcr.io/projectbluefin/lab-runner@sha256:"
+        "fe097bb3b85a126b9a16093fbc498b4b6fb7b24e0f74162ad3d91a402dcfa940"
+    )
+    assert wait_for_vm["script"]["command"] == ["bash"]
+
 
 def test_kde_runner_sources_complete_session_environment():
     kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(


### PR DESCRIPTION
## Summary
- add the nightly-kde CronWorkflow at 04:00 UTC
- serialize Aurora/KDE runs with the GitOps-managed aurora-vm-qa semaphore
- document the corrected rolling 30-run evaluator and live evidence requirements
- add focused manifest/semaphore coverage

## Validation
- `just lint`
- `argo lint --offline manifests/nightly-kde.yaml argo/workflow-templates/*.yaml`
- `pytest -q tests/unit/test_workflow_defaults.py -k nightly_kde tests/unit/test_publish_test_results.py -k "kde_soak or infrastructure_failure"`

Live lab evidence remains required after ArgoCD reconciliation; this PR does not apply manifests or merge them.