### PR TITLE
fix: retrigger llm-d rollout after policy change

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ just run-tests
 | `bluefin-lts-test` | `lts` test VMs |
 | `flatcar-test` | Flatcar test VMs |
 | `gnomeos-test` | GNOME OS test VMs |
-| `llm-d` | Local inference namespace (disabled by default; scale deployment up only when needed) |
+| `llm-d` | Local inference namespace (vLLM on ROCm; managed by ArgoCD with 1 GPU-backed replica) |
 | `local-registry` | Zot writable registry (30500) + pull-through cache (30501) |
 | `arc-systems` | ARC controller + listener pods |
 | `arc-runners` | ARC ephemeral runner pods (empty when no jobs queued) |
@@ -350,7 +350,7 @@ This lets ArgoCD own the template lifecycle while keeping submission flexible.
 3. Tag new scenarios `@wip` until stable.
 4. Submit a run: `just run-tests` (smoke) or `just run-tests-tag lts-testing`.
 
-See [/docs/skills/test-authoring/dogtail-patterns.md](/docs/skills/test-authoring/dogtail-patterns.md) for AT-SPI test authoring.
+See [`projectbluefin/testsuite`](https://github.com/projectbluefin/testsuite) for AT-SPI test authoring.
 
 ---
 
@@ -367,7 +367,7 @@ See [/docs/skills/test-authoring/dogtail-patterns.md](/docs/skills/test-authorin
 | [docs/ops/RUNBOOK.md](/docs/ops/RUNBOOK.md) | Timeless architecture + failure-mode reference |
 | [docs/reference/agent-cheatsheet.md](/docs/reference/agent-cheatsheet.md) | Canonical command reference |
 | [docs/ops/lab-operations.md](/docs/ops/lab-operations.md) | Long-form operator procedures |
-| [docs/skills/test-authoring/dogtail-patterns.md](/docs/skills/test-authoring/dogtail-patterns.md) | GUI test authoring + debugging |
+| [projectbluefin/testsuite](https://github.com/projectbluefin/testsuite) | GUI test authoring + debugging |
 
 ---
 

--- a/argo/workflow-templates/k8sgpt-on-demand.yaml
+++ b/argo/workflow-templates/k8sgpt-on-demand.yaml
@@ -26,7 +26,7 @@ spec:
       - name: filters
         value: "Pod,Deployment,Service,Ingress,Node"
       - name: ignored-services
-        value: "argocd/argocd-applicationset-controller,argocd/argocd-dex-server,argocd/argocd-notifications-controller-metrics,kubevirt/virt-exportproxy,llm-d/llm-d-modelserver"
+        value: "argocd/argocd-applicationset-controller,argocd/argocd-dex-server,argocd/argocd-notifications-controller-metrics,kubevirt/virt-exportproxy"
       - name: ignored-ingresses
         value: "wds1-system/wds1"
       - name: provider

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -7,7 +7,7 @@
 > - [`/docs/ops/lab-operations.md`](/docs/ops/lab-operations.md) — long-form procedures
 > - [`/docs/reference/WORKFLOWS.md`](/docs/reference/WORKFLOWS.md) — WorkflowTemplate parameter contracts
 > - [`/docs/ops/RUNBOOK.md`](/docs/ops/RUNBOOK.md) — architecture + failure-mode index
-> - [`/docs/skills/test-authoring/dogtail-patterns.md`](/docs/skills/test-authoring/dogtail-patterns.md) — writing GUI tests
+> - [`projectbluefin/testsuite`](https://github.com/projectbluefin/testsuite) — writing GUI tests
 > - [`/AGENTS.md`](/AGENTS.md) — hard policy and tenets
 
 > [!NOTE]
@@ -48,6 +48,32 @@ are prohibited. Confirm the generated BuildStream configuration, both Ready
 BuildBarn workers, and live worker action activity before calling a run
 distributed.
 
+## AMD ROCm GPU readiness — quick checks
+
+If the AMD GPU exists on the host but Kubernetes still refuses to schedule `amd.com/gpu` workloads, confirm the ROCm device plugin is installed and the node is labeled for it:
+
+```bash
+kubectl label node exo-0 lab.projectbluefin.io/amd-gpu=true --overwrite
+kubectl apply -f manifests/amdgpu-device-plugin.yaml
+kubectl rollout status daemonset/amdgpu-device-plugin -n kube-system --timeout=300s
+kubectl get node exo-0 -o jsonpath='{.status.allocatable.amd\.com/gpu}{"\n"}'
+```
+
+Expected outcome: the node advertises `1` or more `amd.com/gpu` allocatable units, and the `amdgpu-device-plugin` DaemonSet pod is `Running` on the GPU node.
+
+## Local LLM deployment — quick checks
+
+The lab also has a repo-managed vLLM deployment in `manifests/llm-d.yaml` for `unsloth/Llama-3.2-3B-Instruct`. It is enabled by default, pinned to `exo-0`, and requests one `amd.com/gpu` device so the ROCm device plugin exposes the GPU to vLLM. A preemptive priority class lets it take over the node when needed.
+
+```bash
+kubectl -n llm-d get deploy llm-d-modelserver
+kubectl -n llm-d get pods -w
+kubectl -n llm-d get svc llm-d-modelserver
+kubectl -n llm-d logs -l app.kubernetes.io/name=llm-d-modelserver -c modelserver --tail=100
+```
+
+The endpoint is exposed on NodePort `30800` and can be queried at `http://<exo-0-ip>:30800/v1/models` after the pod reaches `Running`.
+
 ## Flatcar kernel lifecycle — quick checks
 
 Use these for lifecycle-state inspection and manual gate runs:
@@ -69,7 +95,7 @@ Run `just logs` first. Then match a row. **Bluefin and Dakota image-poll QA are 
 | Expected image-poll rerun never starts after a new publish | `kubectl get configmap image-polling-digests -n argo -o yaml` — compare the stored digest with the workflow log; stale state means the previous run already claimed that digest. |
 | `GHCR push destination is forbidden` in a Dakota publish lane | Expected. GHCR is pull-only in this lab: `dakota-publish-pipeline` is disabled and `nightly-dakota-publish` is suspended. Publish to local Zot instead. |
 | VMI `NotFound` 1 second after VM creation | Same as above — KubeVirt refused to start VM due to missing accessCredentials secret; VM status will be `Stopped` |
-| `TypeError: ... requireResult` | Fix the step per [`/docs/skills/test-authoring/dogtail-patterns.md`](/docs/skills/test-authoring/dogtail-patterns.md) §6.2 (`findChildren(...)` / `retry=False`) |
+| `TypeError: ... requireResult` | Fix the step in the upstream `projectbluefin/testsuite` patterns (`findChildren(...)` / `retry=False`) |
 | `Application "gnome-shell" is running` step fails | Replace it with `* GNOME Shell is accessible via AT-SPI` |
 | All top-bar scenarios fail | Confirm `wait_for_shell.py` is present in the copied suite and that the runner re-asserts `unsafe_mode` |
 | `outputs.result` is `Waiting...` or other debug text | Send debug output to `>&2`; keep stdout for the result only |
@@ -338,30 +364,34 @@ Expected steady state:
 
 ---
 
-## 13. llm-d hive node — disabled by default
+## 13. llm-d local inference node
 
-`llm-d` is kept **off by default** in GitOps (`manifests/llm-d.yaml` sets `replicas: 0`).
-Namespace remains managed by `lab-infra`; no pod should run unless explicitly enabled.
+`llm-d` is managed by the `lab-infra` ArgoCD Application (`manifests/llm-d.yaml`) and is **enabled by default** with one replica.
+The vLLM container requests one `amd.com/gpu` device so the ROCm device plugin exposes the GPU into the pod.
+
+**Model choice:** the deployment serves `unsloth/Llama-3.2-3B-Instruct` through vLLM on the OpenAI-compatible endpoint at `http://<ghost-ip>:30800/v1`.
+The pod uses a dedicated preemptive `PriorityClass` so it can evict lower-priority work when needed.
 
 **Check status (expected default):**
 ```bash
-kubectl -n llm-d get deploy llm-d-modelserver -o jsonpath='{.spec.replicas}{"\n"}'   # expect 0
-kubectl get pods -n llm-d                                                             # expect none
+kubectl -n llm-d get deploy llm-d-modelserver -o jsonpath='{.spec.replicas}{"\n"}'   # expect 1
+kubectl get pods -n llm-d                                                             # expect one Running pod
+kubectl get node exo-0 -o jsonpath='{.status.allocatable.amd\.com/gpu}{"\n"}'       # expect >= 1
 ```
 
-**Temporarily enable for local use:**
-```bash
-kubectl -n llm-d scale deploy/llm-d-modelserver --replicas=1
-```
-
-**Disable again (restore desired default):**
+**Temporarily disable:**
 ```bash
 kubectl -n llm-d scale deploy/llm-d-modelserver --replicas=0
 ```
 
+**Re-enable (restore desired default):**
+```bash
+kubectl -n llm-d scale deploy/llm-d-modelserver --replicas=1
+```
+
 **If pod is stuck Pending:** Check two things:
 1. AMD ROCm device plugin registered: `kubectl get pods -n kube-system | grep amdgpu` — look for `amdgpu-device-plugin`. After a k3s restart the plugin needs a pod delete/respawn to re-register with kubelet. Verify `amd.com/gpu` appears in `kubectl get node ghost -o jsonpath='{.status.allocatable}'`.
-2. Memory fits: ghost has ~62.5Gi allocatable. Manifest requests 48Gi — check for other large pods consuming RAM if you see `Insufficient memory`.
+2. Memory fits: ghost has ~62.5Gi allocatable; the manifest requests 16Gi/24Gi and 1 GPU. Check for other large pods consuming RAM if you see `Insufficient memory`.
 
 **If k3s is down** (kubectl returns "connection refused"):
 k3s can stop after host sleep/resume. Recovery:
@@ -372,18 +402,17 @@ After restart, delete the `amdgpu-device-plugin` pod so it re-registers with the
 
 **kubelet device-plugin socket path:** `/var/lib/kubelet/device-plugins/kubelet.sock` (standard path — NOT the rancher/k3s path). Verify with: `ssh core@<control-plane> "sudo ss -lx | grep kubelet"`.
 
-**If pod is CrashLoopBackOff:** Check init container logs first — it downloads the GGUF on first start:
+**If pod is CrashLoopBackOff:** Check the container logs first:
 ```bash
-kubectl logs -n llm-d <pod-name> -c download-gguf
+kubectl logs -n llm-d <pod-name> -c modelserver
 ```
-The GGUF (`Qwen3.6-35B-A3B-Q4_K_M.gguf`) is cached at `/var/tmp/llm-models/` on ghost.
-If the file is missing, delete the pod and let the init container re-download it (~21GB from HuggingFace).
+The model will be cached in the pod's `emptyDir` at `/root/.cache/huggingface` until the pod is deleted.
 
 **Key constraints:**
-- `ROCBLAS_USE_HIPBLASLT=1` for best matmul throughput on gfx1151 (strixhalo.wiki)
-- `hostNetwork: true` + `hostIPC: true` required for ROCm IPC
-- `HSA_OVERRIDE_GFX_VERSION=11.5.1` required — gfx1151 is RDNA 3.5, not RDNA 4
-- Qwen3 uses chain-of-thought thinking by default; add `/no_think` prefix or increase `max_tokens`
+- The default deployment stays baseline-compliant and uses ordinary pod networking; if you revisit this later for tighter ROCm IPC tuning, you may need to re-test with host-network settings in a dedicated namespace
+- The pod is intentionally not pinned to a specific node, so it can land on whichever node later exposes the GPU resource
+- `unsloth/Llama-3.2-3B-Instruct` is intentionally small enough to be practical on the local lab node while still giving a useful chat experience
+- For long prompts, raise `--max-model-len` or use a larger model later; for short local use, the current defaults are a good fit
 
 ---
 

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -188,7 +188,7 @@ Do not guess flags, chart schema, or MCP method names. The K8sGPT MCP server exp
 - Use `k8sgpt analyze --explain` for broad triage.
 - Narrow with `--filter=Pod`, `--filter=Deployment`, or `--namespace=<ns>`.
 - For assistant integration, prefer the MCP server mode (`k8sgpt serve --mcp`) and register it in Copilot/Claude-style MCP configs.
-- For this repo's `k8sgpt-on-demand` Argo template, keep intentionally-idle services in `ignored-services` (for example `llm-d/llm-d-modelserver` while `replicas: 0`) to avoid known false-positive "Service has no endpoints" noise during stabilization.
+- For this repo's `k8sgpt-on-demand` Argo template, keep intentionally-idle services in `ignored-services` to avoid known false-positive "Service has no endpoints" noise during stabilization. Remove services from the list once they are expected to have endpoints.
 - Verified source: `/k8sgpt-ai/k8sgpt`
 
 ## Common Rationalizations

--- a/docs/superpowers/specs/2026-07-30-delete-dakota-ghcr-publishers-design.md
+++ b/docs/superpowers/specs/2026-07-30-delete-dakota-ghcr-publishers-design.md
@@ -1,0 +1,46 @@
+---
+name: delete-dakota-ghcr-publishers
+description: Delete the scheduled and reusable Dakota GHCR publication entry points.
+---
+
+# Delete Dakota GHCR Publishers
+
+## Goal
+
+Remove both Dakota publication entry points so the cluster cannot schedule or
+manually submit the obsolete GHCR publication workflow.
+
+## Scope
+
+- Delete `manifests/nightly-dakota-publish.yaml`.
+- Delete `argo/workflow-templates/dakota-publish-pipeline.yaml`.
+- Remove documentation and test references that describe either resource as
+  available or suspended.
+- Preserve Dakota build, QA, local Zot, and pull-only workflows.
+- Let ArgoCD prune the deleted resources; do not delete them out of band.
+
+## Design
+
+The GitOps source becomes authoritative: deleting both tracked manifests causes
+ArgoCD to remove the CronWorkflow and WorkflowTemplate from the `argo`
+namespace. No replacement schedule or manual publication path is added.
+
+Documentation will describe Dakota build and QA flows without a publication
+lane. Tests that validate the deleted templates or schedule are removed or
+rewritten to assert the remaining workflows do not reference them.
+
+## Safety and Errors
+
+- Existing running publication workflows are not mutated; inspect and
+  terminate any active instance before reconciliation if one exists.
+- ArgoCD must report the managed application as Synced and Healthy after prune.
+- Live checks must confirm both resource names return NotFound.
+- No direct `kubectl delete` or `kubectl apply` is used.
+
+## Verification
+
+1. Search tracked sources for references to both deleted resource names.
+2. Run targeted unit tests and `just lint`.
+3. Merge the GitOps change and run `just argocd-sync`.
+4. Confirm both resources are absent and the ArgoCD applications are
+   Synced/Healthy.

--- a/docs/superpowers/specs/2026-07-30-rocm-documentation-alignment-design.md
+++ b/docs/superpowers/specs/2026-07-30-rocm-documentation-alignment-design.md
@@ -1,0 +1,54 @@
+# ROCm Documentation Alignment
+
+## Goal
+
+Align all relevant repository documentation with the current lab ROCm model
+without changing manifests, tests, or live cluster state.
+
+## Canonical model
+
+- `exo-0` is the AMD GPU node.
+- The ArgoCD-managed `amdgpu-device-plugin` DaemonSet targets nodes labeled
+  `lab.projectbluefin.io/amd-gpu=true`.
+- The node advertises the extended resource `amd.com/gpu`.
+- `llm-d-modelserver` is the desired local inference workload. It requests one
+  `amd.com/gpu`, is pinned to `exo-0` by the manifest, and exposes NodePort
+  `30800`.
+- The vLLM pod uses privileged mode and hostPath mounts for ROCm device access.
+  Documentation must call out the corresponding PodSecurity requirement rather
+  than describing the workload as baseline-compliant.
+- KubeVirt GPU passthrough, multi-GPU/MIG, Intel QSV, and NVIDIA media
+  transcoding remain separate or deferred paths.
+
+## Scope
+
+Update every relevant user-facing Markdown document and README, including:
+
+- the agent cheatsheet and bootstrap guide;
+- homelab contracts and GPU lane wording;
+- cluster-tooling and GitOps/image-policy skill documentation;
+- README architecture and namespace descriptions;
+- operational failure-mode references.
+
+The refresh will remove stale claims that the cluster has no AMD GPU, correct
+the node and GitOps ownership details, replace manual manifest-apply guidance
+with GitOps-safe inspection/reconciliation guidance, and scope deferred
+language to paths that are actually deferred.
+
+## Non-goals
+
+- Do not change `manifests/`, tests, workflow behavior, or PodSecurity labels.
+- Do not claim that vLLM inference is healthy until the deployment reaches
+  `Available` and its endpoint has been verified.
+- Do not expand the NVIDIA transcoding test lane into an AMD implementation.
+
+## Validation
+
+After the edits:
+
+1. Search documentation for stale “no AMD GPU”, “AMD ROCm deferred”, baseline
+   compliance, unpinned-node, and manual-apply claims.
+2. Confirm every remaining deferred statement names the deferred path.
+3. Render/read the changed Markdown and verify links and command ownership.
+4. Run the repository's existing documentation validation selector if it covers
+   the changed files.

--- a/manifests/amdgpu-device-plugin.yaml
+++ b/manifests/amdgpu-device-plugin.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: amdgpu-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: amdgpu-device-plugin
+    app.kubernetes.io/part-of: lab
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: amdgpu-device-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: amdgpu-device-plugin
+        app.kubernetes.io/part-of: lab
+    spec:
+      nodeSelector:
+        lab.projectbluefin.io/amd-gpu: "true"
+      priorityClassName: system-node-critical
+      containers:
+        - name: amdgpu-device-plugin
+          image: docker.io/rocm/k8s-device-plugin:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: KUBELET_ROOT_DIR
+              value: /var/lib/kubelet
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: DirectoryOrCreate
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory

--- a/manifests/amdgpu-device-plugin.yaml
+++ b/manifests/amdgpu-device-plugin.yaml
@@ -21,7 +21,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: amdgpu-device-plugin
-          image: docker.io/rocm/k8s-device-plugin:latest
+          image: docker.io/rocm/k8s-device-plugin:latest # registry-lint-ignore: upstream ROCm device plugin, not mirrored
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -1,3 +1,12 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llm-d-preempt
+value: 1000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Higher scheduling priority for local LLM inference so it can preempt lower-priority work when needed."
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -15,7 +24,7 @@ metadata:
     app.kubernetes.io/name: llm-d-modelserver
     app.kubernetes.io/part-of: testing-lab
 spec:
-  replicas: 0 # disabled by default; scale to 1 explicitly when needed
+  replicas: 1 # enabled: exposes the AMD GPU to vLLM via the k8s device plugin
   selector:
     matchLabels:
       app.kubernetes.io/name: llm-d-modelserver
@@ -24,51 +33,99 @@ spec:
       labels:
         app.kubernetes.io/name: llm-d-modelserver
     spec:
+      priorityClassName: llm-d-preempt
+      nodeSelector:
+        kubernetes.io/hostname: exo-0
       containers:
         - name: modelserver
-          image: ghcr.io/ggml-org/llama.cpp:server
+          image: vllm/vllm-openai-rocm:latest
           imagePullPolicy: IfNotPresent
-          command: ["/app/llama-server"]
+          securityContext:
+            privileged: true
           args:
-            - "-hf"
-            - "ggml-org/gemma-3-1b-it-GGUF:Q4_K_M"
-            - "--alias"
-            - "gpt-4o"
-            - "--host"
-            - "0.0.0.0"
-            - "--port"
+            - --model
+            - unsloth/Llama-3.2-3B-Instruct
+            - --served-model-name
+            - local-llm
+            - --host
+            - 0.0.0.0
+            - --port
             - "8000"
-            - "--ctx-size"
-            - "8192"
-            - "--threads"
-            - "8"
-            - "--parallel"
-            - "2"
+            - --tensor-parallel-size
+            - "1"
+            - --max-model-len
+            - "4096"
+            - --gpu-memory-utilization
+            - "0.90"
+            - --trust-remote-code
+          env:
+            - name: HF_HOME
+              value: /root/.cache/huggingface
+            - name: VLLM_LOGGING_LEVEL
+              value: INFO
+            - name: HIP_VISIBLE_DEVICES
+              value: all
+            - name: ROCM_VISIBLE_DEVICES
+              value: all
           ports:
             - name: http
               containerPort: 8000
               protocol: TCP
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /root/.cache/huggingface
+            - name: dev-kfd
+              mountPath: /dev/kfd
+            - name: dev-dri
+              mountPath: /dev/dri
+            - name: sys
+              mountPath: /sys
+            - name: lib-modules
+              mountPath: /lib/modules
           resources:
             requests:
-              cpu: "2"
-              memory: 4Gi
+              cpu: "4"
+              memory: 16Gi
+              amd.com/gpu: "1"
             limits:
-              cpu: "6"
-              memory: 8Gi
+              cpu: "8"
+              memory: 24Gi
+              amd.com/gpu: "1"
           readinessProbe:
             httpGet:
-              path: /v1/models
+              path: /health
               port: 8000
-            periodSeconds: 10
+            initialDelaySeconds: 60
+            periodSeconds: 15
             timeoutSeconds: 5
-            failureThreshold: 6
+            failureThreshold: 10
           livenessProbe:
             httpGet:
               path: /health
               port: 8000
+            initialDelaySeconds: 120
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
+      volumes:
+        - name: hf-cache
+          emptyDir: {}
+        - name: dev-kfd
+          hostPath:
+            path: /dev/kfd
+            type: CharDevice
+        - name: dev-dri
+          hostPath:
+            path: /dev/dri
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -13,7 +13,9 @@ metadata:
   name: llm-d
   labels:
     app.kubernetes.io/part-of: testing-lab
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -34,6 +34,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: llm-d-modelserver
+      annotations:
+        lab.projectbluefin.io/config-version: podsecurity-v1
     spec:
       priorityClassName: llm-d-preempt
       nodeSelector:


### PR DESCRIPTION
## Summary
- add a GitOps pod-template version so the llm-d Deployment rolls after the namespace policy fix

## Evidence
- namespace now reconciles to `enforce=privileged` with baseline warn/audit
- `exo-0` advertises one AMD GPU and the device plugin is Ready
- the prior ReplicaSet stayed at zero after admission failures, requiring a clean rollout