### PR TITLE
feat(recc): wire the fail-closed runner seam

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -344,6 +344,34 @@ run-bluefin-server-build ref="main" repo="https://github.com/projectbluefin/serv
       -p repo={{ repo }} \
       -n {{ argo_ns }} --watch
 
+# Run the isolated operator-only RECC baseline.
+# Usage: just run-recc-baseline mode=cache-only cache-policy=both recc-provider=components/buildbox.bst
+run-recc-baseline *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    MODE="buildstream-only"
+    RUN_ID=""
+    CACHE_POLICY="cold"
+    RECC_PROVIDER="freedesktop-sdk.bst:components/buildbox.bst"
+    for arg in {{ args }}; do
+      case "${arg}" in
+        mode=*) MODE="${arg#mode=}" ;;
+        run-id=*) RUN_ID="${arg#run-id=}" ;;
+        cache-policy=*) CACHE_POLICY="${arg#cache-policy=}" ;;
+        recc-provider=*) RECC_PROVIDER="${arg#recc-provider=}" ;;
+        *)
+          echo "Unsupported run-recc-baseline argument: ${arg}" >&2
+          exit 2
+          ;;
+      esac
+    done
+    exec argo submit --from workflowtemplate/recc-baseline-pipeline \
+      -p mode="${MODE}" \
+      -p run-id="${RUN_ID}" \
+      -p cache-policy="${CACHE_POLICY}" \
+      -p recc-provider="${RECC_PROVIDER}" \
+      -n {{ argo_ns }} --watch
+
 # ── Validation ───────────────────────────────────────────────────────────────
 
 # Validate the reusable BuildStream OCI rechunk transform.

--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -221,13 +221,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "USB4 BuildBarn gate rejected: no Ready worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
@@ -297,6 +316,8 @@ spec:
                 path: remote-execution.conf
               - key: recc-environment.conf
                 path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: "{{inputs.parameters.registry}}/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d"
         command: [bash]
@@ -325,6 +346,11 @@ spec:
           # environment when the FUSE stager crashes during source staging.
           - name: BUILDBOX_STAGER
             value: copy-or-link
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
         volumeMounts:
           - name: fuse
             mountPath: /dev/fuse
@@ -345,6 +371,17 @@ spec:
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "https://x-access-token:${GITHUB_TOKEN}@${REPO#https://}" /src
           cd /src
+          echo "=== Applying lab RECC overlay (bluefin-server) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py /src \
+            --project-kind bluefin-server \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
           PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cp /etc/buildstream/buildstream.conf /tmp/buildstream-cluster.conf

--- a/argo/workflow-templates/bst-cache-warm.yaml
+++ b/argo/workflow-templates/bst-cache-warm.yaml
@@ -174,13 +174,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "Cache warmup rejected: no Ready BuildBarn worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "BuildBarn remote-execution grid admitted for cache warmup"
           printf '%s' re > /tmp/mode

--- a/argo/workflow-templates/bst-qa-pipeline.yaml
+++ b/argo/workflow-templates/bst-qa-pipeline.yaml
@@ -88,6 +88,12 @@ spec:
             items:
               - key: dakota-buildstream.conf
                 path: buildstream.conf
+              - key: remote-execution.conf
+                path: remote-execution.conf
+              - key: recc-environment.conf
+                path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
         command: [bash]
@@ -117,6 +123,11 @@ spec:
             value: "{{inputs.parameters.element}}"
           - name: REMOTE_EXECUTION_SERVICE
             value: "{{inputs.parameters.remote-execution-service}}"
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
           # Avoid the FUSE staging backend; BuildStream exits 255 in this lab
           # environment when the FUSE stager crashes during source staging.
           - name: BUILDBOX_STAGER
@@ -130,6 +141,18 @@ spec:
           cd src
           git sparse-checkout set "${PROJECT_SUBDIR}"
           cd "${PROJECT_SUBDIR}"
+
+          echo "=== Applying lab RECC overlay (bst-qa) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py . \
+            --project-kind bst-qa \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
 
           cp /etc/buildstream/buildstream.conf /tmp/buildstream-cluster.conf
           BST_CONF=/tmp/buildstream-cluster.conf

--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -212,13 +212,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "USB4 BuildBarn gate rejected: no Ready worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
@@ -292,6 +311,10 @@ spec:
                 path: buildstream.conf
               - key: remote-execution.conf
                 path: remote-execution.conf
+              - key: recc-environment.conf
+                path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: "{{inputs.parameters.registry}}/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d"
         command: [bash]
@@ -315,6 +338,11 @@ spec:
           # so skipping smudge does not affect the compiled artifact.
           - name: GIT_LFS_SKIP_SMUDGE
             value: "1"
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
         resources:
           requests:
             cpu: "1"
@@ -345,6 +373,17 @@ spec:
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "${REPO}" /src
           cd /src
+          echo "=== Applying lab RECC overlay (cosmic) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py /src \
+            --project-kind cosmic \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
           PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cat >> /tmp/buildstream-cluster.conf <<EOF

--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -275,13 +275,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "USB4 BuildBarn gate rejected: no Ready worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
@@ -420,6 +439,8 @@ spec:
                 path: remote-execution.conf
               - key: recc-environment.conf
                 path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: "{{inputs.parameters.registry}}/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d"
         command: [bash]
@@ -438,6 +459,11 @@ spec:
           # error, so use `copy-or-link` here.
           - name: BUILDBOX_STAGER
             value: copy-or-link
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
           - name: XDG_CACHE_HOME
             # Reuse persistent node-local cache on the XFS mount for fast
             # coordinator state and local artifact reuse across workflows.
@@ -501,7 +527,25 @@ spec:
           path = Path('/src/elements/gnomeos-deps/bootc.bst')
           text = path.read_text()
           old = 'kind: make\n\nsources:\n'
-          new = 'kind: make\n\nconfig:\n  build-commands:\n  - python3 -c \'from pathlib import Path; p=Path("Makefile"); t=p.read_text(); old=".PHONY: manpages\\nmanpages:\\n\\tcargo run --release --package xtask -- manpages\\n"; new=".PHONY: manpages\\nmanpages:\\n\\t@true\\n"; assert old in t, "bootc Makefile layout changed unexpectedly"; p.write_text(t.replace(old, new, 1))\'\n  - make PREFIX="/usr"\n\nsources:\n'
+          new = r"""kind: make
+
+          config:
+            build-commands:
+            - |
+              python3 - <<'PY'
+              from pathlib import Path
+              p = Path("Makefile")
+              t = p.read_text()
+              old = ".PHONY: manpages\nmanpages:\n\tcargo run --release --package xtask -- manpages\n"
+              new = ".PHONY: manpages\nmanpages:\n\t@true\n"
+              assert old in t, "bootc Makefile layout changed unexpectedly"
+              p.write_text(t.replace(old, new, 1))
+              PY
+            - make PREFIX="/usr"
+
+          sources:
+          """
+
           if old not in text:
               raise SystemExit('bootc element layout changed unexpectedly')
           path.write_text(text.replace(old, new, 1))
@@ -548,6 +592,18 @@ spec:
           else
             echo "WARN: unable to clone freedesktop-sdk upstream patch repo; continuing without patch sync"
           fi
+
+          echo "=== Applying lab RECC overlay (dakota) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py /src \
+            --project-kind dakota \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
 
           PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
           cat >> /tmp/buildstream-cluster.conf <<EOF

--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -1,0 +1,480 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: recc-baseline-pipeline
+  namespace: argo
+  annotations:
+    description: |
+      Operator-only RECC baseline for bst-prototype/elements/recc-baseline.bst.
+      BuildStream artifacts use an ephemeral cache; the remote RECC endpoint is
+      never cleared, so a cold/warm comparison can retain remote warm evidence.
+      This template is isolated from production BuildStream lanes.
+  labels:
+    app.kubernetes.io/component: recc-baseline
+    app.kubernetes.io/part-of: bluefin-test-suite
+    bluefin.io/operator-only: "true"
+spec:
+  serviceAccountName: argo
+  activeDeadlineSeconds: 3600
+  podGC:
+    strategy: OnWorkflowCompletion
+  ttlStrategy:
+    secondsAfterSuccess: 3600
+    secondsAfterFailure: 86400
+  volumeClaimGC:
+    strategy: OnWorkflowCompletion
+
+  arguments:
+    parameters:
+      - name: repo
+        value: "https://github.com/projectbluefin/lab.git"
+      - name: ref
+        value: "main"
+      - name: mode
+        value: "buildstream-only"
+      - name: run-id
+        value: ""
+      - name: cache-policy
+        value: "cold"
+      - name: recc-provider
+        value: "freedesktop-sdk.bst:components/buildbox.bst"
+
+  entrypoint: run
+
+  templates:
+    - name: run
+      inputs:
+        parameters:
+          - name: repo
+            value: "{{workflow.parameters.repo}}"
+          - name: ref
+            value: "{{workflow.parameters.ref}}"
+          - name: mode
+            value: "{{workflow.parameters.mode}}"
+          - name: run-id
+            value: "{{workflow.parameters.run-id}}"
+          - name: cache-policy
+            value: "{{workflow.parameters.cache-policy}}"
+          - name: recc-provider
+            value: "{{workflow.parameters.recc-provider}}"
+      outputs:
+        parameters:
+          - name: metadata
+            valueFrom:
+              path: /work/recc-baseline-metadata.json
+          - name: evidence
+            valueFrom:
+              path: /work/recc-baseline-evidence.json
+      volumes:
+        - name: workdir
+          emptyDir: {}
+        - name: bst-cache
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: [ReadWriteOnce]
+                storageClassName: local-path
+                resources:
+                  requests:
+                    storage: 20Gi
+        - name: buildstream-config
+          configMap:
+            name: buildstream-remote-cache
+            items:
+              - key: dakota-buildstream.conf
+                path: buildstream.conf
+              - key: recc-environment.conf
+                path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
+      script:
+        image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
+        command: [bash]
+        resources:
+          requests:
+            cpu: "1"
+            memory: 2Gi
+          limits:
+            cpu: "2"
+            memory: 4Gi
+        volumeMounts:
+          - name: workdir
+            mountPath: /work
+          - name: bst-cache
+            mountPath: /root/.cache/buildstream
+          - name: buildstream-config
+            mountPath: /etc/buildstream
+            readOnly: true
+        env:
+          - name: REPO
+            value: "{{inputs.parameters.repo}}"
+          - name: REF
+            value: "{{inputs.parameters.ref}}"
+          - name: MODE
+            value: "{{inputs.parameters.mode}}"
+          - name: REQUESTED_RUN_ID
+            value: "{{inputs.parameters.run-id}}"
+          - name: CACHE_POLICY
+            value: "{{inputs.parameters.cache-policy}}"
+          - name: RECC_PROVIDER
+            value: "{{inputs.parameters.recc-provider}}"
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
+          - name: BUILDBOX_STAGER
+            value: copy-or-link
+          - name: PROMETHEUS_URL
+            value: "http://prometheus.kube-system:9090"
+        source: |
+          set -euo pipefail
+
+          RUN_ID="${REQUESTED_RUN_ID:-{{workflow.name}}}"
+          RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          WORKFLOW_STATUS=failed
+          COLD_STATUS=not-run
+          WARM_STATUS=not-run
+          COLD_SECONDS=""
+          WARM_SECONDS=""
+          BUILD_FAILED=0
+          EVIDENCE_FAILED=0
+          COLLECTOR_FAILED=0
+          mkdir -p /work
+          : > /work/buildstream.log
+          : > /work/recc.log
+          : > /work/prometheus-before.txt
+          : > /work/prometheus-after.txt
+
+          METRIC_NAMES=(
+            buildbarn_builder_build_executor_duration_seconds_count
+            buildbarn_builder_build_executor_duration_seconds_sum
+            buildbarn_builder_in_memory_build_queue_tasks_queued_duration_seconds_count
+            buildbarn_builder_in_memory_build_queue_tasks_queued_duration_seconds_sum
+            buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_count
+            buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_sum
+            buildbarn_blobstore_blob_access_operations_blob_size_bytes_count
+            buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum
+            buildbarn_blobstore_blob_access_operations_duration_seconds_count
+            buildbarn_blobstore_blob_access_operations_duration_seconds_sum
+          )
+
+          case "${MODE}" in
+            buildstream-only|passthrough|cache-only|upload-local-build)
+              ;;
+            remote-execution)
+              echo "RECC remote-execution is blocked: nested BuildStream REAPI support is not proven" >&2
+              exit 1
+              ;;
+            *)
+              echo "Unsupported RECC baseline mode: ${MODE}" >&2
+              exit 1
+              ;;
+          esac
+
+          case "${CACHE_POLICY}" in
+            cold|warm|both)
+              ;;
+            *)
+              echo "Unsupported cache-policy: ${CACHE_POLICY}; expected cold, warm, or both" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ "${MODE}" != "buildstream-only" && -z "${RECC_PROVIDER}" ]]; then
+            echo "RECC mode '${MODE}' refused: recc-provider is empty; no safe pinned provider is available" >&2
+            exit 1
+          fi
+
+          if [[ ! "${RUN_ID}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "run-id must contain only letters, digits, '.', '_' or '-'" >&2
+            exit 1
+          fi
+          if [[ -n "${RECC_PROVIDER}" && ! "${RECC_PROVIDER}" =~ ^[A-Za-z0-9._+/-]+(:[A-Za-z0-9._+/-]+)?$ ]]; then
+            echo "recc-provider must be a plain pinned BuildStream element reference" >&2
+            exit 1
+          fi
+
+          cat > /work/run-input.json <<EOF
+          {
+            "run_id": "${RUN_ID}",
+            "mode": "${MODE}",
+            "started_at": "${RUN_STARTED_AT}",
+            "phases": {
+              "cold": {"state": "not-run"},
+              "warm": {"state": "not-run"}
+            }
+          }
+          EOF
+
+          capture_buildbarn_metrics() {
+            local destination="$1"
+            if ! curl --fail --silent --show-error --max-time 20 \
+              --get \
+              --data-urlencode 'match[]={__name__=~"buildbarn_(builder|blobstore)_.*"}' \
+              "${PROMETHEUS_URL}/federate" > "${destination}"; then
+              echo "BuildBarn Prometheus federation failed: ${PROMETHEUS_URL}" >&2
+              : > "${destination}"
+              return 1
+            fi
+            if [[ ! -s "${destination}" ]]; then
+              echo "BuildBarn Prometheus federation returned no samples" >&2
+              return 1
+            fi
+            if [[ ! -s /work/prometheus-before.txt ]]; then
+              cp "${destination}" /work/prometheus-before.txt
+            fi
+            cp "${destination}" /work/prometheus-after.txt
+          }
+
+          finalize() {
+            local exit_code=$?
+            set +e
+            if [[ -n "${RECC_PROVIDER}" ]]; then
+              PROVIDER_JSON="\"${RECC_PROVIDER}\""
+            else
+              PROVIDER_JSON="null"
+            fi
+            RUN_FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            cat > /work/run-input.json <<EOF
+          {
+            "run_id": "${RUN_ID}",
+            "mode": "${MODE}",
+            "started_at": "${RUN_STARTED_AT}",
+            "finished_at": "${RUN_FINISHED_AT}",
+            "phases": {
+              "cold": {
+                "state": "${COLD_STATUS}",
+                "timings": {"wall_seconds": ${COLD_SECONDS:-null}}
+              },
+              "warm": {
+                "state": "${WARM_STATUS}",
+                "timings": {"wall_seconds": ${WARM_SECONDS:-null}}
+              }
+            }
+          }
+          EOF
+            if [[ -f /work/src/scripts/collect_recc_run.py ]]; then
+              collector_args=(
+                --metadata /work/run-input.json
+                --buildstream-log /work/buildstream.log
+                --recc-log /work/recc.log
+                --prometheus-before /work/prometheus-before.txt
+                --prometheus-after /work/prometheus-after.txt
+                --source-url "argo://recc-baseline/${RUN_ID}"
+                --output /work/recc-baseline-evidence.json
+              )
+              for metric in "${METRIC_NAMES[@]}"; do
+                collector_args+=(--metric "${metric}")
+              done
+              if ! python3 /work/src/scripts/collect_recc_run.py "${collector_args[@]}"; then
+                echo "RECC evidence collector failed" >&2
+                COLLECTOR_FAILED=1
+              fi
+            else
+              echo "RECC evidence collector is missing from the sparse checkout" >&2
+              COLLECTOR_FAILED=1
+            fi
+            if [[ ! -s /work/recc-baseline-evidence.json ]]; then
+              cat > /work/recc-baseline-evidence.json <<'EOF'
+          {
+            "schema_version": "recc-baseline.evidence.v1",
+            "state": "unavailable",
+            "state_reason": "the evidence collector was unavailable or produced no parseable output",
+            "unavailable_fields": {
+              "buildstream": "no parseable BuildStream evidence",
+              "recc": "no parseable RECC_VERBOSE evidence",
+              "buildbarn": "no before/after BuildBarn metric snapshots"
+            }
+          }
+          EOF
+            fi
+            if [[ "${COLLECTOR_FAILED}" -ne 0 || "${EVIDENCE_FAILED}" -ne 0 ]]; then
+              exit_code=1
+            fi
+            if [[ "${exit_code}" -eq 0 ]]; then
+              WORKFLOW_STATUS=success
+            fi
+            EVIDENCE_STATE=available
+            EVIDENCE_REASON_JSON=null
+            if [[ "${COLLECTOR_FAILED}" -ne 0 || "${EVIDENCE_FAILED}" -ne 0 ]]; then
+              EVIDENCE_STATE=unavailable
+              EVIDENCE_REASON_JSON='"collector or BuildBarn metric capture failed"'
+            fi
+            COLD_SECONDS_JSON="${COLD_SECONDS:-null}"
+            WARM_SECONDS_JSON="${WARM_SECONDS:-null}"
+            cat > /work/recc-baseline-metadata.json <<EOF
+          {
+            "schema_version": "recc-baseline.v1",
+            "run": {
+              "run_id": "${RUN_ID}",
+              "mode": "${MODE}",
+              "cache_policy": "${CACHE_POLICY}",
+              "recc_provider": ${PROVIDER_JSON},
+              "started_at": "${RUN_STARTED_AT}",
+              "finished_at": "${RUN_FINISHED_AT}"
+            },
+            "status": "${WORKFLOW_STATUS}",
+            "phases": {
+              "cold": {"state": "${COLD_STATUS}", "timings": {"wall_seconds": ${COLD_SECONDS_JSON}}},
+              "warm": {"state": "${WARM_STATUS}", "timings": {"wall_seconds": ${WARM_SECONDS_JSON}}}
+            },
+            "buildstream_cache": {
+              "state": "available",
+              "policy": "ephemeral",
+              "state_reason": "the BuildStream artifact cache is a workflow-scoped PVC deleted on completion",
+              "unavailable_fields": {}
+            },
+            "evidence_capture": {
+              "state": "${EVIDENCE_STATE}",
+              "state_reason": ${EVIDENCE_REASON_JSON}
+            }
+          }
+          EOF
+            exit "${exit_code}"
+          }
+          trap finalize EXIT
+
+          echo "=== Staging bst-prototype from ${REPO}@${REF} ==="
+          git clone --depth=1 --branch "${REF}" --filter=blob:none --sparse "${REPO}" /work/src
+          cd /work/src
+          git sparse-checkout set bst-prototype scripts/collect_recc_run.py
+          cd /work/src/bst-prototype
+          ELEMENT="recc-baseline.bst"
+          [[ -f "elements/${ELEMENT}" ]] || {
+            echo "required element bst-prototype/elements/${ELEMENT} is missing" >&2
+            exit 1
+          }
+
+          if [[ "${MODE}" != "buildstream-only" ]]; then
+            echo "=== Applying operator-only RECC cache pilot overlay ==="
+            python3 /etc/buildstream/apply_recc_overlay.py . \
+              --project-kind bst-prototype \
+              --endpoint "${RECC_ENDPOINT}" \
+              --pilot-cache-only \
+              --recc-provider "${RECC_PROVIDER}" \
+              --json > /work/recc-overlay.json
+          fi
+
+          PROJECT_NAME="$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')"
+          [[ "${PROJECT_NAME}" == "bst-prototype" ]] || {
+            echo "unexpected BuildStream project name: ${PROJECT_NAME}" >&2
+            exit 1
+          }
+          cp /etc/buildstream/buildstream.conf /work/buildstream.conf
+          cat >> /work/buildstream.conf <<EOF
+          projects:
+            ${PROJECT_NAME}:
+              artifacts:
+                override-project-caches: true
+                servers: []
+          EOF
+          BST_CONF=/work/buildstream.conf
+
+          run_phase() {
+            local phase="$1"
+            local status_var="$2"
+            local phase_log="/work/buildstream-${phase}.log"
+            local phase_recc="/work/recc-${phase}.log"
+            local phase_raw_recc="/work/recc-${phase}.raw"
+            local phase_start
+            local phase_end
+            local phase_seconds
+            local rc=0
+            local state="unavailable"
+            local full_key=""
+            local artifact_digest=""
+            local fixture_stdout=""
+            local cache_origin="unavailable"
+            phase_start="$(date +%s)"
+            find /root/.cache/buildstream -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+            printf '\n=== %s phase: BuildStream cache cleared; remote RECC cache preserved ===\n' "${phase}" > "${phase_log}"
+            if ! capture_buildbarn_metrics "/work/prometheus-${phase}-before.txt"; then
+              EVIDENCE_FAILED=1
+            fi
+            bst --config "${BST_CONF}" --no-interactive \
+              --option recc "${MODE}" \
+              build "${ELEMENT}" >> "${phase_log}" 2>&1 || rc=$?
+            if [[ "${rc}" -eq 0 ]]; then
+              state="$(bst --config "${BST_CONF}" --no-interactive show \
+                --deps none --format '%{state}' "${ELEMENT}" 2>>"${phase_log}" \
+                | tr -d '\r\n')" || state="unavailable"
+              full_key="$(bst --config "${BST_CONF}" --no-interactive show \
+                --deps none --format '%{full-key}' "${ELEMENT}" 2>>"${phase_log}" \
+                | tr -d '\r\n')" || full_key=""
+              artifact_digest="$(bst --config "${BST_CONF}" --no-interactive show \
+                --deps none --format '%{artifact-cas-digest}' "${ELEMENT}" 2>>"${phase_log}" \
+                | tr -d '\r\n')" || artifact_digest=""
+              if [[ -n "${state}" && "${state}" != "unavailable" ]]; then
+                cache_origin="local-build"
+              fi
+              artifact_dir="/work/artifact-${phase}"
+              rm -rf "${artifact_dir}"
+              if ! bst --config "${BST_CONF}" --no-interactive artifact checkout \
+                --deps none --directory "${artifact_dir}" "${ELEMENT}" \
+                >> "${phase_log}" 2>&1; then
+                echo "artifact checkout failed; fixture stdout is unavailable" >&2
+                EVIDENCE_FAILED=1
+              elif [[ -x "${artifact_dir}/usr/bin/recc-baseline" ]]; then
+                if ! fixture_stdout="$("${artifact_dir}/usr/bin/recc-baseline")"; then
+                  echo "fixture execution failed" >&2
+                  EVIDENCE_FAILED=1
+                fi
+              else
+                echo "artifact did not contain /usr/bin/recc-baseline" >&2
+                EVIDENCE_FAILED=1
+              fi
+              printf '%s phase: success\n' "${phase}" >> "${phase_log}"
+              printf '%s wall_seconds: %s\n' "${phase}" \
+                "$(( $(date +%s) - phase_start ))" >> "${phase_log}"
+              printf 'element: %s\nstate: %s\nkey: %s\ncache origin: %s\noutput digest: %s\n' \
+                "${ELEMENT}" "${state}" "${full_key}" "${cache_origin}" \
+                "${artifact_digest}" >> "${phase_log}"
+              printf '[FIXTURE_STDOUT] %s\n' "${fixture_stdout}" >> "${phase_log}"
+              printf -v "${status_var}" '%s' success
+            else
+              printf '%s phase: failed (exit %s)\n' "${phase}" "${rc}" >> "${phase_log}"
+              printf -v "${status_var}" '%s' failed
+            fi
+            grep -Eio '(^|[[:space:]\[\(])RECC(_VERBOSE)?([[:space:]:\]\)]|$).*' \
+              "${phase_log}" > "${phase_raw_recc}" || true
+            {
+              printf '=== BEGIN RECC_VERBOSE LOG ===\n'
+              cat "${phase_raw_recc}"
+              printf '=== END RECC_VERBOSE LOG ===\n'
+            } > "${phase_recc}"
+            cat "${phase_log}" >> /work/buildstream.log
+            cat "${phase_recc}" >> /work/recc.log
+            phase_end="$(date +%s)"
+            phase_seconds=$((phase_end - phase_start))
+            printf -v "${status_var}" '%s' \
+              "$([[ "${rc}" -eq 0 ]] && echo success || echo failed)"
+            if [[ "${phase}" == "cold" ]]; then
+              COLD_SECONDS="${phase_seconds}"
+            else
+              WARM_SECONDS="${phase_seconds}"
+            fi
+            if ! capture_buildbarn_metrics "/work/prometheus-${phase}-after.txt"; then
+              EVIDENCE_FAILED=1
+            fi
+            return "${rc}"
+          }
+
+          case "${CACHE_POLICY}" in
+            cold)
+              run_phase cold COLD_STATUS || BUILD_FAILED=1
+              ;;
+            warm)
+              run_phase warm WARM_STATUS || BUILD_FAILED=1
+              ;;
+            both)
+              run_phase cold COLD_STATUS || BUILD_FAILED=1
+              if [[ "${BUILD_FAILED}" -eq 0 ]]; then
+                run_phase warm WARM_STATUS || BUILD_FAILED=1
+              fi
+              ;;
+          esac
+
+          if [[ "${BUILD_FAILED}" -ne 0 ]]; then
+            exit 1
+          fi

--- a/bst-prototype/elements/freedesktop-sdk.bst
+++ b/bst-prototype/elements/freedesktop-sdk.bst
@@ -1,0 +1,11 @@
+kind: junction
+
+sources:
+- kind: git_repo
+  url: gitlab:freedesktop-sdk/freedesktop-sdk.git
+  ref: freedesktop-sdk-25.08.14-0-g57149392fe26548b0e7c50a2e171e3aac005a412
+
+config:
+  options:
+    target_arch: '%{arch}'
+    bootstrap_build_arch: '%{arch}'

