### PR TITLE
feat(recc): wire the fail-closed runner seam

### DIFF
--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -221,13 +221,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "USB4 BuildBarn gate rejected: no Ready worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
@@ -297,6 +316,8 @@ spec:
                 path: remote-execution.conf
               - key: recc-environment.conf
                 path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: "{{inputs.parameters.registry}}/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d"
         command: [bash]
@@ -325,6 +346,11 @@ spec:
           # environment when the FUSE stager crashes during source staging.
           - name: BUILDBOX_STAGER
             value: copy-or-link
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
         volumeMounts:
           - name: fuse
             mountPath: /dev/fuse
@@ -345,6 +371,17 @@ spec:
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "https://x-access-token:${GITHUB_TOKEN}@${REPO#https://}" /src
           cd /src
+          echo "=== Applying lab RECC overlay (bluefin-server) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py /src \
+            --project-kind bluefin-server \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
           PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cp /etc/buildstream/buildstream.conf /tmp/buildstream-cluster.conf

--- a/argo/workflow-templates/bst-cache-warm.yaml
+++ b/argo/workflow-templates/bst-cache-warm.yaml
@@ -174,13 +174,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "Cache warmup rejected: no Ready BuildBarn worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "BuildBarn remote-execution grid admitted for cache warmup"
           printf '%s' re > /tmp/mode

--- a/argo/workflow-templates/bst-qa-pipeline.yaml
+++ b/argo/workflow-templates/bst-qa-pipeline.yaml
@@ -88,6 +88,12 @@ spec:
             items:
               - key: dakota-buildstream.conf
                 path: buildstream.conf
+              - key: remote-execution.conf
+                path: remote-execution.conf
+              - key: recc-environment.conf
+                path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
         command: [bash]
@@ -117,6 +123,11 @@ spec:
             value: "{{inputs.parameters.element}}"
           - name: REMOTE_EXECUTION_SERVICE
             value: "{{inputs.parameters.remote-execution-service}}"
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
           # Avoid the FUSE staging backend; BuildStream exits 255 in this lab
           # environment when the FUSE stager crashes during source staging.
           - name: BUILDBOX_STAGER
@@ -130,6 +141,18 @@ spec:
           cd src
           git sparse-checkout set "${PROJECT_SUBDIR}"
           cd "${PROJECT_SUBDIR}"
+
+          echo "=== Applying lab RECC overlay (bst-qa) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py . \
+            --project-kind bst-qa \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
 
           cp /etc/buildstream/buildstream.conf /tmp/buildstream-cluster.conf
           BST_CONF=/tmp/buildstream-cluster.conf

--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -212,13 +212,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "USB4 BuildBarn gate rejected: no Ready worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
@@ -292,6 +311,10 @@ spec:
                 path: buildstream.conf
               - key: remote-execution.conf
                 path: remote-execution.conf
+              - key: recc-environment.conf
+                path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: "{{inputs.parameters.registry}}/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d"
         command: [bash]
@@ -315,6 +338,11 @@ spec:
           # so skipping smudge does not affect the compiled artifact.
           - name: GIT_LFS_SKIP_SMUDGE
             value: "1"
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
         resources:
           requests:
             cpu: "1"
@@ -345,6 +373,17 @@ spec:
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "${REPO}" /src
           cd /src
+          echo "=== Applying lab RECC overlay (cosmic) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py /src \
+            --project-kind cosmic \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
           PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cat >> /tmp/buildstream-cluster.conf <<EOF

--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -275,13 +275,32 @@ spec:
             fi
           done
 
-          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|"}{.status.containerStatuses[*].ready}{"\n"}{end}')"
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
           for NODE in ghost exo-0; do
-            if ! grep -Eq "^${NODE}\|Running\|true true$" <<<"${WORKERS}"; then
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
               echo "USB4 BuildBarn gate rejected: no Ready worker on ${NODE}" >&2
               exit 1
             fi
           done
