### PR TITLE
fix(recc): enable nested sandbox mounts

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -88,6 +88,10 @@ spec:
       script:
         image: 192.168.1.102:30500/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
         command: [bash]
+        securityContext:
+          privileged: true
+          seLinuxOptions:
+            type: spc_t
         resources:
           requests:
             cpu: "1"

--- a/tests/unit/test_recc_baseline_workflow.py
+++ b/tests/unit/test_recc_baseline_workflow.py
@@ -72,6 +72,10 @@ def test_parameters_target_recc_baseline_and_fail_closed_provider_defaults():
 
 def test_buildstream_cache_is_ephemeral_and_no_host_usr_is_mounted():
     run = _run_template()
+    assert run["script"]["securityContext"] == {
+        "privileged": True,
+        "seLinuxOptions": {"type": "spc_t"},
+    }
     volumes = {volume["name"]: volume for volume in run["volumes"]}
     assert "ephemeral" in volumes["bst-cache"]
     assert (


### PR DESCRIPTION
Run the isolated `bst2` pilot with the same privileged bubblewrap runtime contract used by the existing lab BuildStream lanes. This fixes `bwrap: Can't mount proc on /newroot/proc`.