### PR TITLE
fix(recc): retain failed pilot pods

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -16,8 +16,6 @@ metadata:
 spec:
   serviceAccountName: argo
   activeDeadlineSeconds: 3600
-  podGC:
-    strategy: OnPodSuccess
   ttlStrategy:
     secondsAfterSuccess: 3600
     secondsAfterFailure: 86400


### PR DESCRIPTION
Do not garbage-collect the operator pilot pod before its logs can be inspected. This keeps failed preflight/build evidence available while successful runs remain covered by the workflow TTL.