--- a/bst-prototype/elements/plugins/buildstream-plugins-community.bst
+++ b/bst-prototype/elements/plugins/buildstream-plugins-community.bst
@@ -1,0 +1,6 @@
+kind: junction
+
+sources:
+- kind: tar
+  url: pypi:source/b/buildstream-plugins-community/buildstream_plugins_community-2.3.1.tar.gz
+  ref: 85c2bae9d3a1eb3121c9674f68ef6e87211fddb9c930f3e5057b9a1e66eb41d9

--- a/bst-prototype/elements/recc-baseline.bst
+++ b/bst-prototype/elements/recc-baseline.bst
@@ -1,0 +1,63 @@
+kind: manual
+
+description: |
+  Deterministic C++ compiler pilot for comparing BuildStream and RECC.
+  The project option controls the compiler launcher and RECC mode.
+
+sources:
+- kind: local
+  path: files/recc-baseline
+
+build-depends:
+- freedesktop-sdk.bst:components/gcc.bst
+
+variables:
+  compiler: /usr/bin/g++
+  compiler_launcher: ""
+  (?):
+  - recc != "buildstream-only":
+      compiler_launcher: recc
+
+environment:
+  CXX: "%{compiler}"
+  CXX_LAUNCHER: "%{compiler_launcher}"
+  (?):
+  - recc != "buildstream-only":
+      RECC_PROJECT_ROOT: /
+      RECC_SERVER: grpc://frontend.buildbarn.svc.cluster.local:8980
+      RECC_CAS_SERVER: grpc://frontend.buildbarn.svc.cluster.local:8980
+      RECC_ACTION_CACHE_SERVER: grpc://frontend.buildbarn.svc.cluster.local:8980
+      RECC_ACTION_UNCACHEABLE: "0"
+  - recc == "passthrough":
+      RECC_PASSTHROUGH: "1"
+  - recc == "cache-only":
+      RECC_CACHE_ONLY: "1"
+  - recc == "upload-local-build":
+      RECC_CACHE_ONLY: "1"
+      RECC_CACHE_UPLOAD_LOCAL_BUILD: "1"
+
+config:
+  build-commands:
+  - |
+    set -eu
+    mkdir -p "%{build-root}"
+    run_cxx() {
+      if [ -n "${CXX_LAUNCHER}" ]; then
+        "${CXX_LAUNCHER}" "${CXX}" "$@"
+      else
+        "${CXX}" "$@"
+      fi
+    }
+    run_cxx -std=c++17 -O2 -g0 -fno-ident -c message.cpp \
+      -o "%{build-root}/message.o"
+    run_cxx -std=c++17 -O2 -g0 -fno-ident -c main.cpp \
+      -o "%{build-root}/main.o"
+    run_cxx -std=c++17 -Wl,--build-id=none \
+      "%{build-root}/message.o" "%{build-root}/main.o" \
+      -o "%{build-root}/recc-baseline"
+  install-commands:
+  - |
+    set -eu
+    mkdir -p "%{install-root}/usr/bin"
+    install -m 0755 "%{build-root}/recc-baseline" \
+      "%{install-root}/usr/bin/recc-baseline"

--- a/bst-prototype/files/recc-baseline/main.cpp
+++ b/bst-prototype/files/recc-baseline/main.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+#include "message.hpp"
+
+int main() {
+    std::cout << recc_baseline_message() << '\n';
+    return 0;
+}

--- a/bst-prototype/files/recc-baseline/message.cpp
+++ b/bst-prototype/files/recc-baseline/message.cpp
@@ -1,0 +1,5 @@
+#include "message.hpp"
+
+const char *recc_baseline_message() {
+    return "recc-baseline-v1";
+}

--- a/bst-prototype/files/recc-baseline/message.hpp
+++ b/bst-prototype/files/recc-baseline/message.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+const char *recc_baseline_message();

--- a/bst-prototype/include/aliases.yml
+++ b/bst-prototype/include/aliases.yml
@@ -1,0 +1,3 @@
+aliases:
+  gitlab: https://gitlab.com/
+  pypi: https://files.pythonhosted.org/packages/

--- a/bst-prototype/project.conf
+++ b/bst-prototype/project.conf
@@ -6,3 +6,32 @@ min-version: 2.0
 
 # Subdirectory where elements are stored
 element-path: elements
+
+(@):
+  - include/aliases.yml
+
+# Selects the compiler path and RECC policy for the lab-owned pilot element.
+# The default keeps the fixture a plain BuildStream-only build.
+options:
+  arch:
+    type: arch
+    description: Host architecture for the pinned freedesktop-sdk junction
+    variable: arch
+    values:
+    - x86_64
+  recc:
+    type: enum
+    description: RECC mode for the deterministic C++ pilot fixture
+    values:
+    - buildstream-only
+    - passthrough
+    - cache-only
+    - upload-local-build
+    - remote-execution
+    default: buildstream-only
+
+plugins:
+  - origin: junction
+    junction: plugins/buildstream-plugins-community.bst
+    sources:
+      - git_repo

--- a/docs/reference/recc-baseline.md
+++ b/docs/reference/recc-baseline.md
@@ -1,0 +1,110 @@
+# RECC baseline and pilot contract
+
+This is a lab-only contract for measuring C/C++ compilation inside a
+BuildStream element. It does not change Dakota, Cosmic, Bluefin Server, or any
+other production BuildStream lane.
+
+## Current state and evidence boundary
+
+The prototype pins the freedesktop-sdk 25.08.14 junction used by the factory
+and stages the compiler from `components/gcc.bst`. RECC comes from the same
+junction's `components/buildbox.bst`. The overlay validates the provider path
+at run time, so a missing or changed junction fails closed before build work.
+
+## Fixture
+
+`bst-prototype/elements/recc-baseline.bst` compiles two deterministic C++
+translation units and links `/usr/bin/recc-baseline`. The operator-only
+`recc-baseline-pipeline` targets this element, not `hello.bst`.
+
+The project option `recc` selects the launcher and mode:
+
+| Option | Compiler action | Expected purpose |
+| --- | --- | --- |
+| `buildstream-only` | `/usr/bin/g++` | Outer BuildStream baseline; no RECC |
+| `passthrough` | `recc /usr/bin/g++` + `RECC_PASSTHROUGH=1` | Wrapper overhead/control |
+| `cache-only` | `recc /usr/bin/g++` + `RECC_CACHE_ONLY=1` | Remote hit, or local compile on a miss |
+| `upload-local-build` | cache-only + `RECC_CACHE_UPLOAD_LOCAL_BUILD=1` | Compile misses locally and upload results |
+| `remote-execution` | blocked | Nested runner capability is not proven |
+
+The fixture deliberately uses two compile actions and one link action. Linking
+stays local unless a later pilot explicitly enables `RECC_LINK`.
+
+The pilot sandbox stages `/bin/sh`, `/usr/bin/g++`, `/usr/bin/recc`, and the
+matching C++ sysroot through BuildStream dependencies. It never mounts a host
+`/usr`; the `bst2` image's host `recc` is not visible inside the sandbox.
+
+## Workflow run contract
+
+Use the isolated operator entrypoint:
+
+```bash
+just run-recc-baseline
+just run-recc-baseline mode=cache-only cache-policy=both \
+  recc-provider=freedesktop-sdk.bst:components/buildbox.bst
+```
+
+The workflow defaults to the pinned provider and accepts `mode`, `run-id`,
+`cache-policy`, and `recc-provider`.
+`cache-policy` is `cold`, `warm`, or `both`. Each selected phase starts with a
+clean workflow-scoped BuildStream cache. The remote RECC endpoint and its
+action cache are not cleared, so a `both` run can preserve remote warm-hit
+evidence while avoiding a local BuildStream artifact hit.
+
+`buildstream-only` runs without the overlay. Every supported RECC mode
+(`passthrough`, `cache-only`, and `upload-local-build`) requires a non-empty
+provider and invokes the overlay with `--pilot-cache-only`.
+`remote-execution` remains blocked until an upstream runner candidate proves
+that it consumes BuildStream's `remoteApisSocketPath` and stages the pod-local
+LocalCAS socket.
+
+Keep the source revision, BuildStream image, compiler/sysroot, BuildStream
+config, RECC config, node, and worker set fixed for a comparison. Do not run
+the pilot through a production lane.
+
+## Evidence
+
+For each selected phase, record:
+
+- wall-clock duration and BuildStream fetch/build/push durations;
+- BuildStream element key, final state, and whether the result came from its
+  artifact cache;
+- RECC compile action count, action-cache hits/misses, local fallbacks, and
+  compile/link duration;
+- BuildBarn worker action count, execution time, and scheduler queue time from
+  explicit Prometheus counter/histogram deltas;
+- CAS/action-cache blob requests and bytes uploaded/downloaded from explicit
+  BuildBarn blobstore metrics;
+- output digest and `recc-baseline` stdout.
+
+The workflow captures dedicated RECC log sections, BuildStream show metadata,
+fixture stdout, and before/after BuildBarn Prometheus federation snapshots.
+Collector failure is surfaced as a failed workflow; missing metric fields
+remain explicit `unavailable_fields` entries and are never represented as zero
+or a successful warm hit. The workflow emits compact `metadata` and `evidence`
+output parameters.
+
+The acceptance comparison is mode-specific: `cache-only` and
+`upload-local-build` must prove stable action keys and a warm action-cache hit.
+A successful outer BuildStream build alone is not RECC evidence.
+
+## Evidence boundaries
+
+- `buildstream-only` establishes the deterministic fixture and outer artifact
+  baseline.
+- `passthrough` isolates wrapper/launcher overhead without cache or remote
+  execution.
+- `cache-only` establishes lookup behavior and miss handling.
+- `upload-local-build` establishes local-miss result upload behavior.
+- `remote-execution` is blocked until nested socket support is verified.
+- The first phase is **cold-local**: the workflow-local BuildStream cache is
+  cleared while the shared remote RECC endpoint is preserved. A second phase
+  is **warm-remote** evidence, not a true remote-cold result.
+- The generic `bst-qa` workflow is a QA lane, not this prototype's measurement
+  harness.
+- The dedicated operator workflow is intentionally separate from `bst-qa` and
+  all production lanes. It must not be referenced by those lanes or gain a
+  runtime switch into them.
+
+Do not enable `recc_optimisations`, `RECC_LINK`, or production project includes
+until these measurements are captured and reviewed.

--- a/docs/reference/recc-project-overlay.md
+++ b/docs/reference/recc-project-overlay.md
@@ -1,0 +1,134 @@
+# Lab RECC project overlay
+
+`scripts/apply_recc_overlay.py` prepares an isolated BuildStream checkout for
+the lab RECC pilot. It is intentionally a lab-owned checkout transformation:
+it does not edit `.github/workflows`, upstream repositories, or production
+lanes, and it is not a measurement workflow.
+
+The helper has explicit adapters for `dakota`, `cosmic`, `bluefin-server`, and
+`bst-prototype`/`bst-qa`. It adds the upstream-style wrapper element, the RECC
+project include, GCC/Clang `digest-environment` includes, and the `recc`
+project option pinned to the resolved policy. It refuses unknown layouts,
+conflicting existing overlay files, inline dependency lists, and endpoints
+containing credentials.
+
+## Mandatory, unambiguous mode selection
+
+Every invocation must state exactly one mode, and there is no default:
+
+| Adapter | no mode flag (what the templates use) | `--runner-capability` | `--pilot-cache-only` |
+| --- | --- | --- | --- |
+| `dakota`, `cosmic`, `bluefin-server`, `bst-qa` | **refused** — lane fails closed | `recc=remote-execution` + `sandbox.remote-apis-socket` | **refused** (operator-only flag) |
+| `bst-prototype` | **refused** | `recc=remote-execution` + nested socket | `recc=cache-only` (requires an explicit provider) |
+
+`--runner-capability` is an assertion that the deployed BuildBarn runner honors
+BuildStream's `remoteApisSocketPath`. No such runner is verified in this
+checkout, so **every mandatory-RECC lane refuses**, before the checkout is
+touched and before the expensive build work. That refusal is the intended
+behavior: a lane that cannot run nested RECC must fail, not quietly build with
+outer remote execution only or with a cache-only fallback.
+
+`--pilot-cache-only` is an **operator-only** flag for the documented prototype
+baseline in `docs/reference/recc-baseline.md`. Only the isolated
+`recc-baseline-pipeline` may pass it; mandatory-RECC adapters refuse it
+outright.
+
+Running a lane with outer BuildStream remote execution alone is only reachable
+through a deliberate GitOps rollback (revert the overlay invocation and the
+admission check, let ArgoCD reconcile). It is not a normal operating path.
+
+The generic `bst-qa` workflow is not the prototype measurement harness. It is a
+mandatory QA lane and must keep the no-mode invocation above; it cannot be used
+to claim RECC cold/warm timings, action-cache results, or remote worker actions.
+The dedicated `recc-baseline-pipeline` is the operator-only measurement
+workflow and must validate its provider before checkout/build work.
+
+## Prototype provider status
+
+The `bst-prototype` adapter intentionally has no adapter-level default because
+the workflow validates the provider in the actual checkout. The prototype
+checkout now pins the freedesktop-sdk junction and its
+`components/buildbox.bst` provider, and the workflow defaults to that exact
+element reference. Omitting or overriding the provider still fails closed when
+the referenced junction or element is absent.
+
+## The `recc` binary must come from a pinned element
+
+The generated wrapper (`files/recc-wrapper/recc-wrapper`) execs `recc`. A
+BuildStream sandbox does not inherit the `bst2` image's host binaries, so the
+overlay requires an operator-verified element that stages `recc` and declares
+it as the wrapper element's `runtime-depends`:
+
+- SDK-based adapters default to `freedesktop-sdk.bst:components/buildbox.bst`,
+  which freedesktop-sdk builds with `-DRECC=ON`;
+- any adapter can override it with `--recc-provider ELEMENT`;
+- `bst-prototype` resolves the provider through its pinned junction; `bst-qa`
+  remains providerless and mandatory/fail-closed.
+
+The overlay verifies that the named element (or its junction) exists under the
+project's `element-path` and refuses with a diagnostic otherwise. The wrapper
+script itself also fails closed at build time if `recc` is not on `PATH`.
+
+```bash
+python3 scripts/apply_recc_overlay.py /src \
+  --project-kind dakota \
+  --runner-capability
+```
+
+Diagnostics contain only the validated endpoint, policy/capability state, the
+resolved `recc` provider, and SHA-256 checksums. `changed_files` reports files
+written during this invocation; `file_checksums` reports the stable checksums of
+all managed files, including on an idempotent second invocation.
+
+`include/recc.yml` prepends `/usr/recc/bin` to `PATH` and keeps the standard
+`/usr/bin`, `/bin`, `/usr/sbin`, and `/sbin` entries, so overlaying a project
+never hides its existing tooling.
+
+A documented pilot experiment looks like:
+
+```bash
+# Illustrative only: this provider must first exist in /src.
+python3 scripts/apply_recc_overlay.py /src \
+  --project-kind bst-prototype \
+  --pilot-cache-only \
+  --recc-provider freedesktop-sdk.bst:components/buildbox.bst \
+  --json
+```
+
+The prototype has a pinned compiler dependency and the overlay attaches both
+the wrapper and GCC `digest-environment` include to `recc-baseline.bst`. This
+supplies `RECC_REMOTE_PLATFORM_chrootRootDigest` without inventing a digest.
+Provider references are resolved and checked to remain inside the checkout
+before any overlay files are written.
+
+Adapters only patch compiler dependencies declared in the checkout's own
+`build-depends` lists. Compiler elements hidden inside an upstream junction are
+not rewritten; changing those would require an upstream checkout or patch
+queue, which is outside this lab-only overlay.
+
+## Workflow wiring
+
+The Dakota, Cosmic, Bluefin Server, and `bst-qa` BuildStream pods mount the
+byte-identical helper and shared endpoint from the `buildstream-remote-cache`
+ConfigMap and **each invokes it with no mode flags**, after checkout and before
+any `bst show`/`bst build`. Warmup paths reuse the same `build-core` template,
+so they inherit the same invocation.
+
+Because no currently pinned runner honors `remoteApisSocketPath`, the
+production invocation refuses today and the lane fails. Two admission layers
+make that failure early and explicit:
+
+1. the gate step in each build pipeline (and in `bst-cache-warm.yaml`) probes
+   the deployed `buildbarn-config` `runner.jsonnet` for a real
+   `remoteApisSocketPath:` field and rejects the run before the build work;
+2. the overlay invocation itself refuses in the build container.
+
+Both clear only after a capable runner is independently proven and the
+templates are updated to assert `--runner-capability`; neither capability nor
+live health should be inferred from the presence of the sidecar or a
+successful outer BuildStream build.
+
+The dedicated operator workflow is present in this checkout but requires
+ArgoCD reconciliation before it is live. Repository configuration is not
+treated as live health: verify the deployed template, worker pods, Prometheus
+endpoint, and BuildBarn admission state before submitting a run.

--- a/docs/reference/recc-runner-seam.md
+++ b/docs/reference/recc-runner-seam.md
@@ -1,0 +1,125 @@
+# RECC runner seam
+
+This is a lab-only preparation seam for the isolated RECC pilot. It does not
+enable nested REAPI in a production BuildStream lane, and it does not change
+the outer BuildStream RE contract.
+
+The sidecar, socket, ConfigMap, and admission-gate descriptions below are
+checked-in repository/configuration evidence. The Kubernetes/Argo API timed out
+during the current live-verification attempt, so this document does not claim
+live worker, runner, endpoint, or workflow health.
+
+## What is wired
+
+The checked-in BuildBarn worker manifest declares:
+
+- a `buildbox-casd` sidecar using the existing, pinned `bst2` image contract,
+  invoked as `buildbox-casd` through the image `PATH` (the install prefix of
+  that digest is not pinned anywhere in this repo, so an absolute path would
+  be an unverified guess — this matches the lab's historical casd manifest);
+- a worker-local CAS, Action Cache, and Execution proxy to the BuildBarn
+  frontend;
+- an 8 GiB LRU cache under `/worker/recc-casd`, inside the existing node-local
+  worker storage;
+- a pod-local UNIX socket at `/run/buildbarn/recc/casd.sock`, shared only by
+  the sidecar and runner through an `emptyDir` volume;
+- sidecar readiness/liveness probes for that socket.
+
+The outer BuildStream REAPI endpoint, USB4 admission gates, worker cache,
+concurrency, and existing worker/runner resource limits and security context
+are unchanged.
+
+## Health boundaries
+
+There are two independent health boundaries, and they must stay independent
+until a runner actually consumes the nested socket:
+
+1. **Outer remote execution** — the `worker` and `runner` containers. The
+   workflow admission gates in `dakota-build-pipeline.yaml`,
+   `cosmic-build-pipeline.yaml`, `bluefin-server-build-pipeline.yaml`, and
+   `bst-cache-warm.yaml` select those two containers *by name* from
+   `containerStatuses`, so adding or removing a preparation sidecar cannot
+   reject a healthy worker. Never gate on the container-count-dependent
+   `containerStatuses[*].ready` list.
+2. **Nested RECC preparation** — the `recc-casd` sidecar and its socket. Its
+   readiness/liveness probes cover `/run/buildbarn/recc/casd.sock` and nothing
+   else. `runner.jsonnet` deliberately does **not** set
+   `readinessCheckingPathnames` for that socket: nothing consumes it yet, so
+   coupling outer BuildBarn admission to it would take both workers out of
+   service for an unused capability. The socket is not exposed through a Service, host mount,
+`hostPID`, or `hostIPC`.
+The sidecar adds only a bounded 100m/128Mi request and 1 CPU/2Gi limit.
+The sidecar image is the lab registry's
+`bst2@sha256:ce272e0ae4b59251680b8a70645740640ced17689e21268ddc037614c755f734`
+digest, verified to contain `buildbox-casd` 1.3.53 and `buildbox-run`.
+
+## Shared RECC config contract
+
+`manifests/buildstream-remote-cache-config.yaml` publishes the
+`recc-environment.conf` key for every BuildStream pipeline to mount. It
+contains the lab's shared RECC server, CAS, action-cache, project-root, and
+cache-policy values. It intentionally contains no wrapper-prefix setting.
+Toolchain-specific integrations must add
+`RECC_REMOTE_PLATFORM_chrootRootDigest` from their compiler/sysroot dependency
+tree; the lab cannot safely invent that digest.
+
+The contract is only an environment map. A consumer still has to install the
+RECC wrapper and merge the map into its BuildStream project. The current
+`bb_runner` does not support nested socket pass-through, so consumers must not
+enable `sandbox.remote-apis-socket` yet.
+
+## Concrete blocker
+
+The checked-in pinned `bb_runner` installer/image contract exposes only
+BuildBarn's native chroot runner. Its `ApplicationConfiguration` has no LocalCAS
+client or BuildBox runner command, and the checked-in source/configuration does
+not consume the `remoteApisSocketPath` platform property. BuildBox's
+`buildbox-run` can honor that property only when it stages through LocalCAS;
+adding an arbitrary `remoteApisSocketPath` or LocalCAS field to `runner.jsonnet`
+would therefore fail configuration or silently do nothing. This is not a live
+health observation.
+
+The next implementation step is a separately built and pinned runner image
+that implements BuildBarn's `Runner` gRPC service by invoking a
+LocalCAS-capable `buildbox-run`, or an upstream `bb_runner` release that
+provides the same capability. Until then, keep
+`sandbox.remote-apis-socket` disabled in all lab projects. The prototype's
+cache-only mode is only an operator experiment after a provider is explicitly
+verified; the generic `bst-qa` workflow is not a prototype measurement
+harness.
+
+`scripts/apply_recc_overlay.py` enforces this: it refuses the `dakota`,
+`cosmic`, `bluefin-server`, and `bst-qa` adapters unless `--runner-capability`
+is passed to assert a proven runner, and it refuses the operator-only
+`--pilot-cache-only` flag for those lanes.
+
+The dedicated `recc-baseline-pipeline` is the operator-only measurement
+workflow. It validates the pinned provider before applying the cache pilot
+overlay and keeps `remote-execution` blocked until both an upstream runner
+candidate and a nested-socket canary prove support. It must not substitute
+outer-only execution or a production cache-only fallback.
+
+RECC admission is mandatory, not optional. Every build lane, QA lane, and
+warmup path still invokes the shared overlay with no mode flags, and each gate
+step additionally probes the deployed `buildbarn-config` `runner.jsonnet` for a
+real `remoteApisSocketPath:` field before the expensive build work:
+
+```
+RECC admission rejected: the deployed bb_runner does not consume BuildStream's
+remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back
+to outer-RE-only or cache-only execution
+```
+
+So the checked-in contract makes these lanes fail closed. Building with outer
+BuildStream remote execution alone is a **rollback-only** path: revert the
+overlay invocation and the admission check in git and let ArgoCD reconcile.
+There is no runtime switch, parameter, or fallback that reaches it. Because the
+live API timed out, no current workflow health or failed-run observation is
+claimed here.
+
+## Rollback
+
+Remove the `recc-casd` container and the `nested-reapi` volume mounts. Nothing
+else references the socket, so no workflow or downstream repository change is
+required and the outer BuildStream worker continues to use the existing
+`bb_runner` path.

--- a/docs/research/2026-07-31-recc-upstream-runner-gate.md
+++ b/docs/research/2026-07-31-recc-upstream-runner-gate.md
@@ -1,0 +1,37 @@
+# RECC nested-runner upstream gate
+
+## Result
+
+The lab's pinned `bb_runner` path remains unsuitable for nested RECC. The
+BuildBarn `ApplicationConfiguration` exposes readiness path checks and native
+chroot execution, but the current upstream source does not contain
+`remoteApisSocketPath`, `remote_apis_socket`, or LocalCAS socket handoff
+support.
+
+The inspected upstream revision was:
+
+```text
+buildbarn/bb-remote-execution
+236bcd95eb8fd2136807f8f6b47093639311a9f1
+```
+
+This is source evidence, not a live cluster claim. Adding a speculative field
+to `runner.jsonnet` would either fail schema validation or silently leave the
+pod-local `recc-casd` socket unused.
+
+## Gate for adopting an upstream runner
+
+An upstream candidate is eligible only when all of these are proven:
+
+1. The image is pinned by immutable digest and its configuration schema
+   documents the nested socket/LocalCAS capability.
+2. A minimal BuildStream action sends `remoteApisSocketPath` and the runner
+   stages the pod-local `emptyDir` socket into the action sandbox.
+3. RECC connects through that socket and emits dedicated evidence while the
+   sandbox cannot reach a host-mounted or cluster-wide socket.
+4. BuildBarn worker metrics show the nested action and the output remains
+   deterministic across a repeated run.
+
+Until that canary passes, production BuildStream lanes remain fail-closed and
+the isolated pilot's `remote-execution` mode remains blocked. A custom runner
+implementation is out of scope.

--- a/manifests/buildbarn-config.yaml
+++ b/manifests/buildbarn-config.yaml
@@ -302,4 +302,12 @@ data:
       // Keep this config aligned with bb_runner ApplicationConfiguration fields.
       chrootIntoInputRoot: true,
       runCommandsAs: { userId: 0, groupId: 0 },
+      // Outer BuildBarn worker readiness is deliberately NOT gated on the
+      // pod-local RECC preparation socket. No runner consumes
+      // remoteApisSocketPath yet, so the socket is unused by outer remote
+      // execution; coupling admission to it would take both workers out of
+      // service for a capability nothing depends on. The recc-casd sidecar
+      // keeps its own readiness/liveness probes on that socket, which is the
+      // separate health boundary. Add readinessCheckingPathnames back only
+      // when a runner actually stages that socket into action sandboxes.
     }

--- a/manifests/buildbarn-worker.yaml
+++ b/manifests/buildbarn-worker.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         app: worker
       annotations:
-        buildbarn-config-revision: "2026-07-23-1"
+        buildbarn-config-revision: "2026-07-30-recc-seam"
         prometheus.io/scrape: "true"
         prometheus.io/port: "9980"
     spec:
@@ -48,7 +48,7 @@ spec:
           command:
             - sh
             - -c
