### PR TITLE
fix(recc): use file-safe sparse checkout

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -339,7 +339,7 @@ spec:
           echo "=== Staging bst-prototype from ${REPO}@${REF} ==="
           git clone --depth=1 --branch "${REF}" --filter=blob:none --sparse "${REPO}" /work/src
           cd /work/src
-          git sparse-checkout set bst-prototype scripts/collect_recc_run.py
+          git sparse-checkout set --no-cone bst-prototype scripts/collect_recc_run.py
           echo "=== Checkout staged ==="
           cd /work/src/bst-prototype
           ELEMENT="recc-baseline.bst"

--- a/tests/unit/test_recc_baseline_workflow.py
+++ b/tests/unit/test_recc_baseline_workflow.py
@@ -67,6 +67,7 @@ def test_parameters_target_recc_baseline_and_fail_closed_provider_defaults():
     assert 'ELEMENT="recc-baseline.bst"' in text
     assert "required element bst-prototype/elements/${ELEMENT}" in text
     assert "recc-provider is empty" in text
+    assert "git sparse-checkout set --no-cone bst-prototype scripts/collect_recc_run.py" in text
 
 
 def test_buildstream_cache_is_ephemeral_and_no_host_usr_is_mounted():


### PR DESCRIPTION
Use non-cone sparse-checkout mode so the operator workflow can select the collector file without aborting before the first measurement phase.