### PR TITLE
fix: repair Dakota BuildStream bootc patch and stdio devices

### DIFF
--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -501,7 +501,25 @@ spec:
           path = Path('/src/elements/gnomeos-deps/bootc.bst')
           text = path.read_text()
           old = 'kind: make\n\nsources:\n'
-          new = 'kind: make\n\nconfig:\n  build-commands:\n  - python3 -c \'from pathlib import Path; p=Path("Makefile"); t=p.read_text(); old=".PHONY: manpages\\nmanpages:\\n\\tcargo run --release --package xtask -- manpages\\n"; new=".PHONY: manpages\\nmanpages:\\n\\t@true\\n"; assert old in t, "bootc Makefile layout changed unexpectedly"; p.write_text(t.replace(old, new, 1))\'\n  - make PREFIX="/usr"\n\nsources:\n'
+          new = r"""kind: make
+
+          config:
+            build-commands:
+            - |
+              python3 - <<'PY'
+              from pathlib import Path
+              p = Path("Makefile")
+              t = p.read_text()
+              old = ".PHONY: manpages\nmanpages:\n\tcargo run --release --package xtask -- manpages\n"
+              new = ".PHONY: manpages\nmanpages:\n\t@true\n"
+              assert old in t, "bootc Makefile layout changed unexpectedly"
+              p.write_text(t.replace(old, new, 1))
+              PY
+            - make PREFIX="/usr"
+
+          sources:
+          """
+
           if old not in text:
               raise SystemExit('bootc element layout changed unexpectedly')
           path.write_text(text.replace(old, new, 1))

--- a/manifests/buildbarn-worker.yaml
+++ b/manifests/buildbarn-worker.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - sh
             - -c
-            - mkdir -pm 0777 /worker/build && mkdir -pm 0700 /worker/cache && mkdir -p /worker/dev && chmod 0777 /worker && (mknod -m 666 /worker/dev/null c 1 3 || test -c /worker/dev/null) && (mknod -m 666 /worker/dev/zero c 1 5 || test -c /worker/dev/zero) && (mknod -m 666 /worker/dev/random c 1 8 || test -c /worker/dev/random) && (mknod -m 666 /worker/dev/urandom c 1 9 || test -c /worker/dev/urandom)
+            - mkdir -pm 0777 /worker/build && mkdir -pm 0700 /worker/cache && mkdir -p /worker/dev && chmod 0777 /worker && (mknod -m 666 /worker/dev/null c 1 3 || test -c /worker/dev/null) && (mknod -m 666 /worker/dev/zero c 1 5 || test -c /worker/dev/zero) && (mknod -m 666 /worker/dev/random c 1 8 || test -c /worker/dev/random) && (mknod -m 666 /worker/dev/urandom c 1 9 || test -c /worker/dev/urandom) && ln -sfn /proc/self/fd/0 /worker/dev/stdin && ln -sfn /proc/self/fd/1 /worker/dev/stdout && ln -sfn /proc/self/fd/2 /worker/dev/stderr
           volumeMounts:
             - mountPath: /worker
               name: worker

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import subprocess
+import sys
+import textwrap
 
 import yaml
 
@@ -82,6 +85,63 @@ def test_dakota_production_lane_has_no_local_fallback():
     assert "name: bst-build-re" in pipeline
     assert "name: bst-build-local" not in pipeline
     assert "template: bst-build-local" not in pipeline
+
+
+def test_dakota_bootc_patch_emits_parseable_element_yaml(tmp_path):
+    pipeline = yaml.safe_load(
+        (ROOT / "argo/workflow-templates/dakota-build-pipeline.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    def find_script(value):
+        if isinstance(value, dict):
+            for child in value.values():
+                result = find_script(child)
+                if result is not None:
+                    return result
+        elif isinstance(value, list):
+            for child in value:
+                result = find_script(child)
+                if result is not None:
+                    return result
+        elif isinstance(value, str) and "Patching bootc element" in value:
+            return value
+        return None
+
+    source = find_script(pipeline)
+    assert source is not None
+    start = source.index("python3 - <<'BOOTC_PATCH'\n") + len(
+        "python3 - <<'BOOTC_PATCH'\n"
+    )
+    end = source.index("\nBOOTC_PATCH", start)
+    patch = textwrap.dedent(source[start:end])
+
+    element = tmp_path / "bootc.bst"
+    element.write_text("kind: make\n\nsources:\n- kind: local\n  path: .\n", encoding="utf-8")
+    patch = patch.replace(
+        "Path('/src/elements/gnomeos-deps/bootc.bst')",
+        f"Path({str(element)!r})",
+    )
+    subprocess.run([sys.executable, "-c", patch], check=True)
+
+    parsed = yaml.safe_load(element.read_text(encoding="utf-8"))
+    assert parsed["config"]["build-commands"][-1] == 'make PREFIX="/usr"'
+
+
+def test_buildbarn_chroot_supplies_standard_stdio_devices():
+    worker = yaml.safe_load(
+        (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
+    )
+    init_container = next(
+        container
+        for container in worker["spec"]["template"]["spec"]["initContainers"]
+        if container["name"] == "volume-init"
+    )
+    command = init_container["command"][-1]
+
+    for name, fd in (("stdin", 0), ("stdout", 1), ("stderr", 2)):
+        assert f"ln -sfn /proc/self/fd/{fd} /worker/dev/{name}" in command
 
 
 def test_usb4_monitor_publishes_a_fresh_observation_on_every_probe():


### PR DESCRIPTION
Fixes two failures observed in a timed Dakota BuildStream run:

- Emit the bootc manpage workaround as a YAML block scalar/heredoc instead of an inline `python3 -c` scalar that corrupts element YAML.
- Stage `/dev/stdin`, `/dev/stdout`, and `/dev/stderr` proc-fd links in BuildBarn chroot action roots; Dakota elements use these paths.

Adds executable regression coverage for the rendered patch and worker init command. `just lint` and focused tests pass.