-            - mkdir -pm 0777 /worker/build && mkdir -pm 0700 /worker/cache && mkdir -p /worker/dev && chmod 0777 /worker && (mknod -m 666 /worker/dev/null c 1 3 || test -c /worker/dev/null) && (mknod -m 666 /worker/dev/zero c 1 5 || test -c /worker/dev/zero) && (mknod -m 666 /worker/dev/random c 1 8 || test -c /worker/dev/random) && (mknod -m 666 /worker/dev/urandom c 1 9 || test -c /worker/dev/urandom)
+            - mkdir -pm 0777 /worker/build && mkdir -pm 0700 /worker/cache && mkdir -pm 0770 /worker/recc-casd && mkdir -p /worker/dev && chmod 0777 /worker && (mknod -m 666 /worker/dev/null c 1 3 || test -c /worker/dev/null) && (mknod -m 666 /worker/dev/zero c 1 5 || test -c /worker/dev/zero) && (mknod -m 666 /worker/dev/random c 1 8 || test -c /worker/dev/random) && (mknod -m 666 /worker/dev/urandom c 1 9 || test -c /worker/dev/urandom) && ln -sfn /proc/self/fd/0 /worker/dev/stdin && ln -sfn /proc/self/fd/1 /worker/dev/stdout && ln -sfn /proc/self/fd/2 /worker/dev/stderr
           volumeMounts:
             - mountPath: /worker
               name: worker
@@ -98,6 +98,59 @@ spec:
               name: fuse
             - mountPath: /bb
               name: bb-runner-bin
+        - name: recc-casd
+          # This is the existing BuildStream image contract: it contains the
+          # LocalCAS proxy used by the lab's historical buildbox-casd manifest.
+          # The current bb_runner still cannot consume remoteApisSocketPath;
+          # this sidecar only makes the worker-local endpoint available for a
+          # compatible runner image.
+          image: 192.168.1.102:30500/bst2@sha256:ce272e0ae4b59251680b8a70645740640ced17689e21268ddc037614c755f734
+          imagePullPolicy: IfNotPresent
+          # PATH lookup, not an absolute path: the bst2 image install prefix
+          # is not pinned by anything in this repo, and the lab's historical
+          # buildbox-casd manifest resolved the binary through PATH against
+          # the same image family. Only pin an absolute path once the pinned
+          # digest is proven to ship it there.
+          command: [buildbox-casd]
+          args:
+            - --cas-remote=grpc://frontend.buildbarn.svc.cluster.local:8980
+            - --ac-remote=grpc://frontend.buildbarn.svc.cluster.local:8980
+            - --exec-remote=grpc://frontend.buildbarn.svc.cluster.local:8980
+            - --bind=unix:/run/buildbarn/recc/casd.sock
+            - --unix-socket-mode=0660
+            - --quota-high=8G
+            - --quota-low=6G
+            - /worker/recc-casd
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            exec:
+              command: [test, -S, /run/buildbarn/recc/casd.sock]
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command: [test, -S, /run/buildbarn/recc/casd.sock]
+            periodSeconds: 15
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /run/buildbarn/recc
+              name: nested-reapi
+            - mountPath: /worker
+              name: worker
         - name: runner
           image: cgr.dev/chainguard/wolfi-base@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795
           command: [/bb/bb_runner, /config/runner.jsonnet]
@@ -139,8 +192,15 @@ spec:
               name: fuse
             - mountPath: /bb
               name: bb-runner-bin
+            - mountPath: /run/buildbarn/recc
+              name: nested-reapi
       volumes:
         - name: bb-runner-bin
+          emptyDir: {}
+        # Pod-local only: the socket must never become a host or cluster
+        # endpoint. A future LocalCAS-capable runner can stage this endpoint
+        # into the BuildStream sandbox without hostPID or hostIPC.
+        - name: nested-reapi
           emptyDir: {}
         - name: fuse
           hostPath:

--- a/manifests/buildstream-remote-cache-config.yaml
+++ b/manifests/buildstream-remote-cache-config.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/component: buildstream
 
 data:
+  recc-endpoint: grpc://frontend.buildbarn.svc.cluster.local:8980
   # Dakota's coordinator fetches four artifacts/sources concurrently. Use a
   # moderate profile that still leaves headroom for BuildBarn queue depth and
   # worker action pressure while avoiding the earlier over-saturation.
@@ -66,13 +67,878 @@ data:
           retry-limit: 8
           retry-delay: 1000
           request-timeout: 1800
-  # RECC (Remote Execution C/C++ Compiler) environment configuration snippet.
-  # Enables fine-grained C/C++ compilation distribution into BuildBarn RE
-  # (following GNOME gnome-build-meta!4704 and FreeDesktop-SDK#1961).
+  # Shared lab RECC (Remote Execution C/C++ Compiler) contract. This is a
+  # BuildStream/YAML environment map, not a shell script. A future sandbox
+  # integration may merge it under the project's environment section.
+  # Per-toolchain integrations must add RECC_REMOTE_PLATFORM_chrootRootDigest
+  # themselves; it cannot be a lab-wide constant.
   recc-environment.conf: |
     RECC_SERVER: "frontend.buildbarn.svc.cluster.local:8980"
     RECC_CAS_SERVER: "frontend.buildbarn.svc.cluster.local:8980"
+    RECC_ACTION_CACHE_SERVER: "frontend.buildbarn.svc.cluster.local:8980"
     RECC_ACTION_UNCACHEABLE: "0"
     RECC_PROJECT_ROOT: "/workspace"
-    RECC_PREFIX: "recc"
     RECC_VERBOSE: "1"
+
+  # The workflow pods mount this exact lab-owned helper. Keep it byte-identical
+  # to scripts/apply_recc_overlay.py; the focused seam test enforces that.
+  apply_recc_overlay.py: |
+    #!/usr/bin/env python3
+    """Apply the lab-owned RECC integration to an isolated BuildStream checkout.
+
+    The overlay is deliberately checkout-local.  It never edits a downstream
+    repository or a workflow template, and it refuses to guess at unfamiliar
+    project layouts.
+
+    It is also fail-closed about the two known blockers:
+
+    * production lanes are refused unless ``--runner-capability`` asserts that the
+      deployed BuildBarn runner honors BuildStream's ``remoteApisSocketPath``;
+    * every overlay requires a pinned element that actually stages ``recc`` in the
+      sandbox, because the build image's host ``recc`` is not visible there.
+    """
+
+    from __future__ import annotations
+
+    import argparse
+    import hashlib
+    import json
+    import os
+    import re
+    import sys
+    from dataclasses import dataclass
+    from pathlib import Path
+    from urllib.parse import urlsplit
+
+
+    OVERLAY_VERSION = "2.0.0"
+    DEFAULT_ENDPOINT = "grpc://frontend.buildbarn.svc.cluster.local:8980"
+    MIN_BUILDSTREAM_VERSION = (2, 5)
+    MANAGED_FILES = (
+        "include/recc.yml",
+        "include/gcc-for-recc.yml",
+        "include/clang-for-recc.yml",
+        "elements/buildsystems/recc-wrapper.bst",
+        "files/recc-wrapper/recc-wrapper",
+    )
+
+
+    class OverlayError(RuntimeError):
+        """Raised when a checkout is not a known, safe overlay target."""
+
+
+    @dataclass(frozen=True)
+    class ProjectAdapter:
+        kind: str
+        required_paths: tuple[str, ...]
+        element_roots: tuple[str, ...]
+        compiler_markers: tuple[str, ...]
+        forced_digest_targets: tuple[str, ...] = ()
+        forced_wrapper_targets: tuple[str, ...] = ()
+        # Element that stages the `recc` binary into the sandbox. freedesktop-sdk
+        # builds `components/buildbox.bst` with -DRECC=ON, so that element is the
+        # only pinned provider the lab can point at today. The bst2 image's host
+        # `recc` is never visible inside a BuildStream sandbox.
+        recc_provider: str | None = "freedesktop-sdk.bst:components/buildbox.bst"
+        allow_missing_digest_targets: bool = False
+        # Mandatory-RECC lanes (production builds, warmup, and QA) must not run at
+        # all until a runner is proven to honor BuildStream's remoteApisSocketPath
+        # platform property. Only the operator-driven pilot baseline is exempt.
+        production: bool = True
+
+
+    ADAPTERS = {
+        "dakota": ProjectAdapter(
+            kind="dakota",
+            required_paths=(
+                "project.conf",
+                "elements/freedesktop-sdk.bst",
+                "elements/gnome-build-meta.bst",
+                "elements/oci/layers/bluefin.bst",
+                "elements/oci/layers/bluefin-nvidia.bst",
+            ),
+            element_roots=("elements/bluefin", "elements/oci"),
+            compiler_markers=(
+                "freedesktop-sdk.bst:components/gcc",
+                "freedesktop-sdk.bst:components/clang",
+                "buildsystems/",
+            ),
+            forced_digest_targets=(
+                "elements/oci/layers/bluefin.bst",
+                "elements/oci/layers/bluefin-nvidia.bst",
+            ),
+        ),
+        "cosmic": ProjectAdapter(
+            kind="cosmic",
+            required_paths=(
+                "project.conf",
+                "elements/freedesktop-sdk.bst",
+                "elements/core/cosmic-comp.bst",
+                "elements/core/cosmic-files.bst",
+            ),
+            element_roots=(
+                "elements/core",
+                "elements/core-deps",
+                "elements/cosmic-deps",
+                "elements/cosmic-deps-nvidia",
+                "elements/gaming",
+                "elements/oci",
+            ),
+            compiler_markers=(
+                "freedesktop-sdk.bst:components/gcc",
+                "freedesktop-sdk.bst:components/clang",
+                "buildsystems/",
+            ),
+            forced_digest_targets=(
+                "elements/core/cosmic-comp.bst",
+                "elements/core/cosmic-files.bst",
+            ),
+        ),
+        "bluefin-server": ProjectAdapter(
+            kind="bluefin-server",
+            required_paths=(
+                "project.conf",
+                "elements/freedesktop-sdk.bst",
+                "elements/gnome-build-meta.bst",
+                "elements/oci/bluefin-server-ddi.bst",
+                "elements/oci/bluefin-server-installer.bst",
+            ),
+            element_roots=("elements/bluefin-server", "elements/oci"),
+            compiler_markers=(
+                "freedesktop-sdk.bst:components/gcc",
+                "freedesktop-sdk.bst:components/clang",
+                "buildsystems/",
+            ),
+            forced_digest_targets=(
+                "elements/oci/bluefin-server-ddi.bst",
+                "elements/oci/bluefin-server-installer.bst",
+            ),
+            forced_wrapper_targets=(
+                "elements/oci/bluefin-server-ddi.bst",
+                "elements/oci/bluefin-server-installer.bst",
+            ),
+        ),
+        "bst-prototype": ProjectAdapter(
+            kind="bst-prototype",
+            required_paths=(
+                "project.conf",
+                "elements/freedesktop-sdk.bst",
+                "elements/recc-baseline.bst",
+            ),
+            element_roots=("elements",),
+            compiler_markers=("g++", "clang++"),
+            forced_digest_targets=("elements/recc-baseline.bst",),
+            forced_wrapper_targets=("elements/recc-baseline.bst",),
+            recc_provider=None,
+            allow_missing_digest_targets=False,
+            production=False,
+        ),
+        # The bst-qa lane is a real lab QA lane, not an operator experiment: it
+        # carries the same mandatory-RECC admission contract as the build lanes.
+        "bst-qa": ProjectAdapter(
+            kind="bst-qa",
+            required_paths=("project.conf", "elements/recc-baseline.bst"),
+            element_roots=("elements",),
+            compiler_markers=("g++", "clang++"),
+            forced_wrapper_targets=("elements/recc-baseline.bst",),
+            recc_provider=None,
+            allow_missing_digest_targets=True,
+            production=True,
+        ),
+    }
+
+
+    RECC_INCLUDE = """\
+    # Generated by the lab RECC checkout overlay {version}; do not commit this file.
+    #
+    # The nested socket stanza is intentionally absent unless the runner capability
+    # was explicitly supplied to apply_recc_overlay.py.
+    environment:
+      # Prepend the wrapper directory; keep the standard search path intact so
+      # build systems still resolve /bin, /usr/sbin, and /sbin tooling.
+      PATH: /usr/recc/bin:/usr/bin:/bin:/usr/sbin:/sbin
+      RECC_SERVER: {endpoint}
+      RECC_CAS_SERVER: {endpoint}
+      RECC_ACTION_CACHE_SERVER: {endpoint}
+      RECC_ACTION_UNCACHEABLE: "0"
+      RECC_PROJECT_ROOT: /workspace
+      RECC_VERBOSE: "1"
+      RECC_DEPS_GLOBAL_PATHS: true
+      RECC_NO_PATH_REWRITE: true
+
+      (?):
+      - recc == "passthrough":
+          RECC_PASSTHROUGH: true
+      - recc == "cache-only":
+          RECC_CACHE_ONLY: true
+      - recc == "upload-local-build":
+          RECC_CACHE_ONLY: true
+          RECC_CACHE_UPLOAD_LOCAL_BUILD: true
+
+    environment-nocache:
+    - RECC_CACHE_ONLY
+    - RECC_PASSTHROUGH
+    - RECC_CACHE_UPLOAD_LOCAL_BUILD
+    - RECC_USE_LOCALCAS
+    - RECC_USE_JOBSERVER
+    {socket}
+    """
+
+    GCC_DIGEST_INCLUDE = """\
+    # Generated by the lab RECC checkout overlay {version}.
+    filename:
+    - freedesktop-sdk.bst:components/gcc.bst
+    config:
+      digest-environment: RECC_REMOTE_PLATFORM_chrootRootDigest
+    """
+
+    CLANG_DIGEST_INCLUDE = """\
+    # Generated by the lab RECC checkout overlay {version}.
+    filename:
+    - freedesktop-sdk.bst:components/llvm.bst
+    - freedesktop-sdk.bst:components/zlib.bst
+    config:
+      digest-environment: RECC_REMOTE_PLATFORM_chrootRootDigest
+    """
+
+    RECC_WRAPPER = """\
+    #!/bin/sh
+    set -eu
+
+    if [ -z "${RECC_REMOTE_PLATFORM_chrootRootDigest:-}" ]; then
+        echo "RECC_REMOTE_PLATFORM_chrootRootDigest is required for RECC" >&2
+        exit 1
+    fi
+
+    if ! command -v recc >/dev/null 2>&1; then
+        echo "recc is not staged in this sandbox; the RECC wrapper cannot run." >&2
+        echo "The build image's host recc is not visible inside the sandbox; the" >&2
+        echo "element must depend on the pinned recc provider element." >&2
+        exit 1
+    fi
+
+    exec recc "/usr/bin/$(basename "$0")" "$@"
+    """
+
+
+    def _wrapper_element(recc_provider: str, version: str) -> str:
+        return f"""\
+    # Generated by the lab RECC checkout overlay {version}.
+    #
+    # runtime-depends supplies the `recc` binary that files/recc-wrapper/recc-wrapper
+    # executes. Without it the wrapper would exec a binary that does not exist in
+    # the sandbox, so the overlay refuses to generate this element unless a pinned
+    # provider element is known.
+    kind: import
+
+    sources:
+    - kind: local
+      path: files/recc-wrapper/recc-wrapper
+
+    config:
+      target: /usr/recc/bin
+
+    runtime-depends:
+    - {recc_provider}
+
+    public:
+      bst:
+        integration-commands:
+        - |
+          for COMPILER in \
+            /usr/bin/cc \
+            /usr/bin/c++ \
+            /usr/bin/gcc \
+            /usr/bin/g++ \
+            /usr/bin/clang \
+            /usr/bin/clang++ \
+            /usr/bin/*-cc \
+            /usr/bin/*-c++ \
+            /usr/bin/*-gcc \
+            /usr/bin/*-g++ \
+            /usr/bin/*-clang \
+            /usr/bin/*-clang++; do
+            [ -e "$COMPILER" ] || continue
+            ln -s recc-wrapper /usr/recc/bin/"$(basename "$COMPILER")"
+          done
+    """
+
+
+    def _safe_endpoint(value: str) -> str:
+        """Validate an endpoint and return a diagnostic-safe representation."""
+
+        if not value or any(char.isspace() for char in value):
+            raise OverlayError("RECC endpoint must be a non-empty URL without whitespace")
+        if "://" not in value:
+            value = f"grpc://{value}"
+        parsed = urlsplit(value)
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise OverlayError("RECC endpoint must contain a valid numeric port") from exc
+        if parsed.scheme not in {"grpc", "grpcs"} or not parsed.hostname or port is None:
+            raise OverlayError(
+                "RECC endpoint must use grpc:// or grpcs:// with a host and port"
+            )
+        hostname = parsed.hostname
+        if ":" not in hostname and not re.fullmatch(r"[A-Za-z0-9.-]+", hostname):
+            raise OverlayError("RECC endpoint host contains unsafe characters")
+        if parsed.username or parsed.password or parsed.path or parsed.query or parsed.fragment:
+            raise OverlayError("RECC endpoint must not contain credentials or URL data")
+        return f"{parsed.scheme}://{hostname}:{port}"
+
+
+    def _version_tuple(value: str) -> tuple[int, ...]:
+        match = re.fullmatch(r"\s*(\d+(?:\.\d+)*)\s*", value)
+        if not match:
+            raise OverlayError(f"unsupported BuildStream version: {value!r}")
+        return tuple(int(part) for part in match.group(1).split("."))
+
+
+    def _resolve_policy(
+        adapter: ProjectAdapter,
+        *,
+        runner_capability: bool,
+        pilot_cache_only: bool,
+    ) -> str:
+        """Return the RECC policy, refusing every unsafe combination."""
+
+        if runner_capability and pilot_cache_only:
+            raise OverlayError(
+                "--runner-capability and --pilot-cache-only are mutually exclusive"
+            )
+        if adapter.production:
+            if pilot_cache_only:
+                raise OverlayError(
+                    f"{adapter.kind} is a mandatory-RECC lane: --pilot-cache-only is "
+                    "an operator-only flag for the documented prototype baseline, "
+                    "and RECC cache-only/local fallback is not permitted here"
+                )
+            if not runner_capability:
+                raise OverlayError(
+                    f"{adapter.kind} is a mandatory-RECC lane and RECC is blocked: "
+                    "the pinned BuildBarn runner does not honor BuildStream's "
+                    "remoteApisSocketPath, so nested RECC cannot be enabled. This "
+                    "lane must fail closed rather than build with outer remote "
+                    "execution only or with a cache-only fallback. Re-run with "
+                    "--runner-capability only once a runner that consumes that "
+                    "platform property is deployed and proven; see "
+                    "docs/reference/recc-runner-seam.md"
+                )
+            return "remote-execution"
+        if runner_capability:
+            return "remote-execution"
+        if pilot_cache_only:
+            return "cache-only"
+        raise OverlayError(
+            f"{adapter.kind} is the operator-only pilot baseline: pass "
+            "--pilot-cache-only for the documented cache-only experiment, or "
+            "--runner-capability once nested RECC is proven. Workflow templates "
+            "must never pass either flag"
+        )
+
+
+    def _element_path(text: str) -> str:
+        match = re.search(r"(?m)^element-path:\s*(\S+)\s*$", text)
+        return match.group(1) if match else "elements"
+
+
+    def _resolve_recc_provider(
+        checkout: Path,
+        adapter: ProjectAdapter,
+        *,
+        override: str | None,
+        element_path: str,
+    ) -> str:
+        """Return the element that stages `recc`, or refuse before any write."""
+
+        provider = override or adapter.recc_provider
+        if not provider:
+            raise OverlayError(
+                f"{adapter.kind} cannot supply the recc binary: no pinned element in "
+                "this checkout provides it, and the build image's host recc is not "
+                "visible inside a BuildStream sandbox. Pass --recc-provider with a "
+                "pinned element that stages recc (for example a freedesktop-sdk "
+                "junction's components/buildbox.bst, built with -DRECC=ON)"
+            )
+        if not re.fullmatch(r"[A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*"
+                            r"(?::[A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*)?", provider):
+            raise OverlayError(f"recc provider is not a plain element name: {provider!r}")
+        junction, _, element = provider.partition(":")
+        if not element:
+            junction, element = "", junction
+        if not element.endswith(".bst"):
+            raise OverlayError(f"recc provider must name a .bst element: {provider!r}")
+        checkout = checkout.resolve()
+
+        def resolve_inside_checkout(path: Path, description: str) -> Path:
+            try:
+                resolved = path.resolve()
+            except (OSError, RuntimeError) as exc:
+                raise OverlayError(
+                    f"recc provider {provider!r} cannot resolve its {description} safely"
+                ) from exc
+            try:
+                resolved.relative_to(checkout)
+            except ValueError as exc:
+                raise OverlayError(
+                    f"recc provider {provider!r} resolves outside the checkout: "
+                    f"{resolved}"
+                ) from exc
+            return resolved
+
+        if junction:
+            if not junction.endswith(".bst"):
+                raise OverlayError(
+                    f"recc provider junction must be a .bst element: {provider!r}"
+                )
+            required = resolve_inside_checkout(
+                checkout / element_path / junction, "junction path"
+            )
+            description = f"junction {junction}"
+        else:
+            required = resolve_inside_checkout(
+                checkout / element_path / element, "element path"
+            )
+            description = f"element {element}"
+        if not required.is_file():
+            raise OverlayError(
+                f"recc provider {provider!r} is unusable: {description} is missing "
+                f"from {element_path}/; the wrapper would exec a recc binary that "
+                "is not staged in the sandbox"
+            )
+        return provider
+
+
+    def _project_conf_version(text: str) -> tuple[int, ...]:
+        match = re.search(r"(?m)^min-version:\s*([0-9.]+)\s*$", text)
+        if not match:
+            raise OverlayError("project.conf has no min-version")
+        return _version_tuple(match.group(1))
+
+
+    def _ensure_project_include(text: str) -> str:
+        if re.search(r"(?m)^\s*-\s+include/recc\.yml\s*$", text):
+            return text
+        match = re.search(r"(?m)^(\(@\):\s*)$", text)
+        if match:
+            line_end = match.end()
+            return text[:line_end] + "\n  - include/recc.yml" + text[line_end:]
+
+        marker = re.search(r"(?m)^element-path:.*$", text)
+        if not marker:
+            raise OverlayError("project.conf has no supported element-path anchor")
+        insertion = "\n\n(@):\n  - include/recc.yml"
+        return text[: marker.end()] + insertion + text[marker.end() :]
+
+
+    def _recc_option_block(policy: str) -> str:
+        return f"""
+      recc:
+        type: enum
+        description: lab RECC policy
+        values:
+        - passthrough
+        - cache-only
+        - remote-execution
+        - upload-local-build
+        default: {policy}
+    """
+
+
+    def _ensure_recc_option(text: str, policy: str) -> str:
+        options = re.search(r"(?m)^options:\s*$", text)
+        if not options:
+            return text.rstrip() + "\n\noptions:" + _recc_option_block(policy)
+
+        start = options.end()
+        next_section = re.search(r"(?m)^[^\s#][^:]*:\s*$", text[start:])
+        end = start + next_section.start() if next_section else len(text)
+        block = text[start:end]
+        recc = re.search(r"(?m)^  recc:\s*$", block)
+        if not recc:
+            return text[:end].rstrip() + "\n" + _recc_option_block(policy) + text[end:]
+
+        recc_start = recc.start()
+        next_option = re.search(r"(?m)^  [A-Za-z0-9_-]+:\s*$", block[recc.end() :])
+        recc_end = recc.end() + (next_option.start() if next_option else len(block[recc.end() :]))
+        recc_block = block[recc_start:recc_end]
+        if not re.search(r"(?m)^\s+type:\s*enum\s*$", recc_block):
+            raise OverlayError("project.conf recc option is not an enum")
+        if not re.search(rf"(?m)^\s+-\s+{re.escape(policy)}\s*$", recc_block):
+            list_item = re.search(r"(?m)^(\s+)-\s+", recc_block)
+            item_indent = list_item.group(1) if list_item else "    "
+            default = re.search(r"(?m)^\s+default:", recc_block)
+            entry = f"{item_indent}- {policy}\n"
+            if default:
+                recc_block = recc_block[: default.start()] + entry + recc_block[default.start() :]
+            else:
+                recc_block += entry
+        if re.search(r"(?m)^\s+default:", recc_block):
+            recc_block = re.sub(
+                r"(?m)^(\s+default:)\s*.*$",
+                rf"\1 {policy}",
+                recc_block,
+                count=1,
+            )
+        else:
+            recc_block = recc_block.rstrip() + f"\n    default: {policy}\n"
+        return text[:start] + block[:recc_start] + recc_block + block[recc_end:] + text[end:]
+
+
+    def _prepare_project_conf(text: str, policy: str) -> str:
+        version = _project_conf_version(text)
+        if version < MIN_BUILDSTREAM_VERSION:
+            text = re.sub(
+                r"(?m)^min-version:\s*[0-9.]+\s*$",
+                "min-version: 2.5",
+                text,
+                count=1,
+            )
+        text = _ensure_project_include(text)
+        return _ensure_recc_option(text, policy)
+
+
+    def _compiler_target(path: Path, markers: tuple[str, ...]) -> bool:
+        text = path.read_text(encoding="utf-8")
+        match = re.search(
+            r"(?ms)^build-depends:\s*(.*?)(?=^[A-Za-z][A-Za-z0-9_-]*:\s*$|\Z)",
+            text,
+        )
+        if not match:
+            return False
+        return any(marker in match.group(0) for marker in markers)
+
+
+    def _find_targets(checkout: Path, adapter: ProjectAdapter) -> list[Path]:
+        targets: list[Path] = []
+        for root_name in adapter.element_roots:
+            root = checkout / root_name
+            if not root.is_dir():
+                continue
+            targets.extend(
+                path
+                for path in sorted(root.rglob("*.bst"))
+                if _compiler_target(path, adapter.compiler_markers)
+            )
+        for name in adapter.forced_digest_targets + adapter.forced_wrapper_targets:
+            path = checkout / name
+            if path.exists() and path not in targets:
+                targets.append(path)
+        return sorted(targets)
+
+
+    def _insert_build_depends(text: str, entries: tuple[str, ...]) -> str:
+        if "build-depends:" not in text:
+            kind = re.search(r"(?m)^kind:\s*.+$", text)
+            if not kind:
+                raise OverlayError("element has no kind anchor for build-depends injection")
+            return (
+                text[: kind.end()]
+                + "\n\nbuild-depends:\n"
+                + "".join(f"- {entry}\n" for entry in entries)
+                + text[kind.end() :]
+            )
+
+        match = re.search(r"(?m)^build-depends:[ \t]*(?:#.*)?$", text)
+        if not match:
+            raise OverlayError("element has an unsupported inline build-depends layout")
+        # Insert after the newline that terminates the section line, never before
+        # it: anything else can splice the first entry onto `build-depends:` when
+        # the next line is a comment.
+        line_end = text.find("\n", match.end())
+        if line_end == -1:
+            text += "\n"
+            section_start = len(text)
+        else:
+            section_start = line_end + 1
+        next_section = re.search(r"(?m)^[A-Za-z][A-Za-z0-9_-]*:", text[section_start:])
+        section_end = section_start + next_section.start() if next_section else len(text)
+        section = text[section_start:section_end]
+        missing = [
+            entry
+            for entry in entries
+            if not re.search(
+                rf"(?m)^[ \t]*-[ \t]+(?:\(@\):[ \t]*)?{re.escape(entry)}[ \t]*$", section
+            )
+        ]
+        if not missing:
+            return text
+        # Indentation comes from an existing list item on its own line, so a
+        # leading comment or blank line cannot contribute stray whitespace.
+        indent_match = re.search(r"(?m)^([ \t]*)-[ \t]+", section)
+        indent = indent_match.group(1) if indent_match else ""
+        addition = "".join(f"{indent}- {entry}\n" for entry in missing)
+        return text[:section_start] + addition + text[section_start:]
+
+
+    def _patch_element(
+        path: Path,
+        *,
+        add_digest: bool,
+        digest_include: str,
+        add_wrapper: bool,
+    ) -> str:
+        text = path.read_text(encoding="utf-8")
+        entries: list[str] = []
+        if add_wrapper and "buildsystems/recc-wrapper.bst" not in text:
+            entries.append("buildsystems/recc-wrapper.bst")
+        if add_digest and digest_include not in text:
+            entries.append(f"(@): {digest_include}")
+        if not entries:
+            return text
+        return _insert_build_depends(text, tuple(entries))
+
+
+    def _write_if_safe(path: Path, content: str, writes: dict[str, str]) -> None:
+        if path.exists():
+            current = path.read_text(encoding="utf-8")
+            if current != content:
+                raise OverlayError(f"refusing to overwrite existing file: {path}")
+            return
+        writes[str(path)] = content
+
+
+    def _sha256(content: str) -> str:
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+    def apply_overlay(
+        checkout: Path,
+        *,
+        project_kind: str,
+        endpoint: str = DEFAULT_ENDPOINT,
+        runner_capability: bool = False,
+        pilot_cache_only: bool = False,
+        recc_provider: str | None = None,
+    ) -> dict[str, object]:
+        """Apply an overlay and return safe diagnostics."""
+
+        checkout = Path(checkout).resolve()
+        if not checkout.is_dir():
+            raise OverlayError(f"checkout is not a directory: {checkout}")
+        try:
+            adapter = ADAPTERS[project_kind]
+        except KeyError as exc:
+            raise OverlayError(f"unsupported project kind: {project_kind}") from exc
+
+        policy = _resolve_policy(
+            adapter,
+            runner_capability=runner_capability,
+            pilot_cache_only=pilot_cache_only,
+        )
+        endpoint = _safe_endpoint(endpoint)
+        for relative in adapter.required_paths:
+            if not (checkout / relative).is_file():
+                raise OverlayError(
+                    f"{project_kind} checkout is missing required path: {relative}"
+                )
+
+        project_conf = checkout / "project.conf"
+        project_text = project_conf.read_text(encoding="utf-8")
+        provider = _resolve_recc_provider(
+            checkout,
+            adapter,
+            override=recc_provider,
+            element_path=_element_path(project_text),
+        )
+        project_text = _prepare_project_conf(project_text, policy)
+
+        targets = _find_targets(checkout, adapter)
+        if not targets and not adapter.allow_missing_digest_targets:
+            raise OverlayError(
+                f"{project_kind} checkout has no recognized compiler/buildsystem elements"
+            )
+        for path in targets:
+            if "build-depends:" not in path.read_text(encoding="utf-8") and path not in {
+                checkout / name for name in adapter.forced_wrapper_targets
+            }:
+                # A recognized compiler element without a dependency list cannot be
+                # safely rewritten by this text-preserving helper.
+                if _compiler_target(path, adapter.compiler_markers) and not (
+                    adapter.allow_missing_digest_targets
+                ):
+                    raise OverlayError(
+                        f"unsupported build-depends layout in compiler element: {path}"
+                    )
+
+        socket = ""
+        if runner_capability:
+            socket = """
+
+    sandbox:
+      remote-apis-socket:
+        path: /tmp/casd.sock
+    """
+        include = RECC_INCLUDE.format(
+            version=OVERLAY_VERSION,
+            endpoint=endpoint,
+            socket=socket.rstrip("\n"),
+        )
+        gcc_include = GCC_DIGEST_INCLUDE.format(version=OVERLAY_VERSION)
+        clang_include = CLANG_DIGEST_INCLUDE.format(version=OVERLAY_VERSION)
+        wrapper_element = _wrapper_element(provider, OVERLAY_VERSION)
+
+        writes: dict[str, str] = {}
+        _write_if_safe(checkout / "include/recc.yml", include, writes)
+        _write_if_safe(checkout / "include/gcc-for-recc.yml", gcc_include, writes)
+        _write_if_safe(checkout / "include/clang-for-recc.yml", clang_include, writes)
+        _write_if_safe(
+            checkout / "elements/buildsystems/recc-wrapper.bst",
+            wrapper_element,
+            writes,
+        )
+        _write_if_safe(
+            checkout / "files/recc-wrapper/recc-wrapper",
+            RECC_WRAPPER,
+            writes,
+        )
+        wrapper_path = checkout / "files/recc-wrapper/recc-wrapper"
+        if wrapper_path.exists() and not wrapper_path.stat().st_mode & 0o111:
+            raise OverlayError(f"RECC wrapper is not executable: {wrapper_path}")
+
+        changed: dict[str, str] = {}
+        if project_text != project_conf.read_text(encoding="utf-8"):
+            changed[str(project_conf)] = project_text
+
+        forced_digest = {checkout / name for name in adapter.forced_digest_targets}
+        forced_wrapper = {checkout / name for name in adapter.forced_wrapper_targets}
+        for path in targets:
+            element_text = path.read_text(encoding="utf-8")
+            digest_include = (
+                "include/clang-for-recc.yml"
+                if re.search(r"(?i)(clang|llvm)", element_text)
+                else "include/gcc-for-recc.yml"
+            )
+            patched = _patch_element(
+                path,
+                add_digest=(
+                    not adapter.allow_missing_digest_targets
+                    and (
+                        path in forced_digest
+                        or _compiler_target(path, adapter.compiler_markers)
+                    )
+                ),
+                digest_include=digest_include,
+                add_wrapper=path in forced_wrapper
+                or (
+                    not adapter.allow_missing_digest_targets
+                    and _compiler_target(path, adapter.compiler_markers)
+                ),
+            )
+            if patched != path.read_text(encoding="utf-8"):
+                changed[str(path)] = patched
+
+        # All validation is complete before touching the checkout.
+        for filename, content in writes.items():
+            target = Path(filename)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            if target.name == "recc-wrapper":
+                target.chmod(0o755)
+        for filename, content in changed.items():
+            Path(filename).write_text(content, encoding="utf-8")
+
+        changed_files = {}
+        for filename in sorted(set(writes) | set(changed)):
+            content = Path(filename).read_text(encoding="utf-8")
+            changed_files[str(Path(filename).relative_to(checkout))] = _sha256(content)
+        file_checksums = {}
+        for relative in MANAGED_FILES:
+            path = checkout / relative
+            if path.is_file():
+                file_checksums[relative] = _sha256(path.read_text(encoding="utf-8"))
+
+        digest_status = "applied"
+        if adapter.allow_missing_digest_targets:
+            digest_status = "available-but-not-attached-no-sdk-junction"
+        return {
+            "overlay_version": OVERLAY_VERSION,
+            "project_kind": project_kind,
+            "endpoint": endpoint,
+            "remote_execution_policy": policy,
+            "recc_provider": provider,
+            "nested_socket": "enabled" if runner_capability else "disabled",
+            "digest_environment": digest_status,
+            "changed_files": changed_files,
+            "file_checksums": file_checksums,
+        }
+
+
+    def _parser() -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(description=__doc__)
+        parser.add_argument("checkout", type=Path)
+        parser.add_argument(
+            "--project-kind",
+            choices=sorted(ADAPTERS),
+            required=True,
+            help="known BuildStream checkout adapter to apply",
+        )
+        parser.add_argument(
+            "--endpoint",
+            default=os.environ.get("RECC_SERVER", DEFAULT_ENDPOINT),
+            help="shared RECC gRPC endpoint (default: lab BuildBarn frontend)",
+        )
+        parser.add_argument(
+            "--runner-capability",
+            action="store_true",
+            help=(
+                "assert that the deployed BuildBarn runner honors BuildStream's "
+                "remoteApisSocketPath; required before any production lane may be "
+                "overlaid, and enables sandbox.remote-apis-socket"
+            ),
+        )
+        parser.add_argument(
+            "--pilot-cache-only",
+            action="store_true",
+            help=(
+                "pilot fixtures only: apply a documented cache-only experiment "
+                "instead of nested remote execution"
+            ),
+        )
+        parser.add_argument(
+            "--recc-provider",
+            default=None,
+            help=(
+                "pinned BuildStream element that stages the recc binary in the "
+                "sandbox (default: the adapter's pinned provider, if any)"
+            ),
+        )
+        parser.add_argument("--json", action="store_true", help="emit diagnostics as JSON")
+        parser.add_argument("--version", action="version", version=OVERLAY_VERSION)
+        return parser
+
+
+    def main(argv: list[str] | None = None) -> int:
+        args = _parser().parse_args(argv)
+        try:
+            diagnostics = apply_overlay(
+                args.checkout,
+                project_kind=args.project_kind,
+                endpoint=args.endpoint,
+                runner_capability=args.runner_capability,
+                pilot_cache_only=args.pilot_cache_only,
+                recc_provider=args.recc_provider,
+            )
+        except OverlayError as exc:
+            print(f"recc overlay refused: {exc}", file=sys.stderr)
+            return 2
+        if args.json:
+            print(json.dumps(diagnostics, sort_keys=True))
+        else:
+            print(
+                "RECC overlay "
+                f"v{diagnostics['overlay_version']} applied to "
+                f"{diagnostics['project_kind']}: "
+                f"policy={diagnostics['remote_execution_policy']} "
+                f"recc-provider={diagnostics['recc_provider']} "
+                f"nested-socket={diagnostics['nested_socket']} "
+                f"digest-environment={diagnostics['digest_environment']}"
+            )
+            for filename, checksum in diagnostics["changed_files"].items():
+                print(f"  {filename}: sha256:{checksum}")
+        return 0
+
+
+    if __name__ == "__main__":
+        raise SystemExit(main())

