### PR TITLE
fix(recc): print bounded build failure evidence

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -332,6 +332,14 @@ spec:
             }
           }
           EOF
+            if [[ -s /work/buildstream.log ]]; then
+              echo "=== BuildStream evidence tail ==="
+              tail -200 /work/buildstream.log
+            fi
+            if [[ -s /work/recc.log ]]; then
+              echo "=== RECC evidence tail ==="
+              tail -100 /work/recc.log
+            fi
             exit "${exit_code}"
           }
           trap finalize EXIT


### PR DESCRIPTION
Print bounded BuildStream and RECC log tails from failed operator runs so action failures remain diagnosable after the pod exits. No raw artifact is persisted in the evidence JSON.