### PR TITLE
feat(recc): export compiler metrics from the fixture

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -451,7 +451,7 @@ spec:
               printf '%s phase: failed (exit %s)\n' "${phase}" "${rc}" >> "${phase_log}"
               printf -v "${status_var}" '%s' failed
             fi
-            grep -Eio '(^|[[:space:]\[\(])RECC(_VERBOSE)?([[:space:]:\]\)]|$).*' \
+            grep -Eio '(^|[[:space:]\[\(])RECC(_VERBOSE|_METRICS)?([[:space:]:\]\)]|$).*' \
               "${phase_log}" > "${phase_raw_recc}" || true
             {
               printf '=== BEGIN RECC_VERBOSE LOG ===\n'

--- a/bst-prototype/elements/recc-baseline.bst
+++ b/bst-prototype/elements/recc-baseline.bst
@@ -28,6 +28,8 @@ environment:
       RECC_CAS_SERVER: grpc://frontend.buildbarn.svc.cluster.local:8980
       RECC_ACTION_CACHE_SERVER: grpc://frontend.buildbarn.svc.cluster.local:8980
       RECC_ACTION_UNCACHEABLE: "0"
+      RECC_ENABLE_METRICS: "1"
+      RECC_METRICS_FILE: "%{build-root}/recc-metrics.txt"
   - recc == "passthrough":
       RECC_PASSTHROUGH: "1"
   - recc == "cache-only":
@@ -55,6 +57,11 @@ config:
     run_cxx -std=c++17 -Wl,--build-id=none \
       "%{build-root}/message.o" "%{build-root}/main.o" \
       -o "%{build-root}/recc-baseline"
+    if [ -f "%{build-root}/recc-metrics.txt" ]; then
+      while IFS= read -r METRIC; do
+        printf '[RECC_METRICS] %s\n' "${METRIC}"
+      done < "%{build-root}/recc-metrics.txt"
+    fi
   install-commands:
   - |
     set -eu

--- a/scripts/collect_recc_run.py
+++ b/scripts/collect_recc_run.py
@@ -47,7 +47,7 @@ BUILDBARN_CAS_METRICS = (
 )
 
 RECC_PREFIX = re.compile(
-    r"^\s*(?:\[(?:RECC|RECC_VERBOSE)\]|(?:RECC|RECC_VERBOSE)"
+    r"^\s*(?:\[(?:RECC|RECC_VERBOSE|RECC_METRICS)\]|(?:RECC|RECC_VERBOSE|RECC_METRICS)"
     r"(?:\s*[:|]|\s+))\s*(?P<body>.*)$",
     re.IGNORECASE,
 )
@@ -244,6 +244,22 @@ def _extract_recc_text(text: str) -> tuple[str | None, str]:
     if not any(line.strip() for line in lines):
         return None, "RECC marker or dedicated section contained no evidence lines"
     return "\n".join(lines), ""
+
+
+RECC_STATSD = re.compile(
+    r"^\s*recc\.(?P<name>[A-Za-z0-9_]+):"
+    r"(?P<value>-?(?:\d+(?:\.\d*)?|\.\d+))\|(?P<kind>[a-z]+)"
+)
+
+
+def _parse_recc_statsd(text: str) -> dict[str, list[float]]:
+    metrics: dict[str, list[float]] = {}
+    for line in text.splitlines():
+        match = RECC_STATSD.match(line)
+        if not match:
+            continue
+        metrics.setdefault(match.group("name"), []).append(float(match.group("value")))
+    return metrics
 
 
 def _structured_recc_source(decoded: Any) -> tuple[dict[str, Any] | None, str]:
@@ -632,9 +648,38 @@ def parse_recc_verbose(text: Any) -> dict[str, Any]:
         "link_seconds": _duration_from_mapping(
             timings_source, "link_seconds", "link", "link_duration"
         ),
+        "metrics": None,
     }
 
     if not source and isinstance(text, str) and text:
+        statsd = _parse_recc_statsd(text)
+        if statsd:
+            values["metrics"] = {
+                name: sum(samples) for name, samples in sorted(statsd.items())
+            }
+            for metric_name, field in (
+                ("action_cache_hit", "cache_hits"),
+                ("action_cache_miss", "cache_misses"),
+                ("fallback", "local_fallbacks"),
+            ):
+                if metric_name in statsd:
+                    values[field] = sum(statsd[metric_name])
+            if values["cache_hits"] is not None or values["cache_misses"] is not None:
+                values["action_count"] = sum(
+                    value or 0
+                    for value in (values["cache_hits"], values["cache_misses"])
+                )
+            compile_values = [
+                value
+                for metric_name in (
+                    "execute_local_no_action_result",
+                    "execute_local_with_action_result",
+                    "execute_remote_with_action_result",
+                )
+                for value in statsd.get(metric_name, [])
+            ]
+            if compile_values:
+                values["compile_seconds"] = sum(compile_values) / 1000
         lines = text.splitlines()
         detected_started_actions = 0
         detected_completed_actions = 0

--- a/tests/unit/test_collect_recc_run.py
+++ b/tests/unit/test_collect_recc_run.py
@@ -138,6 +138,26 @@ def test_recc_dedicated_section_is_accepted_without_per_line_markers():
     assert result["state"] == "available"
 
 
+def test_recc_statsd_metrics_provide_action_cache_evidence():
+    result = collector.parse_recc_verbose(
+        """
+        === BEGIN RECC_VERBOSE LOG ===
+        [RECC_METRICS] recc.action_cache_hit:2|c
+        [RECC_METRICS] recc.action_cache_miss:1|c
+        [RECC_METRICS] recc.fallback:1|c
+        [RECC_METRICS] recc.execute_local_no_action_result:125|ms
+        === END RECC_VERBOSE LOG ===
+        """
+    )
+
+    assert result["action_count"] == 3
+    assert result["cache_hits"] == 2
+    assert result["cache_misses"] == 1
+    assert result["local_fallbacks"] == 1
+    assert result["compile_seconds"] == 0.125
+    assert result["state"] == "available"
+
+
 def test_prometheus_names_are_discovered_and_deltas_are_label_aware():
     before = """
     # HELP bb_actions_total actions


### PR DESCRIPTION
Persist RECC StatsD metrics in the BuildStream log without changing the artifact, and parse action-cache hits, misses, fallbacks, and compile timing into the evidence record.