--- a/scripts/apply_recc_overlay.py
+++ b/scripts/apply_recc_overlay.py
@@ -1,0 +1,859 @@
+#!/usr/bin/env python3
+"""Apply the lab-owned RECC integration to an isolated BuildStream checkout.
+
+The overlay is deliberately checkout-local.  It never edits a downstream
+repository or a workflow template, and it refuses to guess at unfamiliar
+project layouts.
+
+It is also fail-closed about the two known blockers:
+
+* production lanes are refused unless ``--runner-capability`` asserts that the
+  deployed BuildBarn runner honors BuildStream's ``remoteApisSocketPath``;
+* every overlay requires a pinned element that actually stages ``recc`` in the
+  sandbox, because the build image's host ``recc`` is not visible there.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+OVERLAY_VERSION = "2.0.0"
+DEFAULT_ENDPOINT = "grpc://frontend.buildbarn.svc.cluster.local:8980"
+MIN_BUILDSTREAM_VERSION = (2, 5)
+MANAGED_FILES = (
+    "include/recc.yml",
+    "include/gcc-for-recc.yml",
+    "include/clang-for-recc.yml",
+    "elements/buildsystems/recc-wrapper.bst",
+    "files/recc-wrapper/recc-wrapper",
+)
+
+
+class OverlayError(RuntimeError):
+    """Raised when a checkout is not a known, safe overlay target."""
+
+
+@dataclass(frozen=True)
+class ProjectAdapter:
+    kind: str
+    required_paths: tuple[str, ...]
+    element_roots: tuple[str, ...]
+    compiler_markers: tuple[str, ...]
+    forced_digest_targets: tuple[str, ...] = ()
+    forced_wrapper_targets: tuple[str, ...] = ()
+    # Element that stages the `recc` binary into the sandbox. freedesktop-sdk
+    # builds `components/buildbox.bst` with -DRECC=ON, so that element is the
+    # only pinned provider the lab can point at today. The bst2 image's host
+    # `recc` is never visible inside a BuildStream sandbox.
+    recc_provider: str | None = "freedesktop-sdk.bst:components/buildbox.bst"
+    allow_missing_digest_targets: bool = False
+    # Mandatory-RECC lanes (production builds, warmup, and QA) must not run at
+    # all until a runner is proven to honor BuildStream's remoteApisSocketPath
+    # platform property. Only the operator-driven pilot baseline is exempt.
+    production: bool = True
+
+
+ADAPTERS = {
+    "dakota": ProjectAdapter(
+        kind="dakota",
+        required_paths=(
+            "project.conf",
+            "elements/freedesktop-sdk.bst",
+            "elements/gnome-build-meta.bst",
+            "elements/oci/layers/bluefin.bst",
+            "elements/oci/layers/bluefin-nvidia.bst",
+        ),
+        element_roots=("elements/bluefin", "elements/oci"),
+        compiler_markers=(
+            "freedesktop-sdk.bst:components/gcc",
+            "freedesktop-sdk.bst:components/clang",
+            "buildsystems/",
+        ),
+        forced_digest_targets=(
+            "elements/oci/layers/bluefin.bst",
+            "elements/oci/layers/bluefin-nvidia.bst",
+        ),
+    ),
+    "cosmic": ProjectAdapter(
+        kind="cosmic",
+        required_paths=(
+            "project.conf",
+            "elements/freedesktop-sdk.bst",
+            "elements/core/cosmic-comp.bst",
+            "elements/core/cosmic-files.bst",
+        ),
+        element_roots=(
+            "elements/core",
+            "elements/core-deps",
+            "elements/cosmic-deps",
+            "elements/cosmic-deps-nvidia",
+            "elements/gaming",
+            "elements/oci",
+        ),
+        compiler_markers=(
+            "freedesktop-sdk.bst:components/gcc",
+            "freedesktop-sdk.bst:components/clang",
+            "buildsystems/",
+        ),
+        forced_digest_targets=(
+            "elements/core/cosmic-comp.bst",
+            "elements/core/cosmic-files.bst",
+        ),
+    ),
+    "bluefin-server": ProjectAdapter(
+        kind="bluefin-server",
+        required_paths=(
+            "project.conf",
+            "elements/freedesktop-sdk.bst",
+            "elements/gnome-build-meta.bst",
+            "elements/oci/bluefin-server-ddi.bst",
+            "elements/oci/bluefin-server-installer.bst",
+        ),
+        element_roots=("elements/bluefin-server", "elements/oci"),
+        compiler_markers=(
+            "freedesktop-sdk.bst:components/gcc",
+            "freedesktop-sdk.bst:components/clang",
+            "buildsystems/",
+        ),
+        forced_digest_targets=(
+            "elements/oci/bluefin-server-ddi.bst",
+            "elements/oci/bluefin-server-installer.bst",
+        ),
+        forced_wrapper_targets=(
+            "elements/oci/bluefin-server-ddi.bst",
+            "elements/oci/bluefin-server-installer.bst",
+        ),
+    ),
+    "bst-prototype": ProjectAdapter(
+        kind="bst-prototype",
+        required_paths=(
+            "project.conf",
+            "elements/freedesktop-sdk.bst",
+            "elements/recc-baseline.bst",
+        ),
+        element_roots=("elements",),
+        compiler_markers=("g++", "clang++"),
+        forced_digest_targets=("elements/recc-baseline.bst",),
+        forced_wrapper_targets=("elements/recc-baseline.bst",),
+        recc_provider=None,
+        allow_missing_digest_targets=False,
+        production=False,
+    ),
+    # The bst-qa lane is a real lab QA lane, not an operator experiment: it
+    # carries the same mandatory-RECC admission contract as the build lanes.
+    "bst-qa": ProjectAdapter(
+        kind="bst-qa",
+        required_paths=("project.conf", "elements/recc-baseline.bst"),
+        element_roots=("elements",),
+        compiler_markers=("g++", "clang++"),
+        forced_wrapper_targets=("elements/recc-baseline.bst",),
+        recc_provider=None,
+        allow_missing_digest_targets=True,
+        production=True,
+    ),
+}
+
+
+RECC_INCLUDE = """\
+# Generated by the lab RECC checkout overlay {version}; do not commit this file.
+#
+# The nested socket stanza is intentionally absent unless the runner capability
+# was explicitly supplied to apply_recc_overlay.py.
+environment:
+  # Prepend the wrapper directory; keep the standard search path intact so
+  # build systems still resolve /bin, /usr/sbin, and /sbin tooling.
+  PATH: /usr/recc/bin:/usr/bin:/bin:/usr/sbin:/sbin
+  RECC_SERVER: {endpoint}
+  RECC_CAS_SERVER: {endpoint}
+  RECC_ACTION_CACHE_SERVER: {endpoint}
+  RECC_ACTION_UNCACHEABLE: "0"
+  RECC_PROJECT_ROOT: /workspace
+  RECC_VERBOSE: "1"
+  RECC_DEPS_GLOBAL_PATHS: true
+  RECC_NO_PATH_REWRITE: true
+
+  (?):
+  - recc == "passthrough":
+      RECC_PASSTHROUGH: true
+  - recc == "cache-only":
+      RECC_CACHE_ONLY: true
+  - recc == "upload-local-build":
+      RECC_CACHE_ONLY: true
+      RECC_CACHE_UPLOAD_LOCAL_BUILD: true
+
+environment-nocache:
+- RECC_CACHE_ONLY
+- RECC_PASSTHROUGH
+- RECC_CACHE_UPLOAD_LOCAL_BUILD
+- RECC_USE_LOCALCAS
+- RECC_USE_JOBSERVER
+{socket}
+"""
+
+GCC_DIGEST_INCLUDE = """\
+# Generated by the lab RECC checkout overlay {version}.
+filename:
+- freedesktop-sdk.bst:components/gcc.bst
+config:
+  digest-environment: RECC_REMOTE_PLATFORM_chrootRootDigest
+"""
+
+CLANG_DIGEST_INCLUDE = """\
+# Generated by the lab RECC checkout overlay {version}.
+filename:
+- freedesktop-sdk.bst:components/llvm.bst
+- freedesktop-sdk.bst:components/zlib.bst
+config:
+  digest-environment: RECC_REMOTE_PLATFORM_chrootRootDigest
+"""
+
+RECC_WRAPPER = """\
+#!/bin/sh
+set -eu
+
+if [ -z "${RECC_REMOTE_PLATFORM_chrootRootDigest:-}" ]; then
+    echo "RECC_REMOTE_PLATFORM_chrootRootDigest is required for RECC" >&2
+    exit 1
+fi
+
+if ! command -v recc >/dev/null 2>&1; then
+    echo "recc is not staged in this sandbox; the RECC wrapper cannot run." >&2
+    echo "The build image's host recc is not visible inside the sandbox; the" >&2
+    echo "element must depend on the pinned recc provider element." >&2
+    exit 1
+fi
+
+exec recc "/usr/bin/$(basename "$0")" "$@"
+"""
+
+
+def _wrapper_element(recc_provider: str, version: str) -> str:
+    return f"""\
+# Generated by the lab RECC checkout overlay {version}.
+#
+# runtime-depends supplies the `recc` binary that files/recc-wrapper/recc-wrapper
+# executes. Without it the wrapper would exec a binary that does not exist in
+# the sandbox, so the overlay refuses to generate this element unless a pinned
+# provider element is known.
+kind: import
+
+sources:
+- kind: local
+  path: files/recc-wrapper/recc-wrapper
+
+config:
+  target: /usr/recc/bin
+
+runtime-depends:
+- {recc_provider}
+
+public:
+  bst:
+    integration-commands:
+    - |
+      for COMPILER in \
+        /usr/bin/cc \
+        /usr/bin/c++ \
+        /usr/bin/gcc \
+        /usr/bin/g++ \
+        /usr/bin/clang \
+        /usr/bin/clang++ \
+        /usr/bin/*-cc \
+        /usr/bin/*-c++ \
+        /usr/bin/*-gcc \
+        /usr/bin/*-g++ \
+        /usr/bin/*-clang \
+        /usr/bin/*-clang++; do
+        [ -e "$COMPILER" ] || continue
+        ln -s recc-wrapper /usr/recc/bin/"$(basename "$COMPILER")"
+      done
+"""
+
+
+def _safe_endpoint(value: str) -> str:
+    """Validate an endpoint and return a diagnostic-safe representation."""
+
+    if not value or any(char.isspace() for char in value):
+        raise OverlayError("RECC endpoint must be a non-empty URL without whitespace")
+    if "://" not in value:
+        value = f"grpc://{value}"
+    parsed = urlsplit(value)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise OverlayError("RECC endpoint must contain a valid numeric port") from exc
+    if parsed.scheme not in {"grpc", "grpcs"} or not parsed.hostname or port is None:
+        raise OverlayError(
+            "RECC endpoint must use grpc:// or grpcs:// with a host and port"
+        )
+    hostname = parsed.hostname
+    if ":" not in hostname and not re.fullmatch(r"[A-Za-z0-9.-]+", hostname):
+        raise OverlayError("RECC endpoint host contains unsafe characters")
+    if parsed.username or parsed.password or parsed.path or parsed.query or parsed.fragment:
+        raise OverlayError("RECC endpoint must not contain credentials or URL data")
+    return f"{parsed.scheme}://{hostname}:{port}"
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    match = re.fullmatch(r"\s*(\d+(?:\.\d+)*)\s*", value)
+    if not match:
+        raise OverlayError(f"unsupported BuildStream version: {value!r}")
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _resolve_policy(
+    adapter: ProjectAdapter,
+    *,
+    runner_capability: bool,
+    pilot_cache_only: bool,
+) -> str:
+    """Return the RECC policy, refusing every unsafe combination."""
+
+    if runner_capability and pilot_cache_only:
+        raise OverlayError(
+            "--runner-capability and --pilot-cache-only are mutually exclusive"
+        )
+    if adapter.production:
+        if pilot_cache_only:
+            raise OverlayError(
+                f"{adapter.kind} is a mandatory-RECC lane: --pilot-cache-only is "
+                "an operator-only flag for the documented prototype baseline, "
+                "and RECC cache-only/local fallback is not permitted here"
+            )
+        if not runner_capability:
+            raise OverlayError(
+                f"{adapter.kind} is a mandatory-RECC lane and RECC is blocked: "
+                "the pinned BuildBarn runner does not honor BuildStream's "
+                "remoteApisSocketPath, so nested RECC cannot be enabled. This "
+                "lane must fail closed rather than build with outer remote "
+                "execution only or with a cache-only fallback. Re-run with "
+                "--runner-capability only once a runner that consumes that "
+                "platform property is deployed and proven; see "
+                "docs/reference/recc-runner-seam.md"
+            )
+        return "remote-execution"
+    if runner_capability:
+        return "remote-execution"
+    if pilot_cache_only:
+        return "cache-only"
+    raise OverlayError(
+        f"{adapter.kind} is the operator-only pilot baseline: pass "
+        "--pilot-cache-only for the documented cache-only experiment, or "
+        "--runner-capability once nested RECC is proven. Workflow templates "
+        "must never pass either flag"
+    )
+
+
+def _element_path(text: str) -> str:
+    match = re.search(r"(?m)^element-path:\s*(\S+)\s*$", text)
+    return match.group(1) if match else "elements"
+
+
+def _resolve_recc_provider(
+    checkout: Path,
+    adapter: ProjectAdapter,
+    *,
+    override: str | None,
+    element_path: str,
+) -> str:
+    """Return the element that stages `recc`, or refuse before any write."""
+
+    provider = override or adapter.recc_provider
+    if not provider:
+        raise OverlayError(
+            f"{adapter.kind} cannot supply the recc binary: no pinned element in "
+            "this checkout provides it, and the build image's host recc is not "
+            "visible inside a BuildStream sandbox. Pass --recc-provider with a "
+            "pinned element that stages recc (for example a freedesktop-sdk "
+            "junction's components/buildbox.bst, built with -DRECC=ON)"
+        )
+    if not re.fullmatch(r"[A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*"
+                        r"(?::[A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*)?", provider):
+        raise OverlayError(f"recc provider is not a plain element name: {provider!r}")
+    junction, _, element = provider.partition(":")
+    if not element:
+        junction, element = "", junction
+    if not element.endswith(".bst"):
+        raise OverlayError(f"recc provider must name a .bst element: {provider!r}")
+    checkout = checkout.resolve()
+
+    def resolve_inside_checkout(path: Path, description: str) -> Path:
+        try:
+            resolved = path.resolve()
+        except (OSError, RuntimeError) as exc:
+            raise OverlayError(
+                f"recc provider {provider!r} cannot resolve its {description} safely"
+            ) from exc
+        try:
+            resolved.relative_to(checkout)
+        except ValueError as exc:
+            raise OverlayError(
+                f"recc provider {provider!r} resolves outside the checkout: "
+                f"{resolved}"
+            ) from exc
+        return resolved
+
+    if junction:
+        if not junction.endswith(".bst"):
+            raise OverlayError(
+                f"recc provider junction must be a .bst element: {provider!r}"
+            )
+        required = resolve_inside_checkout(
+            checkout / element_path / junction, "junction path"
+        )
+        description = f"junction {junction}"
+    else:
+        required = resolve_inside_checkout(
+            checkout / element_path / element, "element path"
+        )
+        description = f"element {element}"
+    if not required.is_file():
+        raise OverlayError(
+            f"recc provider {provider!r} is unusable: {description} is missing "
+            f"from {element_path}/; the wrapper would exec a recc binary that "
+            "is not staged in the sandbox"
+        )
+    return provider
+
+
+def _project_conf_version(text: str) -> tuple[int, ...]:
+    match = re.search(r"(?m)^min-version:\s*([0-9.]+)\s*$", text)
+    if not match:
+        raise OverlayError("project.conf has no min-version")
+    return _version_tuple(match.group(1))
+
+
+def _ensure_project_include(text: str) -> str:
+    if re.search(r"(?m)^\s*-\s+include/recc\.yml\s*$", text):
+        return text
+    match = re.search(r"(?m)^(\(@\):\s*)$", text)
+    if match:
+        line_end = match.end()
+        return text[:line_end] + "\n  - include/recc.yml" + text[line_end:]
+
+    marker = re.search(r"(?m)^element-path:.*$", text)
+    if not marker:
+        raise OverlayError("project.conf has no supported element-path anchor")
+    insertion = "\n\n(@):\n  - include/recc.yml"
+    return text[: marker.end()] + insertion + text[marker.end() :]
+
+
+def _recc_option_block(policy: str) -> str:
+    return f"""
+  recc:
+    type: enum
+    description: lab RECC policy
+    values:
+    - passthrough
+    - cache-only
+    - remote-execution
+    - upload-local-build
+    default: {policy}
+"""
+
+
+def _ensure_recc_option(text: str, policy: str) -> str:
+    options = re.search(r"(?m)^options:\s*$", text)
+    if not options:
+        return text.rstrip() + "\n\noptions:" + _recc_option_block(policy)
+
+    start = options.end()
+    next_section = re.search(r"(?m)^[^\s#][^:]*:\s*$", text[start:])
+    end = start + next_section.start() if next_section else len(text)
+    block = text[start:end]
+    recc = re.search(r"(?m)^  recc:\s*$", block)
+    if not recc:
+        return text[:end].rstrip() + "\n" + _recc_option_block(policy) + text[end:]
+
+    recc_start = recc.start()
+    next_option = re.search(r"(?m)^  [A-Za-z0-9_-]+:\s*$", block[recc.end() :])
+    recc_end = recc.end() + (next_option.start() if next_option else len(block[recc.end() :]))
+    recc_block = block[recc_start:recc_end]
+    if not re.search(r"(?m)^\s+type:\s*enum\s*$", recc_block):
+        raise OverlayError("project.conf recc option is not an enum")
+    if not re.search(rf"(?m)^\s+-\s+{re.escape(policy)}\s*$", recc_block):
+        list_item = re.search(r"(?m)^(\s+)-\s+", recc_block)
+        item_indent = list_item.group(1) if list_item else "    "
+        default = re.search(r"(?m)^\s+default:", recc_block)
+        entry = f"{item_indent}- {policy}\n"
+        if default:
+            recc_block = recc_block[: default.start()] + entry + recc_block[default.start() :]
+        else:
+            recc_block += entry
+    if re.search(r"(?m)^\s+default:", recc_block):
+        recc_block = re.sub(
+            r"(?m)^(\s+default:)\s*.*$",
+            rf"\1 {policy}",
+            recc_block,
+            count=1,
+        )
+    else:
+        recc_block = recc_block.rstrip() + f"\n    default: {policy}\n"
+    return text[:start] + block[:recc_start] + recc_block + block[recc_end:] + text[end:]
+
+
+def _prepare_project_conf(text: str, policy: str) -> str:
+    version = _project_conf_version(text)
+    if version < MIN_BUILDSTREAM_VERSION:
+        text = re.sub(
+            r"(?m)^min-version:\s*[0-9.]+\s*$",
+            "min-version: 2.5",
+            text,
+            count=1,
+        )
+    text = _ensure_project_include(text)
+    return _ensure_recc_option(text, policy)
+
+
+def _compiler_target(path: Path, markers: tuple[str, ...]) -> bool:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(
+        r"(?ms)^build-depends:\s*(.*?)(?=^[A-Za-z][A-Za-z0-9_-]*:\s*$|\Z)",
+        text,
+    )
+    if not match:
+        return False
+    return any(marker in match.group(0) for marker in markers)
+
+
+def _find_targets(checkout: Path, adapter: ProjectAdapter) -> list[Path]:
+    targets: list[Path] = []
+    for root_name in adapter.element_roots:
+        root = checkout / root_name
+        if not root.is_dir():
+            continue
+        targets.extend(
+            path
+            for path in sorted(root.rglob("*.bst"))
+            if _compiler_target(path, adapter.compiler_markers)
+        )
+    for name in adapter.forced_digest_targets + adapter.forced_wrapper_targets:
+        path = checkout / name
+        if path.exists() and path not in targets:
+            targets.append(path)
+    return sorted(targets)
+
+
+def _insert_build_depends(text: str, entries: tuple[str, ...]) -> str:
+    if "build-depends:" not in text:
+        kind = re.search(r"(?m)^kind:\s*.+$", text)
+        if not kind:
+            raise OverlayError("element has no kind anchor for build-depends injection")
+        return (
+            text[: kind.end()]
+            + "\n\nbuild-depends:\n"
+            + "".join(f"- {entry}\n" for entry in entries)
+            + text[kind.end() :]
+        )
+
+    match = re.search(r"(?m)^build-depends:[ \t]*(?:#.*)?$", text)
+    if not match:
+        raise OverlayError("element has an unsupported inline build-depends layout")
+    # Insert after the newline that terminates the section line, never before
+    # it: anything else can splice the first entry onto `build-depends:` when
+    # the next line is a comment.
+    line_end = text.find("\n", match.end())
+    if line_end == -1:
+        text += "\n"
+        section_start = len(text)
+    else:
+        section_start = line_end + 1
+    next_section = re.search(r"(?m)^[A-Za-z][A-Za-z0-9_-]*:", text[section_start:])
+    section_end = section_start + next_section.start() if next_section else len(text)
+    section = text[section_start:section_end]
+    missing = [
+        entry
+        for entry in entries
+        if not re.search(
+            rf"(?m)^[ \t]*-[ \t]+(?:\(@\):[ \t]*)?{re.escape(entry)}[ \t]*$", section
+        )
+    ]
+    if not missing:
+        return text
+    # Indentation comes from an existing list item on its own line, so a
+    # leading comment or blank line cannot contribute stray whitespace.
+    indent_match = re.search(r"(?m)^([ \t]*)-[ \t]+", section)
+    indent = indent_match.group(1) if indent_match else ""
+    addition = "".join(f"{indent}- {entry}\n" for entry in missing)
+    return text[:section_start] + addition + text[section_start:]
+
+
+def _patch_element(
+    path: Path,
+    *,
+    add_digest: bool,
+    digest_include: str,
+    add_wrapper: bool,
+) -> str:
+    text = path.read_text(encoding="utf-8")
+    entries: list[str] = []
+    if add_wrapper and "buildsystems/recc-wrapper.bst" not in text:
+        entries.append("buildsystems/recc-wrapper.bst")
+    if add_digest and digest_include not in text:
+        entries.append(f"(@): {digest_include}")
+    if not entries:
+        return text
+    return _insert_build_depends(text, tuple(entries))
+
+
+def _write_if_safe(path: Path, content: str, writes: dict[str, str]) -> None:
+    if path.exists():
+        current = path.read_text(encoding="utf-8")
+        if current != content:
+            raise OverlayError(f"refusing to overwrite existing file: {path}")
+        return
+    writes[str(path)] = content
+
+
+def _sha256(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def apply_overlay(
+    checkout: Path,
+    *,
+    project_kind: str,
+    endpoint: str = DEFAULT_ENDPOINT,
+    runner_capability: bool = False,
+    pilot_cache_only: bool = False,
+    recc_provider: str | None = None,
+) -> dict[str, object]:
+    """Apply an overlay and return safe diagnostics."""
+
+    checkout = Path(checkout).resolve()
+    if not checkout.is_dir():
+        raise OverlayError(f"checkout is not a directory: {checkout}")
+    try:
+        adapter = ADAPTERS[project_kind]
+    except KeyError as exc:
+        raise OverlayError(f"unsupported project kind: {project_kind}") from exc
+
+    policy = _resolve_policy(
+        adapter,
+        runner_capability=runner_capability,
+        pilot_cache_only=pilot_cache_only,
+    )
+    endpoint = _safe_endpoint(endpoint)
+    for relative in adapter.required_paths:
+        if not (checkout / relative).is_file():
+            raise OverlayError(
+                f"{project_kind} checkout is missing required path: {relative}"
+            )
+
+    project_conf = checkout / "project.conf"
+    project_text = project_conf.read_text(encoding="utf-8")
+    provider = _resolve_recc_provider(
+        checkout,
+        adapter,
+        override=recc_provider,
+        element_path=_element_path(project_text),
+    )
+    project_text = _prepare_project_conf(project_text, policy)
+
+    targets = _find_targets(checkout, adapter)
+    if not targets and not adapter.allow_missing_digest_targets:
+        raise OverlayError(
+            f"{project_kind} checkout has no recognized compiler/buildsystem elements"
+        )
+    for path in targets:
+        if "build-depends:" not in path.read_text(encoding="utf-8") and path not in {
+            checkout / name for name in adapter.forced_wrapper_targets
+        }:
+            # A recognized compiler element without a dependency list cannot be
+            # safely rewritten by this text-preserving helper.
+            if _compiler_target(path, adapter.compiler_markers) and not (
+                adapter.allow_missing_digest_targets
+            ):
+                raise OverlayError(
+                    f"unsupported build-depends layout in compiler element: {path}"
+                )
+
+    socket = ""
+    if runner_capability:
+        socket = """
+
+sandbox:
+  remote-apis-socket:
+    path: /tmp/casd.sock
+"""
+    include = RECC_INCLUDE.format(
+        version=OVERLAY_VERSION,
+        endpoint=endpoint,
+        socket=socket.rstrip("\n"),
+    )
+    gcc_include = GCC_DIGEST_INCLUDE.format(version=OVERLAY_VERSION)
+    clang_include = CLANG_DIGEST_INCLUDE.format(version=OVERLAY_VERSION)
+    wrapper_element = _wrapper_element(provider, OVERLAY_VERSION)
+
+    writes: dict[str, str] = {}
+    _write_if_safe(checkout / "include/recc.yml", include, writes)
+    _write_if_safe(checkout / "include/gcc-for-recc.yml", gcc_include, writes)
+    _write_if_safe(checkout / "include/clang-for-recc.yml", clang_include, writes)
+    _write_if_safe(
+        checkout / "elements/buildsystems/recc-wrapper.bst",
+        wrapper_element,
+        writes,
+    )
+    _write_if_safe(
+        checkout / "files/recc-wrapper/recc-wrapper",
+        RECC_WRAPPER,
+        writes,
+    )
+    wrapper_path = checkout / "files/recc-wrapper/recc-wrapper"
+    if wrapper_path.exists() and not wrapper_path.stat().st_mode & 0o111:
+        raise OverlayError(f"RECC wrapper is not executable: {wrapper_path}")
+
+    changed: dict[str, str] = {}
+    if project_text != project_conf.read_text(encoding="utf-8"):
+        changed[str(project_conf)] = project_text
+
+    forced_digest = {checkout / name for name in adapter.forced_digest_targets}
+    forced_wrapper = {checkout / name for name in adapter.forced_wrapper_targets}
+    for path in targets:
+        element_text = path.read_text(encoding="utf-8")
+        digest_include = (
+            "include/clang-for-recc.yml"
+            if re.search(r"(?i)(clang|llvm)", element_text)
+            else "include/gcc-for-recc.yml"
+        )
+        patched = _patch_element(
+            path,
+            add_digest=(
+                not adapter.allow_missing_digest_targets
+                and (
+                    path in forced_digest
+                    or _compiler_target(path, adapter.compiler_markers)
+                )
+            ),
+            digest_include=digest_include,
+            add_wrapper=path in forced_wrapper
+            or (
+                not adapter.allow_missing_digest_targets
+                and _compiler_target(path, adapter.compiler_markers)
+            ),
+        )
+        if patched != path.read_text(encoding="utf-8"):
+            changed[str(path)] = patched
+
+    # All validation is complete before touching the checkout.
+    for filename, content in writes.items():
+        target = Path(filename)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        if target.name == "recc-wrapper":
+            target.chmod(0o755)
+    for filename, content in changed.items():
+        Path(filename).write_text(content, encoding="utf-8")
+
+    changed_files = {}
+    for filename in sorted(set(writes) | set(changed)):
+        content = Path(filename).read_text(encoding="utf-8")
+        changed_files[str(Path(filename).relative_to(checkout))] = _sha256(content)
+    file_checksums = {}
+    for relative in MANAGED_FILES:
+        path = checkout / relative
+        if path.is_file():
+            file_checksums[relative] = _sha256(path.read_text(encoding="utf-8"))
+
+    digest_status = "applied"
+    if adapter.allow_missing_digest_targets:
+        digest_status = "available-but-not-attached-no-sdk-junction"
+    return {
+        "overlay_version": OVERLAY_VERSION,
+        "project_kind": project_kind,
+        "endpoint": endpoint,
+        "remote_execution_policy": policy,
+        "recc_provider": provider,
+        "nested_socket": "enabled" if runner_capability else "disabled",
+        "digest_environment": digest_status,
+        "changed_files": changed_files,
+        "file_checksums": file_checksums,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("checkout", type=Path)
+    parser.add_argument(
+        "--project-kind",
+        choices=sorted(ADAPTERS),
+        required=True,
+        help="known BuildStream checkout adapter to apply",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.environ.get("RECC_SERVER", DEFAULT_ENDPOINT),
+        help="shared RECC gRPC endpoint (default: lab BuildBarn frontend)",
+    )
+    parser.add_argument(
+        "--runner-capability",
+        action="store_true",
+        help=(
+            "assert that the deployed BuildBarn runner honors BuildStream's "
+            "remoteApisSocketPath; required before any production lane may be "
+            "overlaid, and enables sandbox.remote-apis-socket"
+        ),
+    )
+    parser.add_argument(
+        "--pilot-cache-only",
+        action="store_true",
+        help=(
+            "pilot fixtures only: apply a documented cache-only experiment "
+            "instead of nested remote execution"
+        ),
+    )
+    parser.add_argument(
+        "--recc-provider",
+        default=None,
+        help=(
+            "pinned BuildStream element that stages the recc binary in the "
+            "sandbox (default: the adapter's pinned provider, if any)"
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="emit diagnostics as JSON")
+    parser.add_argument("--version", action="version", version=OVERLAY_VERSION)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        diagnostics = apply_overlay(
+            args.checkout,
+            project_kind=args.project_kind,
+            endpoint=args.endpoint,
+            runner_capability=args.runner_capability,
+            pilot_cache_only=args.pilot_cache_only,
+            recc_provider=args.recc_provider,
+        )
+    except OverlayError as exc:
+        print(f"recc overlay refused: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(diagnostics, sort_keys=True))
+    else:
+        print(
+            "RECC overlay "
+            f"v{diagnostics['overlay_version']} applied to "
+            f"{diagnostics['project_kind']}: "
+            f"policy={diagnostics['remote_execution_policy']} "
+            f"recc-provider={diagnostics['recc_provider']} "
+            f"nested-socket={diagnostics['nested_socket']} "
+            f"digest-environment={diagnostics['digest_environment']}"
+        )
+        for filename, checksum in diagnostics["changed_files"].items():
+            print(f"  {filename}: sha256:{checksum}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/collect_recc_run.py
+++ b/scripts/collect_recc_run.py
@@ -1,0 +1,1104 @@
+#!/usr/bin/env python3
+"""Collect machine-readable evidence from one RECC baseline run.
+
+The collector deliberately consumes caller-supplied artifacts.  It parses
+metadata, BuildStream output, RECC_VERBOSE output, and two Prometheus
+snapshots, but never stores the raw artifacts in its result.  Prometheus
+metric names are either supplied by the caller or discovered from the
+snapshots; no BuildBarn metric names are guessed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = "1.0"
+TIMING_FIELDS = ("wall_seconds", "fetch_seconds", "build_seconds", "push_seconds")
+RECC_FIELDS = (
+    "action_count",
+    "cache_hits",
+    "cache_misses",
+    "local_fallbacks",
+    "compile_seconds",
+    "link_seconds",
+)
+PHASE_NAMES = ("cold", "warm")
+BUILDBARN_WORKER_METRICS = (
+    "buildbarn_builder_build_executor_duration_seconds_count",
+    "buildbarn_builder_build_executor_duration_seconds_sum",
+    "buildbarn_builder_in_memory_build_queue_tasks_queued_duration_seconds_count",
+    "buildbarn_builder_in_memory_build_queue_tasks_queued_duration_seconds_sum",
+    "buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_count",
+    "buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_sum",
+)
+BUILDBARN_CAS_METRICS = (
+    "buildbarn_blobstore_blob_access_operations_blob_size_bytes_count",
+    "buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum",
+    "buildbarn_blobstore_blob_access_operations_duration_seconds_count",
+    "buildbarn_blobstore_blob_access_operations_duration_seconds_sum",
+)
+
+RECC_PREFIX = re.compile(
+    r"^\s*(?:\[(?:RECC|RECC_VERBOSE)\]|(?:RECC|RECC_VERBOSE)"
+    r"(?:\s*[:|]|\s+))\s*(?P<body>.*)$",
+    re.IGNORECASE,
+)
+RECC_SECTION_START = re.compile(
+    r"^\s*(?:\[(?:RECC|RECC_VERBOSE)\]|(?:===|---)\s*(?:BEGIN\s+)?"
+    r"(?:RECC|RECC_VERBOSE)(?:\s+LOG)?\s*(?:===|---))\s*$",
+    re.IGNORECASE,
+)
+RECC_SECTION_END = re.compile(
+    r"^\s*(?:\[/\s*(?:RECC|RECC_VERBOSE)\s*\]|(?:===|---)\s*END\s+"
+    r"(?:RECC|RECC_VERBOSE)(?:\s+LOG)?\s*(?:===|---))\s*$",
+    re.IGNORECASE,
+)
+FIXTURE_STDOUT_MARKER = re.compile(
+    r"^\s*(?:\[FIXTURE_STDOUT\]|fixture\s+stdout\s*[:|])\s*(?P<body>.*)$",
+    re.IGNORECASE,
+)
+
+
+def parse_timestamp(value: Any) -> dt.datetime | None:
+    """Return a timezone-aware UTC timestamp, or ``None`` for unusable input."""
+
+    if isinstance(value, dt.datetime):
+        if value.tzinfo is None:
+            return None
+        return value.astimezone(dt.timezone.utc)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if not math.isfinite(value):
+            return None
+        try:
+            return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    try:
+        parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def format_timestamp(value: dt.datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(dt.timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def parse_duration(value: Any) -> float | None:
+    """Parse seconds, ``HH:MM:SS``, or a human-readable duration."""
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value) if math.isfinite(value) and value >= 0 else None
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    if not text or "--:--:--" in text:
+        return None
+    if re.fullmatch(r"\d+(?:\.\d+)?", text):
+        return float(text)
+    clock = re.fullmatch(r"(?:(\d+):)?(\d+):(\d+(?:\.\d+)?)", text)
+    if clock:
+        hours = float(clock.group(1) or 0)
+        return hours * 3600 + float(clock.group(2)) * 60 + float(clock.group(3))
+
+    total = 0.0
+    found = False
+    for number, unit in re.findall(
+        r"(\d+(?:\.\d+)?)\s*(hours?|hrs?|h|minutes?|mins?|m|seconds?|secs?|sec|s|milliseconds?|msecs?|ms)\b",
+        text,
+    ):
+        found = True
+        amount = float(number)
+        if unit.startswith("h"):
+            total += amount * 3600
+        elif unit.startswith("m") and unit not in {"ms", "msec", "msecs", "millisecond", "milliseconds"}:
+            total += amount * 60
+        elif unit.startswith("ms") or unit.startswith("millisecond"):
+            total += amount / 1000
+        else:
+            total += amount
+    return total if found else None
+
+
+def _first(mapping: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] is not None:
+            return mapping[key]
+    return None
+
+
+def _parse_key_value_text(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        match = re.match(r"^\s*([A-Za-z][A-Za-z0-9_.-]*)\s*[:=]\s*(.*?)\s*$", line)
+        if match:
+            values[match.group(1).lower().replace("-", "_")] = match.group(2)
+    return values
+
+
+def parse_run_metadata(metadata: Any) -> dict[str, Any]:
+    """Normalize run identity and timestamps from JSON or key/value text."""
+
+    if isinstance(metadata, str):
+        try:
+            decoded = json.loads(metadata)
+        except json.JSONDecodeError:
+            decoded = _parse_key_value_text(metadata)
+        metadata = decoded
+    if not isinstance(metadata, dict):
+        metadata = {}
+    nested = metadata.get("run") or metadata.get("metadata")
+    if isinstance(nested, dict):
+        metadata = {**metadata, **nested}
+
+    run_id = _first(metadata, "run_id", "id", "workflow_name", "workflow")
+    mode = _first(metadata, "mode", "recc_mode", "option")
+    started = parse_timestamp(
+        _first(metadata, "started_at", "started", "start_time", "start")
+    )
+    finished = parse_timestamp(
+        _first(metadata, "finished_at", "finished", "finish_time", "finish", "ended_at")
+    )
+    duration = parse_duration(_first(metadata, "duration_seconds", "duration"))
+    if duration is None and started and finished and finished >= started:
+        duration = (finished - started).total_seconds()
+    raw_phases = _first(metadata, "phases")
+    phases = raw_phases if isinstance(raw_phases, dict) else {}
+
+    values = {
+        "run_id": run_id,
+        "mode": mode,
+        "started_at": format_timestamp(started),
+        "finished_at": format_timestamp(finished),
+        "duration_seconds": duration,
+        "phases": phases,
+    }
+    missing = {
+        field: "run metadata did not provide this field"
+        for field, value in values.items()
+        if value is None or (field == "phases" and not value)
+    }
+    return {
+        **values,
+        "state": "available" if values["run_id"] or started or finished else "unavailable",
+        "state_reason": (
+            None
+            if values["run_id"] or started or finished
+            else "no run metadata was supplied"
+        ),
+        "unavailable_fields": missing,
+    }
+
+
+def _load_json_text(text: Any) -> Any:
+    if isinstance(text, (dict, list)):
+        return text
+    if not isinstance(text, str) or not text or not text.lstrip().startswith(("{", "[")):
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _extract_recc_text(text: str) -> tuple[str | None, str]:
+    """Return only text explicitly identified as RECC evidence."""
+
+    lines: list[str] = []
+    in_section = False
+    marked = False
+    for line in text.splitlines():
+        if RECC_SECTION_END.match(line):
+            in_section = False
+            marked = True
+            continue
+        if RECC_SECTION_START.match(line):
+            in_section = True
+            marked = True
+            continue
+        prefix = RECC_PREFIX.match(line)
+        if prefix:
+            marked = True
+            lines.append(prefix.group("body"))
+        elif in_section:
+            lines.append(line)
+    if not marked:
+        return None, "RECC output lacked an explicit RECC marker or dedicated RECC log section"
+    if not any(line.strip() for line in lines):
+        return None, "RECC marker or dedicated section contained no evidence lines"
+    return "\n".join(lines), ""
+
+
+def _structured_recc_source(decoded: Any) -> tuple[dict[str, Any] | None, str]:
+    """Find a structured RECC section without treating generic JSON as RECC."""
+
+    if not isinstance(decoded, dict):
+        return None, "RECC output was not a structured object"
+    for key in ("recc", "recc_verbose", "recc_log"):
+        section = decoded.get(key)
+        if isinstance(section, dict):
+            return section, ""
+        if isinstance(section, str):
+            nested = _load_json_text(section)
+            if isinstance(nested, dict):
+                return nested, ""
+    section_name = str(
+        _first(decoded, "section", "section_name", "source", "source_name") or ""
+    ).lower()
+    if "recc" in section_name:
+        return decoded, ""
+    if any(field in decoded for field in RECC_FIELDS):
+        return decoded, ""
+    return None, "structured output lacked a dedicated RECC section or RECC fields"
+
+
+def _phase_names_from_text(text: str | None) -> list[str]:
+    if not text:
+        return []
+    found = {
+        match.group(1).lower()
+        for match in re.finditer(
+            r"^\s*(?:===\s*)?(cold|warm)\s+phase\b", text, re.IGNORECASE | re.MULTILINE
+        )
+    }
+    return [name for name in PHASE_NAMES if name in found]
+
+
+def _phase_record(
+    timings: dict[str, float | None],
+    *,
+    reason_prefix: str,
+) -> dict[str, Any]:
+    unavailable = {
+        f"timings.{field}": f"{reason_prefix}; {field.replace('_', ' ')} was not supplied"
+        for field, value in timings.items()
+        if value is None
+    }
+    available = any(value is not None for value in timings.values())
+    return {
+        "timings": timings,
+        "state": "available" if available else "unavailable",
+        "state_reason": None if available else reason_prefix,
+        "unavailable_fields": unavailable,
+    }
+
+
+def _parse_phase_timings(
+    source: dict[str, Any],
+    text: str | None,
+    expected_phases: Iterable[str] | None,
+) -> dict[str, dict[str, Any]]:
+    names = {str(name).lower() for name in (expected_phases or ())}
+    raw_phases = source.get("phases")
+    if not isinstance(raw_phases, dict):
+        raw_phases = source.get("phase_timings")
+    if isinstance(raw_phases, dict):
+        names.update(str(name).lower() for name in raw_phases)
+    names.update(_phase_names_from_text(text))
+    if not names:
+        return {}
+
+    phases: dict[str, dict[str, Any]] = {}
+    for name in PHASE_NAMES:
+        if name not in names:
+            continue
+        raw_phase = raw_phases.get(name) if isinstance(raw_phases, dict) else None
+        raw_phase = raw_phase if isinstance(raw_phase, dict) else {}
+        timing_source = (
+            raw_phase.get("timings")
+            if isinstance(raw_phase.get("timings"), dict)
+            else raw_phase
+        )
+        timings = {
+            "wall_seconds": _duration_from_mapping(
+                timing_source, "wall_seconds", "wall", "elapsed_seconds", "elapsed"
+            ),
+            "fetch_seconds": _duration_from_mapping(
+                timing_source, "fetch_seconds", "fetch", "fetch_duration"
+            ),
+            "build_seconds": _duration_from_mapping(
+                timing_source, "build_seconds", "build", "build_duration"
+            ),
+            "push_seconds": _duration_from_mapping(
+                timing_source, "push_seconds", "push", "push_duration"
+            ),
+        }
+        if text:
+            for field, label in (
+                ("wall_seconds", "wall"),
+                ("fetch_seconds", "fetch"),
+                ("build_seconds", "build"),
+                ("push_seconds", "push"),
+            ):
+                if timings[field] is not None:
+                    continue
+                match = re.search(
+                    rf"^\s*{re.escape(name)}\s+{label}(?:_seconds)?\s*[:=]\s*([^\n,]+)",
+                    text,
+                    re.IGNORECASE | re.MULTILINE,
+                )
+                if match:
+                    timings[field] = parse_duration(match.group(1))
+        phases[name] = _phase_record(
+            timings,
+            reason_prefix=f"no {name} phase timing evidence was supplied",
+        )
+    return phases
+
+
+def _duration_from_mapping(mapping: dict[str, Any], *keys: str) -> float | None:
+    value = _first(mapping, *keys)
+    if isinstance(value, dict):
+        value = _first(value, "seconds", "duration", "value")
+    return parse_duration(value)
+
+
+def _section_status(
+    values: dict[str, Any],
+    unavailable_fields: dict[str, str],
+    empty_reason: str,
+) -> tuple[str, str | None]:
+    if any(value is not None for value in values.values()):
+        return "available", None
+    return "unavailable", empty_reason
+
+
+def _parse_element(element: Any, default_name: str | None = None) -> dict[str, Any] | None:
+    if isinstance(element, str):
+        return {
+            "name": element,
+            "state": None,
+            "key": None,
+            "cache_origin": None,
+            "digest": None,
+            "unavailable_fields": {
+                "state": "BuildStream did not provide the element state",
+                "key": "BuildStream did not provide the element key",
+                "cache_origin": "BuildStream did not provide the element cache origin",
+                "digest": "BuildStream did not provide the element digest",
+            },
+        }
+    if not isinstance(element, dict):
+        return None
+    name = _first(element, "name", "element", "element_name") or default_name
+    if not name:
+        return None
+    state = _first(element, "state", "status", "element_state")
+    key = _first(element, "key", "element_key", "cache_key")
+    cache_origin = _first(
+        element,
+        "cache_origin",
+        "cache_source",
+        "artifact_cache_origin",
+        "artifact_cache",
+    )
+    digest = _first(element, "digest", "output_digest", "artifact_digest")
+    values = {
+        "state": state,
+        "key": key,
+        "cache_origin": cache_origin,
+        "digest": digest,
+    }
+    return {
+        "name": name,
+        **values,
+        "unavailable_fields": {
+            field: f"BuildStream did not provide the element {field}"
+            for field, value in values.items()
+            if value is None
+        },
+    }
+
+
+def parse_buildstream_output(
+    text: Any,
+    *,
+    expected_phases: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Parse BuildStream timing and element evidence from JSON or text."""
+
+    decoded = _load_json_text(text)
+    source = decoded if isinstance(decoded, dict) else {}
+    timings_source = source.get("timings") if isinstance(source.get("timings"), dict) else source
+    timings = {
+        "wall_seconds": _duration_from_mapping(
+            timings_source, "wall_seconds", "wall", "elapsed_seconds", "elapsed"
+        ),
+        "fetch_seconds": _duration_from_mapping(
+            timings_source, "fetch_seconds", "fetch", "fetch_duration"
+        ),
+        "build_seconds": _duration_from_mapping(
+            timings_source, "build_seconds", "build", "build_duration"
+        ),
+        "push_seconds": _duration_from_mapping(
+            timings_source, "push_seconds", "push", "push_duration"
+        ),
+    }
+
+    elements: list[dict[str, Any]] = []
+    raw_elements = source.get("elements") if isinstance(source, dict) else None
+    if isinstance(raw_elements, dict):
+        raw_elements = [
+            {"name": name, **value} if isinstance(value, dict) else {"name": name, "state": value}
+            for name, value in raw_elements.items()
+        ]
+    if isinstance(raw_elements, list):
+        elements = [parsed for item in raw_elements if (parsed := _parse_element(item))]
+
+    output_digest = _first(source, "output_digest", "result_digest", "artifact_digest")
+    fixture_stdout = _first(
+        source, "fixture_stdout", "fixture_output", "stdout"
+    )
+
+    if decoded is None and text:
+        for field, labels in {
+            "wall_seconds": r"(?:(?:wall|total|elapsed)\s*(?:build\s*)?(?:time|duration)?|total\s+build)",
+            "fetch_seconds": r"fetch(?:ing)?",
+            "build_seconds": r"build(?:ing)?",
+            "push_seconds": r"push(?:ing)?",
+        }.items():
+            if timings[field] is not None:
+                continue
+            pattern = rf"{labels}\s*[:=]\s*([^\n,]+)"
+            match = re.search(pattern, text, re.IGNORECASE)
+            if match:
+                timings[field] = parse_duration(match.group(1))
+
+        current: dict[str, Any] = {}
+        for line in text.splitlines():
+            name_match = re.search(
+                r"(?:element|name)\s*[:=]\s*([^\s,]+)", line, re.IGNORECASE
+            )
+            if name_match and current:
+                parsed = _parse_element(current)
+                if parsed and parsed not in elements:
+                    elements.append(parsed)
+                current = {}
+            for field, pattern in (
+                ("name", r"(?:element|name)\s*[:=]\s*([^\s,]+)"),
+                ("state", r"(?:state|status)\s*[:=]\s*([^\s,]+)"),
+                ("key", r"(?:element[_ ]?key|cache[_ ]?key|key)\s*[:=]\s*([^\s,]+)"),
+                (
+                    "cache_origin",
+                    r"(?:cache[_ ]?origin|cache[_ ]?source|artifact[_ ]?cache)\s*[:=]\s*([^\s,]+)",
+                ),
+                ("digest", r"(?:output[_ ]?digest|artifact[_ ]?digest|digest)\s*[:=]\s*([^\s,]+)"),
+            ):
+                match = re.search(pattern, line, re.IGNORECASE)
+                if match:
+                    current[field] = match.group(1).rstrip(".,")
+            stdout_match = FIXTURE_STDOUT_MARKER.match(line)
+            if stdout_match:
+                fixture_stdout = stdout_match.group("body")
+            digest_match = re.search(
+                r"^\s*(?:output[_ ]?digest|artifact[_ ]?digest)\s*[:=]\s*([^\s,]+)",
+                line,
+                re.IGNORECASE,
+            )
+            if digest_match:
+                output_digest = digest_match.group(1).rstrip(".,")
+        if current:
+            parsed = _parse_element(current)
+            if parsed and parsed not in elements:
+                elements.append(parsed)
+
+    if output_digest is None and len(elements) == 1:
+        output_digest = elements[0].get("digest")
+
+    phases = _parse_phase_timings(source, text if isinstance(text, str) else None, expected_phases)
+    unavailable = {
+        field: f"BuildStream output did not contain {field.replace('_', ' ')}"
+        for field, value in timings.items()
+        if value is None
+    }
+    elements_available = any(
+        any(
+            element.get(field) is not None
+            for field in ("state", "key", "cache_origin", "digest")
+        )
+        for element in elements
+    )
+    if not elements:
+        unavailable["elements"] = "BuildStream output did not contain element state/key/digest evidence"
+    elif not elements_available:
+        unavailable["elements"] = (
+            "BuildStream output contained element names but no element evidence fields"
+        )
+    else:
+        if any(element.get("key") is None for element in elements):
+            unavailable["element_key"] = (
+                "BuildStream did not provide an element key for every element"
+            )
+        if any(element.get("cache_origin") is None for element in elements):
+            unavailable["element_cache_origin"] = (
+                "BuildStream did not provide an element cache origin for every element"
+            )
+    if output_digest is None:
+        unavailable["output_digest"] = "BuildStream output did not contain an output digest"
+    if not isinstance(fixture_stdout, str) or not fixture_stdout.strip():
+        fixture_stdout = None
+        unavailable["fixture_stdout"] = (
+            "BuildStream output did not contain an explicit fixture stdout field"
+        )
+    phases_available = any(
+        phase["state"] == "available" for phase in phases.values()
+    )
+    state, reason = _section_status(
+        {
+            **timings,
+            "elements": elements if elements_available else None,
+            "output_digest": output_digest,
+            "fixture_stdout": fixture_stdout,
+            "phases": phases if phases_available else None,
+        },
+        unavailable,
+        "no BuildStream timing or element evidence was found",
+    )
+    return {
+        "timings": timings,
+        "phases": phases,
+        "elements": elements,
+        "output_digest": output_digest,
+        "fixture_stdout": fixture_stdout,
+        "state": state,
+        "state_reason": reason,
+        "unavailable_fields": unavailable,
+    }
+
+
+def _number_from_mapping(mapping: dict[str, Any], *keys: str) -> float | int | None:
+    value = _first(mapping, *keys)
+    if isinstance(value, dict):
+        value = _first(value, "count", "total", "value", "seconds", "duration")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(value) and value >= 0:
+        return int(value) if float(value).is_integer() else float(value)
+    return None
+
+
+def parse_recc_verbose(text: Any) -> dict[str, Any]:
+    """Parse conservative evidence from explicitly identified RECC output."""
+
+    decoded = _load_json_text(text)
+    marker_reason = ""
+    if isinstance(decoded, dict):
+        source, marker_reason = _structured_recc_source(decoded)
+        source = source or {}
+    elif isinstance(text, str):
+        marked_text, marker_reason = _extract_recc_text(text)
+        decoded_marked = _load_json_text(marked_text)
+        if isinstance(decoded_marked, dict):
+            source = decoded_marked
+        else:
+            source = {}
+            text = marked_text
+    else:
+        source = {}
+        marker_reason = "RECC output was not supplied"
+
+    timings_source = source.get("timings") if isinstance(source.get("timings"), dict) else source
+    values: dict[str, Any] = {
+        "action_count": _number_from_mapping(
+            source, "action_count", "actions", "actions_total"
+        ),
+        "cache_hits": _number_from_mapping(source, "cache_hits", "hits", "action_cache_hits"),
+        "cache_misses": _number_from_mapping(
+            source, "cache_misses", "misses", "action_cache_misses"
+        ),
+        "local_fallbacks": _number_from_mapping(
+            source, "local_fallbacks", "fallbacks", "local_fallback_count"
+        ),
+        "compile_seconds": _duration_from_mapping(
+            timings_source, "compile_seconds", "compile", "compile_duration"
+        ),
+        "link_seconds": _duration_from_mapping(
+            timings_source, "link_seconds", "link", "link_duration"
+        ),
+    }
+
+    if not source and isinstance(text, str) and text:
+        lines = text.splitlines()
+        detected_started_actions = 0
+        detected_completed_actions = 0
+        detected_hits = 0
+        detected_misses = 0
+        detected_fallbacks = 0
+        for line in lines:
+            lowered = line.lower()
+            if re.search(r"(?:action\s+)?cache\s+hit", lowered):
+                detected_hits += 1
+            if re.search(r"(?:action\s+)?cache\s+miss", lowered):
+                detected_misses += 1
+            if re.search(
+                r"local\s+(?:compile\s+)?fallback|fallback\s+to\s+local|falling\s+back\s+to\s+local",
+                lowered,
+            ):
+                detected_fallbacks += 1
+            if re.search(r"\baction\b.*\b(?:started|submitted|executed)\b", lowered):
+                detected_started_actions += 1
+            elif re.search(r"\baction\b.*\b(?:completed|finished)\b", lowered):
+                detected_completed_actions += 1
+
+            for field, label in (("compile_seconds", "compile"), ("link_seconds", "link")):
+                if values[field] is None:
+                    match = re.search(
+                        rf"\b{label}\b(?:\s+(?:time|duration))?\s*(?::|=|took)\s*([^\n,]+)",
+                        line,
+                        re.IGNORECASE,
+                    )
+                    if match:
+                        values[field] = parse_duration(match.group(1))
+        if values["action_count"] is None:
+            detected_actions = detected_started_actions or detected_completed_actions
+            if detected_actions:
+                values["action_count"] = detected_actions
+        if values["cache_hits"] is None and detected_hits:
+            values["cache_hits"] = detected_hits
+        if values["cache_misses"] is None and detected_misses:
+            values["cache_misses"] = detected_misses
+        if values["local_fallbacks"] is None and detected_fallbacks:
+            values["local_fallbacks"] = detected_fallbacks
+
+    unavailable = {
+        field: f"RECC_VERBOSE output did not contain {field.replace('_', ' ')} evidence"
+        for field, value in values.items()
+        if value is None
+    }
+    if marker_reason:
+        unavailable = {
+            field: f"{reason}; {detail}"
+            for field, detail in unavailable.items()
+            for reason in [marker_reason]
+        }
+    state, reason = _section_status(
+        values, unavailable, "no RECC_VERBOSE evidence was found"
+    )
+    if marker_reason and state == "unavailable":
+        reason = marker_reason
+    return {
+        **values,
+        "state": state,
+        "state_reason": reason,
+        "unavailable_fields": unavailable,
+    }
+
+
+PROMETHEUS_SAMPLE = re.compile(
+    r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)"
+    r"(?:\{(?P<labels>[^}]*)\})?\s+"
+    r"(?P<value>[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)"
+)
+PROMETHEUS_LABEL = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"])*)"')
+
+
+def _parse_prometheus_samples(text: str | None) -> dict[str, list[dict[str, Any]]]:
+    samples: dict[str, list[dict[str, Any]]] = {}
+    if not text:
+        return samples
+    for line in text.splitlines():
+        match = PROMETHEUS_SAMPLE.match(line.strip())
+        if not match:
+            continue
+        try:
+            value = float(match.group("value"))
+        except ValueError:
+            continue
+        labels = {
+            key: bytes(raw, "utf-8").decode("unicode_escape")
+            for key, raw in PROMETHEUS_LABEL.findall(match.group("labels") or "")
+        }
+        samples.setdefault(match.group("name"), []).append(
+            {"labels": labels, "value": value}
+        )
+    return samples
+
+
+def discover_metric_names(text: str | None) -> list[str]:
+    """Discover metric families present in a Prometheus text snapshot."""
+
+    return sorted(_parse_prometheus_samples(text))
+
+
+def parse_prometheus_snapshot(
+    text: str | None, metric_names: Iterable[str] | None = None
+) -> dict[str, Any]:
+    samples = _parse_prometheus_samples(text)
+    requested = sorted(set(metric_names)) if metric_names else sorted(samples)
+    missing = [name for name in requested if name not in samples]
+    if not text:
+        return {
+            "metrics": {},
+            "metric_names": requested,
+            "state": "unavailable",
+            "state_reason": "Prometheus snapshot was not supplied",
+            "unavailable_metrics": requested,
+        }
+    if requested and not any(name in samples for name in requested):
+        return {
+            "metrics": {},
+            "metric_names": requested,
+            "state": "unavailable",
+            "state_reason": "none of the requested Prometheus metrics were present",
+            "unavailable_metrics": requested,
+        }
+    if not samples:
+        return {
+            "metrics": {},
+            "metric_names": requested,
+            "state": "unavailable",
+            "state_reason": "Prometheus snapshot contained no parseable samples",
+            "unavailable_metrics": requested,
+        }
+    return {
+        "metrics": {name: samples[name] for name in requested if name in samples},
+        "metric_names": requested,
+        "state": "available",
+        "state_reason": None,
+        "unavailable_metrics": missing,
+    }
+
+
+def _sample_key(labels: dict[str, str]) -> tuple[tuple[str, str], ...]:
+    return tuple(sorted(labels.items()))
+
+
+def _sum_metric_deltas(
+    metrics: dict[str, list[dict[str, Any]]],
+    name: str,
+    predicate: Any = None,
+) -> float | None:
+    rows = metrics.get(name, [])
+    values = [
+        row["delta"]
+        for row in rows
+        if row.get("delta") is not None
+        and (predicate is None or predicate(row.get("labels", {})))
+    ]
+    return sum(values) if values else None
+
+
+def _metric_group(
+    delta: dict[str, Any],
+    names: Iterable[str],
+    *,
+    group: str,
+) -> dict[str, Any] | None:
+    requested = [name for name in names if name in delta["metric_names"]]
+    if not requested:
+        return None
+    metrics = {name: delta["metrics"].get(name, []) for name in requested}
+    available = any(
+        row["state"] == "available"
+        for rows in metrics.values()
+        for row in rows
+    )
+    unavailable = {
+        name: delta["unavailable_metrics"][name]
+        for name in requested
+        if name in delta["unavailable_metrics"]
+    }
+    result: dict[str, Any] = {
+        "group": group,
+        "metric_names": requested,
+        "metrics": metrics,
+        "state": "available" if available else "unavailable",
+        "state_reason": (
+            None
+            if available
+            else f"no {group} metric samples were present in both snapshots"
+        ),
+        "unavailable_metrics": unavailable,
+        "unavailable_fields": {},
+    }
+    if group == "worker":
+        result["summary"] = {
+            "actions_executed": _sum_metric_deltas(
+                metrics,
+                "buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_count",
+            ),
+            "queue_seconds": _sum_metric_deltas(
+                metrics,
+                "buildbarn_builder_in_memory_build_queue_tasks_queued_duration_seconds_sum",
+            ),
+            "execution_seconds": _sum_metric_deltas(
+                metrics,
+                "buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_sum",
+            ),
+        }
+    else:
+        def operation_is(operation: str):
+            return lambda labels: labels.get("operation") == operation
+
+        result["summary"] = {
+            "get_requests": _sum_metric_deltas(
+                metrics,
+                "buildbarn_blobstore_blob_access_operations_blob_size_bytes_count",
+                operation_is("Get"),
+            ),
+            "put_requests": _sum_metric_deltas(
+                metrics,
+                "buildbarn_blobstore_blob_access_operations_blob_size_bytes_count",
+                operation_is("Put"),
+            ),
+            "get_bytes": _sum_metric_deltas(
+                metrics,
+                "buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum",
+                operation_is("Get"),
+            ),
+            "put_bytes": _sum_metric_deltas(
+                metrics,
+                "buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum",
+                operation_is("Put"),
+            ),
+        }
+    for field, value in result["summary"].items():
+        if value is None:
+            result["unavailable_fields"][f"summary.{field}"] = (
+                f"the selected BuildBarn {group} metrics did not provide {field}"
+            )
+    return result
+
+
+def prometheus_delta(
+    before_text: str | None,
+    after_text: str | None,
+    metric_names: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    before = _parse_prometheus_samples(before_text)
+    after = _parse_prometheus_samples(after_text)
+    if not metric_names:
+        names = sorted(set(before) | set(after))
+    else:
+        names = sorted(set(metric_names))
+
+    metrics: dict[str, list[dict[str, Any]]] = {}
+    unavailable: dict[str, str] = {}
+    for name in names:
+        before_by_label = {
+            _sample_key(sample["labels"]): sample for sample in before.get(name, [])
+        }
+        after_by_label = {
+            _sample_key(sample["labels"]): sample for sample in after.get(name, [])
+        }
+        keys = sorted(set(before_by_label) | set(after_by_label))
+        if not keys:
+            unavailable[name] = "metric was not present in both snapshots"
+            continue
+        rows = []
+        for key in keys:
+            before_sample = before_by_label.get(key)
+            after_sample = after_by_label.get(key)
+            row: dict[str, Any] = {
+                "labels": dict(key),
+                "before": before_sample["value"] if before_sample else None,
+                "after": after_sample["value"] if after_sample else None,
+                "delta": (
+                    after_sample["value"] - before_sample["value"]
+                    if before_sample and after_sample
+                    else None
+                ),
+                "state": "available" if before_sample and after_sample else "unavailable",
+                "state_reason": (
+                    None
+                    if before_sample and after_sample
+                    else "metric sample was missing from one snapshot"
+                ),
+            }
+            rows.append(row)
+        metrics[name] = rows
+
+    available = any(
+        sample["state"] == "available" for rows in metrics.values() for sample in rows
+    )
+    snapshot_reason = (
+        "worker and CAS deltas require explicit before/after metric snapshots"
+        if not before_text or not after_text
+        else "worker and CAS metric families were not explicitly identified; generic deltas are retained without classification"
+    )
+    result = {
+        "metrics": metrics,
+        "metric_names": names,
+        "state": "available" if available else "unavailable",
+        "state_reason": (
+            None if available else "no metric samples were present in both snapshots"
+        ),
+        "unavailable_metrics": unavailable,
+        "worker_deltas": None,
+        "cas_deltas": None,
+        "unavailable_fields": {
+            "worker_deltas": snapshot_reason,
+            "cas_deltas": snapshot_reason,
+        },
+    }
+    result["worker_deltas"] = _metric_group(
+        result, BUILDBARN_WORKER_METRICS, group="worker"
+    )
+    result["cas_deltas"] = _metric_group(
+        result, BUILDBARN_CAS_METRICS, group="cas"
+    )
+    return result
+
+
+def collect_run(
+    metadata: Any = None,
+    *,
+    buildstream_output: str | None = None,
+    recc_verbose: str | None = None,
+    prometheus_before: str | None = None,
+    prometheus_after: str | None = None,
+    metric_names: Iterable[str] | None = None,
+    source_url: str | None = None,
+    collected_at: Any = None,
+) -> dict[str, Any]:
+    """Assemble one parsed run record without retaining raw artifacts."""
+
+    run = parse_run_metadata(metadata)
+    structured_buildbarn: dict[str, Any] = {}
+    if isinstance(metadata, dict):
+        if buildstream_output is None:
+            buildstream_output = metadata.get("buildstream")
+        if recc_verbose is None:
+            recc_verbose = metadata.get("recc")
+        if isinstance(metadata.get("buildbarn"), dict):
+            structured_buildbarn = metadata["buildbarn"]
+    buildstream = parse_buildstream_output(
+        buildstream_output,
+        expected_phases=run.get("phases", {}).keys()
+        if isinstance(run.get("phases"), dict)
+        else None,
+    )
+    recc = parse_recc_verbose(recc_verbose)
+    before = parse_prometheus_snapshot(prometheus_before, metric_names)
+    after = parse_prometheus_snapshot(prometheus_after, metric_names)
+    buildbarn_delta = prometheus_delta(
+        prometheus_before, prometheus_after, metric_names
+    )
+    for field, aliases in (
+        ("worker_deltas", ("worker_deltas", "worker")),
+        ("cas_deltas", ("cas_deltas", "cas")),
+    ):
+        value = _first(structured_buildbarn, *aliases)
+        if value is not None:
+            buildbarn_delta[field] = value
+            buildbarn_delta["unavailable_fields"].pop(field, None)
+
+    collected = parse_timestamp(collected_at) or dt.datetime.now(dt.timezone.utc)
+    sections = (run, buildstream, recc, buildbarn_delta)
+    available = any(section["state"] == "available" for section in sections)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": run,
+        "buildstream": buildstream,
+        "recc": recc,
+        "buildbarn": {
+            "before": before,
+            "after": after,
+            "delta": buildbarn_delta,
+            "state": buildbarn_delta["state"],
+            "state_reason": buildbarn_delta["state_reason"],
+        },
+        "source_url": source_url,
+        "collected_at": format_timestamp(collected),
+        "derivation": (
+            "Parsed caller-supplied run metadata, BuildStream output, "
+            "RECC_VERBOSE output, and before/after Prometheus text snapshots."
+        ),
+        "state": "available" if available else "unavailable",
+        "state_reason": (
+            None
+            if available
+            else "no parseable evidence was supplied for this run"
+        ),
+        "unavailable_fields": (
+            {}
+            if source_url
+            else {"source_url": "no canonical source URL was supplied for local artifacts"}
+        ),
+    }
+
+
+def _read_input(path: str | None) -> str | None:
+    if not path:
+        return None
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _metric_args(values: list[str]) -> list[str]:
+    names = []
+    for value in values:
+        if not re.fullmatch(r"[a-zA-Z_:][a-zA-Z0-9_:]*", value):
+            raise ValueError(f"invalid Prometheus metric name: {value}")
+        names.append(value)
+    return names
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata", help="JSON or key/value metadata artifact")
+    parser.add_argument("--buildstream-log", help="BuildStream output artifact")
+    parser.add_argument("--recc-log", help="RECC_VERBOSE output artifact")
+    parser.add_argument("--prometheus-before", help="Prometheus text snapshot before the run")
+    parser.add_argument("--prometheus-after", help="Prometheus text snapshot after the run")
+    parser.add_argument(
+        "--metric",
+        action="append",
+        default=[],
+        help="Prometheus metric family to compare; repeat for multiple metrics",
+    )
+    parser.add_argument("--source-url")
+    parser.add_argument("--collected-at")
+    parser.add_argument("--output", help="Write JSON here instead of stdout")
+    args = parser.parse_args(argv)
+
+    try:
+        metric_names = _metric_args(args.metric)
+        metadata_text = _read_input(args.metadata)
+        metadata: Any = metadata_text
+        if metadata_text:
+            try:
+                metadata = json.loads(metadata_text)
+            except json.JSONDecodeError:
+                pass
+        record = collect_run(
+            metadata,
+            buildstream_output=_read_input(args.buildstream_log),
+            recc_verbose=_read_input(args.recc_log),
+            prometheus_before=_read_input(args.prometheus_before),
+            prometheus_after=_read_input(args.prometheus_after),
+            metric_names=metric_names or None,
+            source_url=args.source_url,
+            collected_at=args.collected_at,
+        )
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+
+    rendered = json.dumps(record, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_collect_recc_run.py
+++ b/tests/unit/test_collect_recc_run.py
@@ -1,0 +1,280 @@
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import collect_recc_run as collector  # noqa: E402
+
+
+def test_parse_run_metadata_normalizes_timestamps_and_duration():
+    result = collector.parse_run_metadata(
+        {
+            "workflow_name": "recc-baseline-cold",
+            "mode": "cache-only",
+            "started_at": "2026-07-31T14:00:00-04:00",
+            "finished_at": "2026-07-31T18:01:02Z",
+        }
+    )
+
+    assert result["run_id"] == "recc-baseline-cold"
+    assert result["started_at"] == "2026-07-31T18:00:00Z"
+    assert result["finished_at"] == "2026-07-31T18:01:02Z"
+    assert result["duration_seconds"] == 62
+    assert result["state"] == "available"
+
+
+def test_buildstream_parser_keeps_partial_timings_and_element_evidence():
+    result = collector.parse_buildstream_output(
+        json.dumps(
+            {
+                "timings": {"wall": "1m 2s", "fetch": 3.5, "build": "40s"},
+                "elements": [
+                    {
+                        "name": "recc-baseline.bst",
+                        "state": "cached",
+                        "key": "element-key",
+                        "cache_origin": "artifact-cache",
+                        "digest": "sha256:output",
+                    }
+                ],
+                "fixture_stdout": "hello from fixture",
+            }
+        )
+    )
+
+    assert result["state"] == "available"
+    assert result["timings"] == {
+        "wall_seconds": 62.0,
+        "fetch_seconds": 3.5,
+        "build_seconds": 40.0,
+        "push_seconds": None,
+    }
+    assert result["elements"][0]["key"] == "element-key"
+    assert result["elements"][0]["cache_origin"] == "artifact-cache"
+    assert result["output_digest"] == "sha256:output"
+    assert result["fixture_stdout"] == "hello from fixture"
+    assert "push_seconds" in result["unavailable_fields"]
+
+
+def test_buildstream_text_requires_explicit_element_cache_origin_and_digest_fields():
+    result = collector.parse_buildstream_output(
+        """
+        element: recc-baseline.bst
+        state: built
+        key: element-key
+        cache origin: local-build
+        output digest: sha256:output
+        fixture stdout: hello
+        """
+    )
+
+    assert result["elements"] == [
+        {
+            "name": "recc-baseline.bst",
+            "state": "built",
+            "key": "element-key",
+            "cache_origin": "local-build",
+            "digest": "sha256:output",
+            "unavailable_fields": {},
+        }
+    ]
+    assert result["output_digest"] == "sha256:output"
+    assert result["fixture_stdout"] == "hello"
+
+
+def test_recc_verbose_parser_extracts_cache_and_fallback_evidence():
+    result = collector.parse_recc_verbose(
+        """
+        [RECC]
+        action started compile-1
+        action completed compile-1
+        action cache hit compile-1
+        action cache miss compile-2
+        fallback to local compile
+        compile time: 4.5s
+        link duration: 800ms
+        [/RECC]
+        """
+    )
+
+    assert result["action_count"] == 1
+    assert result["cache_hits"] == 1
+    assert result["cache_misses"] == 1
+    assert result["local_fallbacks"] == 1
+    assert result["compile_seconds"] == 4.5
+    assert result["link_seconds"] == 0.8
+    assert result["state"] == "available"
+
+
+def test_generic_buildstream_log_is_not_recc_evidence():
+    result = collector.parse_recc_verbose(
+        """
+        action started compile-1
+        action completed compile-1
+        action cache hit compile-1
+        fallback to local compile
+        compile time: 4.5s
+        """
+    )
+
+    assert result["state"] == "unavailable"
+    assert result["action_count"] is None
+    assert result["cache_hits"] is None
+    assert "explicit RECC marker" in result["state_reason"]
+
+
+def test_recc_dedicated_section_is_accepted_without_per_line_markers():
+    result = collector.parse_recc_verbose(
+        """
+        === BEGIN RECC_VERBOSE LOG ===
+        action cache hit compile-1
+        === END RECC_VERBOSE LOG ===
+        """
+    )
+
+    assert result["cache_hits"] == 1
+    assert result["state"] == "available"
+
+
+def test_prometheus_names_are_discovered_and_deltas_are_label_aware():
+    before = """
+    # HELP bb_actions_total actions
+    bb_actions_total{worker="ghost"} 4
+    bb_actions_total{worker="exo-0"} 2
+    bb_queue_seconds_sum 10
+    """
+    after = """
+    bb_actions_total{worker="ghost"} 7
+    bb_actions_total{worker="exo-0"} 2
+    bb_queue_seconds_sum 13
+    """
+
+    assert collector.discover_metric_names(before) == [
+        "bb_actions_total",
+        "bb_queue_seconds_sum",
+    ]
+    delta = collector.prometheus_delta(
+        before,
+        after,
+        metric_names=["bb_actions_total", "metric_not_present"],
+    )
+    deltas = {
+        row["labels"]["worker"]: row["delta"]
+        for row in delta["metrics"]["bb_actions_total"]
+    }
+    assert deltas == {"ghost": 3, "exo-0": 0}
+    assert delta["unavailable_metrics"] == {
+        "metric_not_present": "metric was not present in both snapshots"
+    }
+    assert delta["worker_deltas"] is None
+    assert delta["cas_deltas"] is None
+
+
+def test_buildbarn_group_summaries_keep_worker_and_cas_numbers_explicit():
+    before = """
+    buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_count{node="ghost"} 2
+    buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_sum{node="ghost"} 4
+    buildbarn_builder_in_memory_build_queue_tasks_queued_duration_seconds_sum{node="ghost"} 1
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_count{operation="Get",storage_type="cas"} 3
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum{operation="Get",storage_type="cas"} 100
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_count{operation="Put",storage_type="cas"} 1
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum{operation="Put",storage_type="cas"} 40
+    """
+    after = """
+    buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_count{node="ghost"} 5
+    buildbarn_builder_in_memory_build_queue_tasks_executing_duration_seconds_sum{node="ghost"} 10
+    buildbarn_builder_in_memory_build_queue_tasks_queued_duration_seconds_sum{node="ghost"} 3
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_count{operation="Get",storage_type="cas"} 5
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum{operation="Get",storage_type="cas"} 180
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_count{operation="Put",storage_type="cas"} 2
+    buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum{operation="Put",storage_type="cas"} 70
+    """
+
+    delta = collector.prometheus_delta(
+        before,
+        after,
+        metric_names=(
+            *collector.BUILDBARN_WORKER_METRICS,
+            *collector.BUILDBARN_CAS_METRICS,
+        ),
+    )
+
+    assert delta["worker_deltas"]["summary"] == {
+        "actions_executed": 3,
+        "queue_seconds": 2,
+        "execution_seconds": 6,
+    }
+    assert delta["cas_deltas"]["summary"] == {
+        "get_requests": 2,
+        "put_requests": 1,
+        "get_bytes": 80,
+        "put_bytes": 30,
+    }
+
+
+def test_missing_sections_are_explicitly_unavailable():
+    result = collector.collect_run({"run_id": "empty"})
+
+    assert result["state"] == "available"
+    assert result["buildstream"]["state"] == "unavailable"
+    assert result["buildstream"]["state_reason"]
+    assert result["recc"]["state"] == "unavailable"
+    assert result["buildbarn"]["delta"]["state"] == "unavailable"
+    assert result["buildbarn"]["before"]["state_reason"]
+    assert result["buildstream"]["output_digest"] is None
+    assert result["buildstream"]["fixture_stdout"] is None
+    assert "output_digest" in result["buildstream"]["unavailable_fields"]
+    assert "fixture_stdout" in result["buildstream"]["unavailable_fields"]
+    assert result["buildbarn"]["delta"]["worker_deltas"] is None
+    assert result["buildbarn"]["delta"]["cas_deltas"] is None
+
+
+def test_missing_phase_timings_and_element_cache_origin_are_explicitly_unavailable():
+    result = collector.collect_run(
+        {
+            "run_id": "run-1",
+            "phases": {"cold": {"state": "success"}, "warm": {"state": "not-run"}},
+        },
+        buildstream_output=json.dumps(
+            {
+                "elements": [
+                    {
+                        "name": "recc-baseline.bst",
+                        "state": "built",
+                        "key": "element-key",
+                    }
+                ]
+            }
+        ),
+    )
+
+    assert result["buildstream"]["phases"]["cold"]["state"] == "unavailable"
+    assert result["buildstream"]["phases"]["cold"]["timings"]["build_seconds"] is None
+    assert result["buildstream"]["phases"]["cold"]["unavailable_fields"]["timings.wall_seconds"]
+    assert "element_cache_origin" in result["buildstream"]["unavailable_fields"]
+    assert "cache_origin" in result["buildstream"]["elements"][0]["unavailable_fields"]
+
+
+def test_cli_emits_machine_readable_record_without_raw_artifacts(tmp_path, capsys):
+    metadata = tmp_path / "metadata.json"
+    metadata.write_text(
+        json.dumps({"run_id": "run-1", "mode": "cache-only"}),
+        encoding="utf-8",
+    )
+    buildstream = tmp_path / "buildstream.log"
+    buildstream.write_text("wall: 2s\n", encoding="utf-8")
+
+    assert collector.main(
+        [
+            "--metadata",
+            str(metadata),
+            "--buildstream-log",
+            str(buildstream),
+        ]
+    ) == 0
+    record = json.loads(capsys.readouterr().out)
+    assert record["run"]["run_id"] == "run-1"
+    assert record["buildstream"]["timings"]["wall_seconds"] == 2.0
+    assert "wall: 2s" not in json.dumps(record)

--- a/tests/unit/test_recc_baseline_workflow.py
+++ b/tests/unit/test_recc_baseline_workflow.py
@@ -1,0 +1,189 @@
+from pathlib import Path
+import subprocess
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / "argo/workflow-templates/recc-baseline-pipeline.yaml"
+FIXTURE = ROOT / "bst-prototype/elements/recc-baseline.bst"
+
+
+def _manifest():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _run_template():
+    return next(
+        template
+        for template in _manifest()["spec"]["templates"]
+        if template["name"] == "run"
+    )
+
+
+def test_recc_fixture_generates_separate_launcher_and_compiler_arguments():
+    fixture = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
+    variables = fixture["variables"]
+    build_commands = fixture["config"]["build-commands"]
+    command = build_commands[0]
+
+    assert variables["compiler"] == "/usr/bin/g++"
+    assert variables["compiler_launcher"] == ""
+    assert variables["(?)"][0]["recc != \"buildstream-only\""]["compiler_launcher"] == (
+        "recc"
+    )
+    assert fixture["environment"]["CXX"] == "%{compiler}"
+    assert fixture["environment"]["CXX_LAUNCHER"] == "%{compiler_launcher}"
+    assert '"${CXX_LAUNCHER}" "${CXX}" "$@"' in command
+    assert command.count("run_cxx ") == 3
+    assert command.count(" -c ") == 2
+    assert '"$CXX" ' not in command
+
+
+def test_recc_baseline_is_an_isolated_operator_only_template():
+    manifest = _manifest()
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert manifest["metadata"]["name"] == "recc-baseline-pipeline"
+    assert manifest["metadata"]["labels"]["bluefin.io/operator-only"] == "true"
+    assert manifest["spec"]["entrypoint"] == "run"
+    assert "templateRef" not in text
+    assert "dakota-build-pipeline" not in text
+    assert "cosmic" not in text
+    assert "bluefin-server" not in text
+
+
+def test_parameters_target_recc_baseline_and_fail_closed_provider_defaults():
+    parameters = {
+        parameter["name"]: parameter["value"]
+        for parameter in _manifest()["spec"]["arguments"]["parameters"]
+    }
+    assert parameters["mode"] == "buildstream-only"
+    assert parameters["run-id"] == ""
+    assert parameters["cache-policy"] == "cold"
+    assert parameters["recc-provider"] == (
+        "freedesktop-sdk.bst:components/buildbox.bst"
+    )
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert 'ELEMENT="recc-baseline.bst"' in text
+    assert "required element bst-prototype/elements/${ELEMENT}" in text
+    assert "recc-provider is empty" in text
+
+
+def test_buildstream_cache_is_ephemeral_and_no_host_usr_is_mounted():
+    run = _run_template()
+    volumes = {volume["name"]: volume for volume in run["volumes"]}
+    assert "ephemeral" in volumes["bst-cache"]
+    assert (
+        volumes["bst-cache"]["ephemeral"]["volumeClaimTemplate"]["spec"]["resources"][
+            "requests"
+        ]["storage"]
+        == "20Gi"
+    )
+    mounts = run["script"]["volumeMounts"]
+    assert all(not mount["mountPath"].startswith("/usr") for mount in mounts)
+    assert all("hostPath" not in volume for volume in run["volumes"])
+    assert "servers: []" in WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_prototype_pins_compiler_and_recc_provider_junction():
+    project = yaml.safe_load((ROOT / "bst-prototype/project.conf").read_text())
+    fixture = yaml.safe_load(FIXTURE.read_text())
+    junction = yaml.safe_load(
+        (ROOT / "bst-prototype/elements/freedesktop-sdk.bst").read_text()
+    )
+
+    assert "include/aliases.yml" in project["(@)"]
+    assert "plugins" in project
+    assert project["plugins"][0]["sources"] == ["git_repo"]
+    assert "freedesktop-sdk.bst:components/gcc.bst" in fixture["build-depends"]
+    assert junction["sources"][0]["ref"].endswith(
+        "57149392fe26548b0e7c50a2e171e3aac005a412"
+    )
+
+
+def test_buildstream_config_uses_existing_configmap_key():
+    run = _run_template()
+    config = next(
+        volume["configMap"]
+        for volume in run["volumes"]
+        if volume["name"] == "buildstream-config"
+    )
+    assert config["name"] == "buildstream-remote-cache"
+    assert config["items"] == [
+        {"key": "dakota-buildstream.conf", "path": "buildstream.conf"},
+        {"key": "recc-environment.conf", "path": "recc-environment.conf"},
+        {"key": "apply_recc_overlay.py", "path": "apply_recc_overlay.py"},
+    ]
+
+
+def test_recc_modes_require_pilot_overlay_and_remote_execution_is_blocked():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "--pilot-cache-only" in text
+    assert '--recc-provider "${RECC_PROVIDER}"' in text
+    assert "remote-execution is blocked" in text
+    assert "--runner-capability" not in text
+    assert (
+        'if [[ "${MODE}" != "buildstream-only" && -z "${RECC_PROVIDER}" ]]'
+        in text
+    )
+    assert text.index('if [[ "${MODE}" != "buildstream-only"') < text.index(
+        "Applying operator-only RECC cache pilot overlay"
+    )
+
+
+def test_metadata_outputs_preserve_remote_cache_and_unavailable_fields():
+    run = _run_template()
+    output_names = {
+        parameter["name"]: parameter["valueFrom"]["path"]
+        for parameter in run["outputs"]["parameters"]
+    }
+    assert output_names["metadata"] == "/work/recc-baseline-metadata.json"
+    assert output_names["evidence"] == "/work/recc-baseline-evidence.json"
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert '"evidence_capture"' in text
+    assert '"unavailable_fields"' in text
+    assert "remote RECC cache preserved" in text
+    assert "--prometheus-before" in text
+    assert "--prometheus-after" in text
+    assert "/work/recc.log" in text
+    assert "find /root/.cache/buildstream" in text
+    assert "capture_buildbarn_metrics" in text
+    assert "EVIDENCE_FAILED=1" in text
+    assert "|| true" not in text[text.index("RECC evidence collector"):text.index("trap finalize EXIT")]
+
+
+def test_justfile_exposes_all_operator_parameters():
+    justfile = (ROOT / "Justfile").read_text(encoding="utf-8")
+    assert "run-recc-baseline *args:" in justfile
+    assert "workflowtemplate/recc-baseline-pipeline" in justfile
+    for parameter in ("mode", "run-id", "cache-policy", "recc-provider"):
+        assert f"-p {parameter}=" in justfile
+
+
+def test_justfile_named_recc_arguments_are_preserved_for_parsing():
+    result = subprocess.run(
+        [
+            "just",
+            "--dry-run",
+            "--justfile",
+            str(ROOT / "Justfile"),
+            "run-recc-baseline",
+            "cache-policy=both",
+            "recc-provider=freedesktop-sdk.bst:components/buildbox.bst",
+            "mode=cache-only",
+            "run-id=warm-run",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+    assert (
+        "for arg in cache-policy=both "
+        "recc-provider=freedesktop-sdk.bst:components/buildbox.bst "
+        "mode=cache-only run-id=warm-run;"
+    ) in output
+    assert 'mode=*) MODE="${arg#mode=}" ;;' in output
+    assert 'run-id=*) RUN_ID="${arg#run-id=}" ;;' in output
+    assert 'cache-policy=*) CACHE_POLICY="${arg#cache-policy=}" ;;' in output
+    assert 'recc-provider=*) RECC_PROVIDER="${arg#recc-provider=}" ;;' in output

--- a/tests/unit/test_recc_overlay.py
+++ b/tests/unit/test_recc_overlay.py
@@ -1,0 +1,597 @@
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts/apply_recc_overlay.py"
+SPEC = importlib.util.spec_from_file_location("apply_recc_overlay", MODULE_PATH)
+OVERLAY = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = OVERLAY
+SPEC.loader.exec_module(OVERLAY)
+
+
+# Lanes that must fail closed rather than build without nested RECC.
+MANDATORY_KINDS = ("dakota", "cosmic", "bluefin-server", "bst-qa")
+# The only operator-driven fixture allowed to use --pilot-cache-only.
+PILOT_KINDS = ("bst-prototype",)
+PILOT_PROVIDER = "components/buildbox.bst"
+SDK_PROVIDER = "freedesktop-sdk.bst:components/buildbox.bst"
+# Adapters with no pinned recc provider of their own.
+PROVIDERLESS_KINDS = ("bst-prototype", "bst-qa")
+
+
+def _apply(checkout: Path, kind: str, **kwargs):
+    """Apply an overlay with the minimum contract each adapter requires."""
+
+    if kind in MANDATORY_KINDS:
+        kwargs.setdefault("runner_capability", True)
+    else:
+        kwargs.setdefault("pilot_cache_only", True)
+    if kind in PROVIDERLESS_KINDS:
+        kwargs.setdefault("recc_provider", PILOT_PROVIDER)
+    return OVERLAY.apply_overlay(checkout, project_kind=kind, **kwargs)
+
+
+def _checkout(tmp_path: Path, kind: str) -> Path:
+    checkout = tmp_path / kind
+    (checkout / "elements").mkdir(parents=True)
+    (checkout / "include").mkdir()
+    (checkout / "project.conf").write_text(
+        """\
+name: sample
+min-version: 2.5
+element-path: elements
+
+(@):
+  - include/aliases.yml
+
+options:
+  arch:
+    type: arch
+    values:
+    - x86_64
+""",
+        encoding="utf-8",
+    )
+    if kind in {"bst-prototype", "bst-qa"}:
+        project = checkout / "project.conf"
+        project.write_text(
+            project.read_text().replace("min-version: 2.5", "min-version: 2.0"),
+            encoding="utf-8",
+        )
+    (checkout / "elements/freedesktop-sdk.bst").write_text(
+        "kind: junction\n", encoding="utf-8"
+    )
+    if kind in {"dakota", "bluefin-server"}:
+        (checkout / "elements/gnome-build-meta.bst").write_text(
+            "kind: junction\n", encoding="utf-8"
+        )
+    if kind == "dakota":
+        root = checkout / "elements/oci/layers"
+        root.mkdir(parents=True)
+        (root / "bluefin.bst").write_text(
+            "kind: manual\n\nbuild-depends:\n"
+            "- freedesktop-sdk.bst:components/gcc.bst\n",
+            encoding="utf-8",
+        )
+        (root / "bluefin-nvidia.bst").write_text(
+            "kind: manual\n\nbuild-depends:\n"
+            "- freedesktop-sdk.bst:components/gcc.bst\n",
+            encoding="utf-8",
+        )
+    elif kind == "cosmic":
+        root = checkout / "elements/core"
+        root.mkdir(parents=True)
+        (root / "cosmic-comp.bst").write_text(
+            "kind: manual\n\nbuild-depends:\n"
+            "- freedesktop-sdk.bst:components/gcc-base.bst\n",
+            encoding="utf-8",
+        )
+        (root / "cosmic-files.bst").write_text(
+            "kind: manual\n\nbuild-depends:\n"
+            "- freedesktop-sdk.bst:components/gcc-base.bst\n",
+            encoding="utf-8",
+        )
+        (checkout / "elements/core-deps").mkdir()
+        (checkout / "elements/core-deps/runtime-only.bst").write_text(
+            "kind: manual\n\nruntime-depends:\n"
+            "- freedesktop-sdk.bst:components/gcc.bst\n",
+            encoding="utf-8",
+        )
+    elif kind == "bluefin-server":
+        root = checkout / "elements/oci"
+        root.mkdir(parents=True)
+        for name in ("bluefin-server-ddi.bst", "bluefin-server-installer.bst"):
+            (root / name).write_text(
+                "kind: script\n\nbuild-depends:\n"
+                "- freedesktop-sdk.bst:components/zstd.bst\n",
+                encoding="utf-8",
+            )
+    elif kind in {"bst-prototype", "bst-qa"}:
+        (checkout / "elements/components").mkdir()
+        (checkout / "elements/components/buildbox.bst").write_text(
+            "kind: cmake\n", encoding="utf-8"
+        )
+        (checkout / "elements/recc-baseline.bst").write_text(
+            "kind: manual\n\n"
+            'variables:\n  compiler: "recc /usr/bin/g++"\n',
+            encoding="utf-8",
+        )
+    return checkout
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ("dakota", "cosmic", "bluefin-server", "bst-prototype", "bst-qa"),
+)
+def test_overlay_supports_all_lab_project_adapters(tmp_path, kind):
+    checkout = _checkout(tmp_path, kind)
+
+    diagnostics = _apply(checkout, kind)
+
+    assert diagnostics["overlay_version"] == OVERLAY.OVERLAY_VERSION
+    if kind in MANDATORY_KINDS:
+        assert diagnostics["remote_execution_policy"] == "remote-execution"
+        assert diagnostics["nested_socket"] == "enabled"
+    else:
+        assert diagnostics["remote_execution_policy"] == "cache-only"
+        assert diagnostics["nested_socket"] == "disabled"
+    expected_provider = (
+        PILOT_PROVIDER if kind in PROVIDERLESS_KINDS else SDK_PROVIDER
+    )
+    assert diagnostics["recc_provider"] == expected_provider
+    if kind == "bst-prototype":
+        assert (
+            diagnostics["digest_environment"]
+            == "applied"
+        )
+    assert (checkout / "include/recc.yml").is_file()
+    assert (checkout / "include/gcc-for-recc.yml").is_file()
+    assert (checkout / "include/clang-for-recc.yml").is_file()
+    assert (checkout / "elements/buildsystems/recc-wrapper.bst").is_file()
+    assert (checkout / "files/recc-wrapper/recc-wrapper").stat().st_mode & 0o111
+    project = yaml.safe_load((checkout / "project.conf").read_text())
+    assert "include/recc.yml" in project["(@)"]
+    expected_policy = (
+        "remote-execution" if kind in MANDATORY_KINDS else "cache-only"
+    )
+    assert project["options"]["recc"]["default"] == expected_policy
+    assert project["min-version"] == 2.5
+    assert "digest-environment" in (
+        checkout / "include/gcc-for-recc.yml"
+    ).read_text()
+    include_text = (checkout / "include/recc.yml").read_text()
+    assert ("remote-apis-socket" in include_text) is (kind in MANDATORY_KINDS)
+    environment = yaml.safe_load(include_text)["environment"]
+    assert environment["RECC_SERVER"] == (
+        "grpc://frontend.buildbarn.svc.cluster.local:8980"
+    )
+    assert environment["RECC_ACTION_UNCACHEABLE"] == "0"
+    assert environment["RECC_VERBOSE"] == "1"
+    assert environment["PATH"] == "/usr/recc/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    if kind == "cosmic":
+        runtime_only = checkout / "elements/core-deps/runtime-only.bst"
+        assert "build-depends:" not in runtime_only.read_text()
+
+
+def test_existing_recc_option_is_forced_to_the_resolved_policy(tmp_path):
+    checkout = _checkout(tmp_path, "bst-prototype")
+    project = checkout / "project.conf"
+    project.write_text(
+        project.read_text()
+        + """
+  recc:
+    type: enum
+    values:
+    - buildstream-only
+    default: buildstream-only
+""",
+        encoding="utf-8",
+    )
+
+    _apply(checkout, "bst-prototype")
+
+    text = project.read_text()
+    assert "default: cache-only" in text
+    assert "- cache-only" in text
+    assert "default: buildstream-only" not in text
+
+
+def test_runner_capability_is_required_for_nested_socket(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+
+    OVERLAY.apply_overlay(
+        checkout,
+        project_kind="cosmic",
+        runner_capability=True,
+    )
+
+    include = (checkout / "include/recc.yml").read_text()
+    assert "remote-apis-socket:" in include
+    assert "path: /tmp/casd.sock" in include
+
+
+@pytest.mark.parametrize("kind", MANDATORY_KINDS)
+def test_mandatory_lanes_refuse_without_proven_runner_capability(tmp_path, kind):
+    checkout = _checkout(tmp_path, kind)
+
+    with pytest.raises(OVERLAY.OverlayError, match="remoteApisSocketPath"):
+        OVERLAY.apply_overlay(checkout, project_kind=kind)
+
+    assert not (checkout / "include/recc.yml").exists()
+    assert not (checkout / "elements/buildsystems/recc-wrapper.bst").exists()
+    assert "include/recc.yml" not in (checkout / "project.conf").read_text()
+
+
+@pytest.mark.parametrize("kind", MANDATORY_KINDS)
+def test_mandatory_lanes_refuse_operator_cache_only_fallback(tmp_path, kind):
+    checkout = _checkout(tmp_path, kind)
+
+    with pytest.raises(OVERLAY.OverlayError, match="operator-only flag"):
+        OVERLAY.apply_overlay(checkout, project_kind=kind, pilot_cache_only=True)
+
+    assert not (checkout / "include/recc.yml").exists()
+
+
+@pytest.mark.parametrize("kind", PILOT_KINDS)
+def test_pilot_fixtures_require_an_explicit_documented_mode(tmp_path, kind):
+    checkout = _checkout(tmp_path, kind)
+
+    with pytest.raises(OVERLAY.OverlayError, match="operator-only pilot"):
+        OVERLAY.apply_overlay(
+            checkout, project_kind=kind, recc_provider=PILOT_PROVIDER
+        )
+
+    assert not (checkout / "include/recc.yml").exists()
+
+
+def test_capability_and_pilot_modes_are_mutually_exclusive(tmp_path):
+    checkout = _checkout(tmp_path, "bst-prototype")
+
+    with pytest.raises(OVERLAY.OverlayError, match="mutually exclusive"):
+        OVERLAY.apply_overlay(
+            checkout,
+            project_kind="bst-prototype",
+            runner_capability=True,
+            pilot_cache_only=True,
+            recc_provider=PILOT_PROVIDER,
+        )
+
+
+@pytest.mark.parametrize("kind", PROVIDERLESS_KINDS)
+def test_overlay_refuses_when_no_element_supplies_recc(tmp_path, kind):
+    checkout = _checkout(tmp_path, kind)
+
+    mode = (
+        {"runner_capability": True}
+        if kind in MANDATORY_KINDS
+        else {"pilot_cache_only": True}
+    )
+    with pytest.raises(OVERLAY.OverlayError, match="cannot supply the recc binary"):
+        OVERLAY.apply_overlay(checkout, project_kind=kind, **mode)
+
+    assert not (checkout / "elements/buildsystems/recc-wrapper.bst").exists()
+    assert "include/recc.yml" not in (checkout / "project.conf").read_text()
+
+
+def test_overlay_refuses_a_recc_provider_that_is_not_in_the_checkout(tmp_path):
+    checkout = _checkout(tmp_path, "bst-prototype")
+
+    with pytest.raises(OVERLAY.OverlayError, match="is unusable"):
+        OVERLAY.apply_overlay(
+            checkout,
+            project_kind="bst-prototype",
+            pilot_cache_only=True,
+            recc_provider="missing-sdk.bst:components/buildbox.bst",
+        )
+
+    assert not (checkout / "elements/buildsystems/recc-wrapper.bst").exists()
+
+
+def test_wrapper_element_declares_the_pinned_recc_provider(tmp_path):
+    checkout = _checkout(tmp_path, "dakota")
+
+    _apply(checkout, "dakota")
+
+    wrapper = yaml.safe_load(
+        (checkout / "elements/buildsystems/recc-wrapper.bst").read_text()
+    )
+    assert wrapper["runtime-depends"] == [
+        "freedesktop-sdk.bst:components/buildbox.bst"
+    ]
+
+
+def test_wrapper_script_fails_closed_when_recc_is_absent(tmp_path):
+    wrapper = tmp_path / "recc-wrapper"
+    wrapper.write_text(OVERLAY.RECC_WRAPPER, encoding="utf-8")
+    wrapper.chmod(0o755)
+    empty_bin = tmp_path / "empty-bin"
+    empty_bin.mkdir()
+
+    missing_recc = subprocess.run(
+        ["/bin/sh", str(wrapper), "-c", "main.c"],
+        env={
+            "PATH": str(empty_bin),
+            "RECC_REMOTE_PLATFORM_chrootRootDigest": "abc/1",
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert missing_recc.returncode == 1
+    assert "recc is not staged in this sandbox" in missing_recc.stderr
+
+    missing_digest = subprocess.run(
+        ["/bin/sh", str(wrapper), "-c", "main.c"],
+        env={"PATH": str(empty_bin)},
+        capture_output=True,
+        text=True,
+    )
+    assert missing_digest.returncode == 1
+    assert "chrootRootDigest is required" in missing_digest.stderr
+
+
+def test_commented_build_depends_section_stays_loadable_yaml(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+    element = checkout / "elements/core/cosmic-comp.bst"
+    element.write_text(
+        "kind: manual\n\n"
+        "build-depends:\n"
+        "# keep the toolchain first\n"
+        "- freedesktop-sdk.bst:components/gcc-base.bst\n",
+        encoding="utf-8",
+    )
+
+    _apply(checkout, "cosmic")
+
+    text = element.read_text()
+    assert "build-depends:-" not in text
+    assert "build-depends:\n" in text
+    parsed = yaml.safe_load(text)
+    assert parsed["kind"] == "manual"
+    assert "buildsystems/recc-wrapper.bst" in parsed["build-depends"]
+    assert (
+        "freedesktop-sdk.bst:components/gcc-base.bst" in parsed["build-depends"]
+    )
+    assert "# keep the toolchain first" in text
+
+
+def test_build_depends_insertion_preserves_existing_indentation(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+    element = checkout / "elements/core/cosmic-comp.bst"
+    element.write_text(
+        "kind: manual\n\n"
+        "build-depends:\n"
+        "  - freedesktop-sdk.bst:components/gcc-base.bst\n\n"
+        "config:\n"
+        "  build-commands:\n"
+        "  - make\n",
+        encoding="utf-8",
+    )
+
+    _apply(checkout, "cosmic")
+
+    text = element.read_text()
+    parsed = yaml.safe_load(text)
+    assert "  - buildsystems/recc-wrapper.bst\n" in text
+    assert "buildsystems/recc-wrapper.bst" in parsed["build-depends"]
+    assert parsed["config"]["build-commands"] == ["make"]
+
+
+def test_build_depends_insertion_is_idempotent_for_commented_sections(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+    element = checkout / "elements/core/cosmic-comp.bst"
+    original = (
+        "kind: manual\n\n"
+        "build-depends:\n"
+        "# comment\n"
+        "- freedesktop-sdk.bst:components/gcc-base.bst\n"
+    )
+    element.write_text(original, encoding="utf-8")
+    entries = ("buildsystems/recc-wrapper.bst",)
+
+    once = OVERLAY._insert_build_depends(original, entries)
+    twice = OVERLAY._insert_build_depends(once, entries)
+
+    assert once == twice
+    assert yaml.safe_load(twice)["build-depends"].count(entries[0]) == 1
+
+
+def test_overlay_fails_closed_before_writing_unsupported_layout(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+    (checkout / "elements/core/cosmic-comp.bst").write_text(
+        "kind: manual\nbuild-depends: [freedesktop-sdk.bst:components/gcc-base.bst]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OVERLAY.OverlayError, match="inline build-depends"):
+        _apply(checkout, "cosmic")
+
+    assert not (checkout / "include/recc.yml").exists()
+    assert "include/recc.yml" not in (checkout / "project.conf").read_text()
+
+
+def test_overlay_refuses_conflicting_lab_file_without_partial_writes(tmp_path):
+    checkout = _checkout(tmp_path, "dakota")
+    (checkout / "include/recc.yml").write_text("environment: {}\n", encoding="utf-8")
+
+    with pytest.raises(OVERLAY.OverlayError, match="overwrite"):
+        _apply(checkout, "dakota")
+
+    assert not (checkout / "elements/buildsystems/recc-wrapper.bst").exists()
+    assert "include/recc.yml" not in (checkout / "project.conf").read_text()
+
+
+def test_existing_overlay_is_idempotent_and_reports_checksums(tmp_path):
+    checkout = _checkout(tmp_path, "dakota")
+
+    first = _apply(checkout, "dakota")
+    second = _apply(checkout, "dakota")
+
+    assert first["changed_files"]
+    assert second["changed_files"] == {}
+    assert all(len(checksum) == 64 for checksum in first["changed_files"].values())
+    assert second["file_checksums"] == first["file_checksums"]
+    assert set(second["file_checksums"]) == set(OVERLAY.MANAGED_FILES)
+
+
+def test_prototype_attaches_the_wrapper_and_pinned_provider(tmp_path):
+    checkout = _checkout(tmp_path, "bst-prototype")
+
+    diagnostics = _apply(checkout, "bst-prototype")
+
+    baseline = yaml.safe_load(
+        (checkout / "elements/recc-baseline.bst").read_text()
+    )
+    assert baseline["build-depends"] == [
+        "buildsystems/recc-wrapper.bst",
+        {"(@)": "include/gcc-for-recc.yml"},
+    ]
+    wrapper = yaml.safe_load(
+        (checkout / "elements/buildsystems/recc-wrapper.bst").read_text()
+    )
+    assert wrapper["runtime-depends"] == [PILOT_PROVIDER]
+    assert (
+        diagnostics["digest_environment"]
+        == "applied"
+    )
+
+
+def test_prototype_provider_attachment_refuses_unsupported_layout_before_writes(
+    tmp_path,
+):
+    checkout = _checkout(tmp_path, "bst-prototype")
+    element = checkout / "elements/recc-baseline.bst"
+    original = element.read_text()
+    element.write_text(
+        original + "build-depends: [components/buildbox.bst]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OVERLAY.OverlayError, match="inline build-depends"):
+        _apply(checkout, "bst-prototype")
+
+    assert element.read_text() == original + "build-depends: [components/buildbox.bst]\n"
+    assert not (checkout / "include/recc.yml").exists()
+    assert not (checkout / "elements/buildsystems/recc-wrapper.bst").exists()
+
+
+def test_provider_path_must_resolve_inside_checkout_before_writes(tmp_path):
+    checkout = _checkout(tmp_path, "bst-prototype")
+    outside_provider = tmp_path / "outside.bst"
+    outside_provider.write_text("kind: junction\n", encoding="utf-8")
+
+    with pytest.raises(OVERLAY.OverlayError, match="outside the checkout"):
+        OVERLAY.apply_overlay(
+            checkout,
+            project_kind="bst-prototype",
+            pilot_cache_only=True,
+            recc_provider="../../outside.bst",
+        )
+
+    assert not (checkout / "include/recc.yml").exists()
+    assert not (checkout / "elements/buildsystems/recc-wrapper.bst").exists()
+
+
+def test_provider_symlink_must_resolve_inside_checkout_before_writes(tmp_path):
+    checkout = _checkout(tmp_path, "bst-prototype")
+    outside_provider = tmp_path / "outside.bst"
+    outside_provider.write_text("kind: cmake\n", encoding="utf-8")
+    (checkout / "elements/components/escaped.bst").symlink_to(outside_provider)
+
+    with pytest.raises(OVERLAY.OverlayError, match="outside the checkout"):
+        OVERLAY.apply_overlay(
+            checkout,
+            project_kind="bst-prototype",
+            pilot_cache_only=True,
+            recc_provider="components/escaped.bst",
+        )
+
+    assert not (checkout / "include/recc.yml").exists()
+    assert not (checkout / "elements/buildsystems/recc-wrapper.bst").exists()
+
+
+def test_wrapper_integration_command_runs_under_bin_sh(tmp_path):
+    wrapper_element = yaml.safe_load(
+        OVERLAY._wrapper_element(PILOT_PROVIDER, OVERLAY.OVERLAY_VERSION)
+    )
+    command = wrapper_element["public"]["bst"]["integration-commands"][0]
+    host_bin = tmp_path / "usr/bin"
+    wrapper_bin = tmp_path / "usr/recc/bin"
+    host_bin.mkdir(parents=True)
+    wrapper_bin.mkdir(parents=True)
+    (wrapper_bin / "recc-wrapper").write_text("#!/bin/sh\n", encoding="utf-8")
+    for compiler in (
+        "cc",
+        "g++",
+        "clang",
+        "x86_64-linux-gnu-gcc",
+        "x86_64-linux-gnu-clang++",
+    ):
+        (host_bin / compiler).write_text("", encoding="utf-8")
+
+    command = command.replace("/usr/recc/bin", str(wrapper_bin)).replace(
+        "/usr/bin", str(host_bin)
+    )
+    subprocess.run(["/bin/sh", "-ceu", command], check=True)
+
+    for compiler in (
+        "cc",
+        "g++",
+        "clang",
+        "x86_64-linux-gnu-gcc",
+        "x86_64-linux-gnu-clang++",
+    ):
+        link = wrapper_bin / compiler
+        assert link.is_symlink()
+        assert os.readlink(link) == "recc-wrapper"
+
+
+def test_endpoint_diagnostics_reject_credentials(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+
+    with pytest.raises(OVERLAY.OverlayError, match="credentials"):
+        _apply(
+            checkout,
+            "cosmic",
+            endpoint="grpc://user:secret@example.test:8980",
+        )
+
+
+def test_endpoint_diagnostics_reject_unsafe_host_or_path(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+
+    with pytest.raises(OVERLAY.OverlayError, match="unsafe characters"):
+        _apply(
+            checkout,
+            "cosmic",
+            endpoint="grpc://bad*host.example:8980",
+        )
+
+    with pytest.raises(OVERLAY.OverlayError, match="URL data"):
+        _apply(
+            checkout,
+            "cosmic",
+            endpoint="grpc://example.test:8980/path",
+        )
+
+
+def test_endpoint_without_scheme_uses_shared_grpc_contract(tmp_path):
+    checkout = _checkout(tmp_path, "cosmic")
+
+    diagnostics = _apply(
+        checkout,
+        "cosmic",
+        endpoint="frontend.buildbarn.svc.cluster.local:8980",
+    )
+
+    assert (
+        diagnostics["endpoint"]
+        == "grpc://frontend.buildbarn.svc.cluster.local:8980"
+    )

--- a/tests/unit/test_recc_runner_seam.py
+++ b/tests/unit/test_recc_runner_seam.py
@@ -1,0 +1,342 @@
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GATED_TEMPLATES = (
+    "dakota-build-pipeline.yaml",
+    "cosmic-build-pipeline.yaml",
+    "bluefin-server-build-pipeline.yaml",
+    "bst-cache-warm.yaml",
+)
+# Containers the outer BuildStream remote-execution contract actually needs.
+OUTER_RE_CONTAINERS = ("worker", "runner")
+
+
+def test_buildbarn_worker_prepares_pod_local_localcas_socket():
+    manifest = yaml.safe_load(
+        (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
+    )
+    pod_spec = manifest["spec"]["template"]["spec"]
+    containers = {container["name"]: container for container in pod_spec["containers"]}
+    volumes = {volume["name"]: volume for volume in pod_spec["volumes"]}
+    volume_init = next(
+        container
+        for container in pod_spec["initContainers"]
+        if container["name"] == "volume-init"
+    )
+    volume_init_command = volume_init["command"][-1]
+
+    assert "recc-casd" in containers
+    for name, fd in (("stdin", 0), ("stdout", 1), ("stderr", 2)):
+        assert f"ln -sfn /proc/self/fd/{fd} /worker/dev/{name}" in volume_init_command
+    casd = containers["recc-casd"]
+    assert casd["image"].startswith("192.168.1.102:30500/bst2@sha256:")
+    assert "--cas-remote=grpc://frontend.buildbarn.svc.cluster.local:8980" in casd[
+        "args"
+    ]
+    assert "--ac-remote=grpc://frontend.buildbarn.svc.cluster.local:8980" in casd[
+        "args"
+    ]
+    assert "--exec-remote=grpc://frontend.buildbarn.svc.cluster.local:8980" in casd[
+        "args"
+    ]
+    assert "--bind=unix:/run/buildbarn/recc/casd.sock" in casd["args"]
+    assert {"name": "nested-reapi", "mountPath": "/run/buildbarn/recc"} in casd[
+        "volumeMounts"
+    ]
+    assert casd["readinessProbe"]["exec"]["command"] == [
+        "test",
+        "-S",
+        "/run/buildbarn/recc/casd.sock",
+    ]
+    assert casd["livenessProbe"]["exec"]["command"] == [
+        "test",
+        "-S",
+        "/run/buildbarn/recc/casd.sock",
+    ]
+    assert {"name": "nested-reapi", "mountPath": "/run/buildbarn/recc"} in containers[
+        "runner"
+    ]["volumeMounts"]
+    assert volumes["nested-reapi"] == {"name": "nested-reapi", "emptyDir": {}}
+
+
+def test_recc_casd_sidecar_resolves_its_binary_through_path():
+    manifest = yaml.safe_load(
+        (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
+    )
+    containers = {
+        container["name"]: container
+        for container in manifest["spec"]["template"]["spec"]["containers"]
+    }
+
+    # Nothing in this repo pins the bst2 install prefix, so an absolute path
+    # would be an unproven guess. PATH lookup matches the lab's historical
+    # buildbox-casd manifest against the same image family.
+    assert containers["recc-casd"]["command"] == ["buildbox-casd"]
+    assert not any(
+        part.startswith("/") and part.endswith("buildbox-casd")
+        for part in containers["recc-casd"]["command"]
+    )
+
+
+def test_shared_lab_recc_contract_uses_supported_environment_keys():
+    config_map = yaml.safe_load(
+        (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    environment = yaml.safe_load(config_map["data"]["recc-environment.conf"])
+
+    assert environment == {
+        "RECC_SERVER": "frontend.buildbarn.svc.cluster.local:8980",
+        "RECC_CAS_SERVER": "frontend.buildbarn.svc.cluster.local:8980",
+        "RECC_ACTION_CACHE_SERVER": "frontend.buildbarn.svc.cluster.local:8980",
+        "RECC_ACTION_UNCACHEABLE": "0",
+        "RECC_PROJECT_ROOT": "/workspace",
+        "RECC_VERBOSE": "1",
+    }
+    assert "RECC_PREFIX" not in environment
+
+
+def test_recc_seam_does_not_enable_unsupported_runner_fields_or_host_namespaces():
+    config = (ROOT / "manifests/buildbarn-config.yaml").read_text(encoding="utf-8")
+    worker = (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
+    element = (ROOT / "bst-prototype/elements/recc-baseline.bst").read_text(
+        encoding="utf-8"
+    )
+    docs = (ROOT / "docs/reference/recc-runner-seam.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "readinessCheckingPathnames:" not in config
+    assert "\n      remoteApisSocketPath:" not in config
+    assert "remote-apis-socket" not in element
+    assert "unix:/tmp/casd.sock" not in element
+    assert "hostPID:" not in worker
+    assert "hostIPC:" not in worker
+    assert "Shared RECC config contract" in docs
+    assert "## Concrete blocker" in docs
+    assert "remoteApisSocketPath" in docs
+
+
+def test_all_buildstream_pipelines_mount_the_shared_recc_contract():
+    for filename in (
+        "bluefin-server-build-pipeline.yaml",
+        "cosmic-build-pipeline.yaml",
+        "dakota-build-pipeline.yaml",
+        "bst-qa-pipeline.yaml",
+    ):
+        pipeline = (
+            ROOT / "argo/workflow-templates" / filename
+        ).read_text(encoding="utf-8")
+        assert "- key: recc-environment.conf" in pipeline
+        assert "path: recc-environment.conf" in pipeline
+
+
+def test_every_lane_applies_the_shared_recc_overlay_with_no_mode_flags():
+    """RECC overlay application is mandatory and fail-closed in every lane.
+
+    ``apply_recc_overlay.py`` refuses every mandatory-RECC lane while no
+    BuildBarn runner honors ``remoteApisSocketPath``. The templates must still
+    invoke it, with no mode flags, so the lane fails closed instead of
+    building with outer remote execution only. ``--runner-capability`` may not
+    appear until that runner is proven, and ``--pilot-cache-only`` is
+    operator-only for the documented prototype baseline.
+    """
+
+    kinds = {
+        "dakota-build-pipeline.yaml": "dakota",
+        "cosmic-build-pipeline.yaml": "cosmic",
+        "bluefin-server-build-pipeline.yaml": "bluefin-server",
+        "bst-qa-pipeline.yaml": "bst-qa",
+    }
+
+    for filename, project_kind in kinds.items():
+        pipeline = (
+            ROOT / "argo/workflow-templates" / filename
+        ).read_text(encoding="utf-8")
+        checkout = pipeline.index("git clone")
+        overlay = pipeline.index("python3 /etc/buildstream/apply_recc_overlay.py")
+        first_bst_command = min(
+            index
+            for index in (
+                pipeline.find("bst --config"),
+                pipeline.find("bst --no-interactive"),
+            )
+            if index >= 0
+        )
+
+        assert "- key: apply_recc_overlay.py" in pipeline
+        assert "path: apply_recc_overlay.py" in pipeline
+        assert "key: recc-endpoint" in pipeline
+        assert f"--project-kind {project_kind}" in pipeline
+        assert '--endpoint "${RECC_ENDPOINT}"' in pipeline
+        assert checkout < overlay < first_bst_command
+        assert not re.search(
+            r"(?m)^\s*--(runner-capability|pilot-cache-only)\b", pipeline
+        )
+        assert "remote-apis-socket" not in pipeline
+
+
+def test_every_mandatory_recc_lane_is_refused_by_the_shared_overlay():
+    """The kinds the templates pass must all be mandatory-RECC adapters."""
+
+    overlay = (ROOT / "scripts/apply_recc_overlay.py").read_text(encoding="utf-8")
+    namespace: dict = {}
+    exec(compile(overlay, "apply_recc_overlay.py", "exec"), namespace)
+    adapters = namespace["ADAPTERS"]
+
+    for kind in ("dakota", "cosmic", "bluefin-server", "bst-qa"):
+        assert adapters[kind].production, kind
+    # Only the operator-driven baseline fixture may use the pilot flags.
+    assert not adapters["bst-prototype"].production
+
+
+def test_gates_fail_admission_when_no_runner_consumes_the_nested_socket():
+    config = yaml.safe_load(
+        (ROOT / "manifests/buildbarn-config.yaml").read_text(encoding="utf-8")
+    )
+    runner_jsonnet = config["data"]["runner.jsonnet"]
+    probe = re.compile(r"^[ \t]*remoteApisSocketPath[ \t]*:", re.MULTILINE)
+
+    # The deployed runner has no such field, so every gate must reject today.
+    assert not probe.search(runner_jsonnet)
+    assert probe.search(runner_jsonnet.rstrip() + "\n  remoteApisSocketPath: 'x',")
+
+    for template in GATED_TEMPLATES:
+        text = (ROOT / "argo/workflow-templates" / template).read_text(
+            encoding="utf-8"
+        )
+        assert "kubectl get configmap buildbarn-config -n buildbarn" in text
+        assert "remoteApisSocketPath[[:space:]]*:" in text
+        assert "RECC admission rejected" in text
+
+
+def test_cache_warmup_reuses_the_shared_overlayed_build_templates():
+    for filename in (
+        "dakota-build-pipeline.yaml",
+        "cosmic-build-pipeline.yaml",
+        "bluefin-server-build-pipeline.yaml",
+    ):
+        pipeline = (
+            ROOT / "argo/workflow-templates" / filename
+        ).read_text(encoding="utf-8")
+        warmup = pipeline.index("name: build-warmup")
+        assert pipeline.index("template: build-core", warmup) > warmup
+        assert "python3 /etc/buildstream/apply_recc_overlay.py" in pipeline
+
+    cache_warm = (
+        ROOT / "argo/workflow-templates/bst-cache-warm.yaml"
+    ).read_text(encoding="utf-8")
+    for pipeline in (
+        "dakota-build-pipeline",
+        "cosmic-build-pipeline",
+        "bluefin-server-build-pipeline",
+    ):
+        assert f"name: {pipeline}" in cache_warm
+    assert cache_warm.count("template: build-warmup") == 3
+
+
+def test_recc_overlay_configmap_embeds_the_lab_owned_helper():
+    config_map = yaml.safe_load(
+        (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    helper = (ROOT / "scripts/apply_recc_overlay.py").read_text(encoding="utf-8")
+
+    assert config_map["data"]["recc-endpoint"] == (
+        "grpc://frontend.buildbarn.svc.cluster.local:8980"
+    )
+    assert config_map["data"]["apply_recc_overlay.py"] == helper
+
+
+def _worker_containers() -> list[str]:
+    manifest = yaml.safe_load(
+        (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
+    )
+    return [
+        container["name"]
+        for container in manifest["spec"]["template"]["spec"]["containers"]
+    ]
+
+
+def _gate_pattern(template: str, node: str) -> str:
+    text = (ROOT / "argo/workflow-templates" / template).read_text(encoding="utf-8")
+    match = re.search(r'grep -Eq "(\^\$\{NODE\}[^"]+)"', text)
+    assert match, f"{template} has no worker readiness gate"
+    return match.group(1).replace("${NODE}", node)
+
+
+def _status_line(node: str, readiness: dict[str, bool]) -> str:
+    """Reproduce the gate's kubectl jsonpath output for one worker pod."""
+
+    def ready(name: str) -> str:
+        return "true" if readiness[name] else "false" if name in readiness else ""
+
+    return (
+        f"{node}|Running"
+        f"|worker={ready('worker')}"
+        f"|runner={ready('runner')}"
+    )
+
+
+def test_worker_admission_gates_match_containers_by_name_not_by_count():
+    containers = _worker_containers()
+    assert set(OUTER_RE_CONTAINERS) <= set(containers)
+    # The DaemonSet carries at least one preparation sidecar beyond the outer
+    # remote-execution pair; the gates must not count containers.
+    assert len(containers) > len(OUTER_RE_CONTAINERS)
+
+    for template in GATED_TEMPLATES:
+        text = (ROOT / "argo/workflow-templates" / template).read_text(
+            encoding="utf-8"
+        )
+        assert "containerStatuses[*].ready" not in text
+        assert "true true" not in text
+        for name in OUTER_RE_CONTAINERS:
+            assert f'containerStatuses[?(@.name=="{name}")]' in text
+        assert "recc-casd" not in text
+
+
+def test_worker_admission_gates_ignore_the_recc_preparation_sidecar():
+    healthy = _status_line("ghost", {"worker": True, "runner": True})
+    degraded_worker = _status_line("ghost", {"worker": False, "runner": True})
+    degraded_runner = _status_line("ghost", {"worker": True, "runner": False})
+    missing_worker = "ghost|Running|worker=|runner=true"
+
+    for template in GATED_TEMPLATES:
+        pattern = _gate_pattern(template, "ghost")
+        # A three-container worker whose recc-casd sidecar is unready is still
+        # admitted: that socket is a separate health boundary.
+        assert re.search(pattern, healthy)
+        assert not re.search(pattern, degraded_worker)
+        assert not re.search(pattern, degraded_runner)
+        assert not re.search(pattern, missing_worker)
+        assert not re.search(pattern, healthy.replace("Running", "Pending"))
+        assert not re.search(pattern, healthy.replace("ghost", "exo-0"))
+
+
+def test_outer_worker_readiness_is_decoupled_from_the_nested_socket():
+    config = (ROOT / "manifests/buildbarn-config.yaml").read_text(encoding="utf-8")
+    manifest = yaml.safe_load(
+        (ROOT / "manifests/buildbarn-worker.yaml").read_text(encoding="utf-8")
+    )
+    containers = {
+        container["name"]: container
+        for container in manifest["spec"]["template"]["spec"]["containers"]
+    }
+
+    # Outer BuildBarn admission must not depend on the unused nested socket.
+    assert "readinessCheckingPathnames:" not in config
+    assert "readinessProbe" not in containers["worker"]
+    assert "readinessProbe" not in containers["runner"]
+    # The sidecar keeps its own probes on that socket.
+    assert containers["recc-casd"]["readinessProbe"]["exec"]["command"] == [
+        "test",
+        "-S",
+        "/run/buildbarn/recc/casd.sock",
+    ]


### PR DESCRIPTION
## Summary

- include the RECC fail-closed production gates
- deploy the pod-local `recc-casd` preparation sidecar and socket seam
- keep `remoteApisSocketPath` admission blocked until a capable runner is proven

## Validation

- `just lint` passed
- focused RECC tests pass with the complete runner-seam files

This PR is intentionally separate from the already-merged operator pilot.