+
+          # Mandatory nested RECC admission, checked before the expensive
+          # build work: the lab-owned overlay refuses every mandatory-RECC
+          # lane while no BuildBarn runner consumes BuildStream's
+          # remoteApisSocketPath. Probe the deployed runner configuration so
+          # this lane fails here with an actionable message instead of
+          # silently running with outer remote execution only. Restoring an
+          # outer-RE-only build is a deliberate GitOps rollback, not a normal
+          # path; see docs/reference/recc-runner-seam.md.
+          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
+          # Match a real jsonnet field, not the explanatory comments.
+          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
+            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
+            exit 1
+          fi
+          echo "Nested RECC runner capability observed in buildbarn-config"
 
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
@@ -420,6 +439,8 @@ spec:
                 path: remote-execution.conf
               - key: recc-environment.conf
                 path: recc-environment.conf
+              - key: apply_recc_overlay.py
+                path: apply_recc_overlay.py
       script:
         image: "{{inputs.parameters.registry}}/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d"
         command: [bash]
@@ -438,6 +459,11 @@ spec:
           # error, so use `copy-or-link` here.
           - name: BUILDBOX_STAGER
             value: copy-or-link
+          - name: RECC_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: buildstream-remote-cache
+                key: recc-endpoint
           - name: XDG_CACHE_HOME
             # Reuse persistent node-local cache on the XFS mount for fast
             # coordinator state and local artifact reuse across workflows.
@@ -566,6 +592,18 @@ spec:
           else
             echo "WARN: unable to clone freedesktop-sdk upstream patch repo; continuing without patch sync"
           fi
+
+          echo "=== Applying lab RECC overlay (dakota) ==="
+          # Mandatory admission, no mode flags: the shared overlay refuses this
+          # lane while nested RECC is unavailable, and this lane must fail
+          # closed rather than continue with outer remote execution only.
+          # --runner-capability may only be added once a BuildBarn runner is
+          # proven to honor BuildStream's remoteApisSocketPath, and
+          # --pilot-cache-only is operator-only for the prototype baseline.
+          python3 /etc/buildstream/apply_recc_overlay.py /src \
+            --project-kind dakota \
+            --endpoint "${RECC_ENDPOINT}" \
+            --json
 
           PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
           cat >> /tmp/buildstream-cluster.conf <<EOF

--- a/manifests/buildbarn-config.yaml
+++ b/manifests/buildbarn-config.yaml
@@ -302,4 +302,12 @@ data:
       // Keep this config aligned with bb_runner ApplicationConfiguration fields.
       chrootIntoInputRoot: true,
       runCommandsAs: { userId: 0, groupId: 0 },
+      // Outer BuildBarn worker readiness is deliberately NOT gated on the
+      // pod-local RECC preparation socket. No runner consumes
+      // remoteApisSocketPath yet, so the socket is unused by outer remote
+      // execution; coupling admission to it would take both workers out of
+      // service for a capability nothing depends on. The recc-casd sidecar
+      // keeps its own readiness/liveness probes on that socket, which is the
+      // separate health boundary. Add readinessCheckingPathnames back only
+      // when a runner actually stages that socket into action sandboxes.
     }

--- a/manifests/buildbarn-worker.yaml
+++ b/manifests/buildbarn-worker.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         app: worker
       annotations:
-        buildbarn-config-revision: "2026-07-23-1"
+        buildbarn-config-revision: "2026-07-30-recc-seam"
         prometheus.io/scrape: "true"
         prometheus.io/port: "9980"
     spec:
@@ -48,7 +48,7 @@ spec:
           command:
             - sh
             - -c
-            - mkdir -pm 0777 /worker/build && mkdir -pm 0700 /worker/cache && mkdir -p /worker/dev && chmod 0777 /worker && (mknod -m 666 /worker/dev/null c 1 3 || test -c /worker/dev/null) && (mknod -m 666 /worker/dev/zero c 1 5 || test -c /worker/dev/zero) && (mknod -m 666 /worker/dev/random c 1 8 || test -c /worker/dev/random) && (mknod -m 666 /worker/dev/urandom c 1 9 || test -c /worker/dev/urandom) && ln -sfn /proc/self/fd/0 /worker/dev/stdin && ln -sfn /proc/self/fd/1 /worker/dev/stdout && ln -sfn /proc/self/fd/2 /worker/dev/stderr
+            - mkdir -pm 0777 /worker/build && mkdir -pm 0700 /worker/cache && mkdir -pm 0770 /worker/recc-casd && mkdir -p /worker/dev && chmod 0777 /worker && (mknod -m 666 /worker/dev/null c 1 3 || test -c /worker/dev/null) && (mknod -m 666 /worker/dev/zero c 1 5 || test -c /worker/dev/zero) && (mknod -m 666 /worker/dev/random c 1 8 || test -c /worker/dev/random) && (mknod -m 666 /worker/dev/urandom c 1 9 || test -c /worker/dev/urandom) && ln -sfn /proc/self/fd/0 /worker/dev/stdin && ln -sfn /proc/self/fd/1 /worker/dev/stdout && ln -sfn /proc/self/fd/2 /worker/dev/stderr
           volumeMounts:
             - mountPath: /worker
               name: worker
@@ -98,6 +98,59 @@ spec:
               name: fuse
             - mountPath: /bb
               name: bb-runner-bin
+        - name: recc-casd
+          # This is the existing BuildStream image contract: it contains the
+          # LocalCAS proxy used by the lab's historical buildbox-casd manifest.
+          # The current bb_runner still cannot consume remoteApisSocketPath;
+          # this sidecar only makes the worker-local endpoint available for a
+          # compatible runner image.
+          image: 192.168.1.102:30500/bst2@sha256:ce272e0ae4b59251680b8a70645740640ced17689e21268ddc037614c755f734
+          imagePullPolicy: IfNotPresent
+          # PATH lookup, not an absolute path: the bst2 image install prefix
+          # is not pinned by anything in this repo, and the lab's historical
+          # buildbox-casd manifest resolved the binary through PATH against
+          # the same image family. Only pin an absolute path once the pinned
+          # digest is proven to ship it there.
+          command: [buildbox-casd]
+          args:
+            - --cas-remote=grpc://frontend.buildbarn.svc.cluster.local:8980
+            - --ac-remote=grpc://frontend.buildbarn.svc.cluster.local:8980
+            - --exec-remote=grpc://frontend.buildbarn.svc.cluster.local:8980
+            - --bind=unix:/run/buildbarn/recc/casd.sock
+            - --unix-socket-mode=0660
+            - --quota-high=8G
+            - --quota-low=6G
+            - /worker/recc-casd
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            exec:
+              command: [test, -S, /run/buildbarn/recc/casd.sock]
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command: [test, -S, /run/buildbarn/recc/casd.sock]
+            periodSeconds: 15
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /run/buildbarn/recc
+              name: nested-reapi
+            - mountPath: /worker
+              name: worker
         - name: runner
           image: cgr.dev/chainguard/wolfi-base@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795
           command: [/bb/bb_runner, /config/runner.jsonnet]
@@ -139,8 +192,15 @@ spec:
               name: fuse
             - mountPath: /bb
               name: bb-runner-bin
+            - mountPath: /run/buildbarn/recc
+              name: nested-reapi
       volumes:
         - name: bb-runner-bin
+          emptyDir: {}
+        # Pod-local only: the socket must never become a host or cluster
+        # endpoint. A future LocalCAS-capable runner can stage this endpoint
+        # into the BuildStream sandbox without hostPID or hostIPC.
+        - name: nested-reapi
           emptyDir: {}
         - name: fuse
           hostPath:


### PR DESCRIPTION
Include the production RECC admission gates, worker-local `recc-casd` sidecar, and pod-local socket preparation. Nested execution remains blocked until a capable upstream runner is proven.