### PR TITLE
fix(recc): expose sandbox metrics through install root

### DIFF
--- a/bst-prototype/elements/recc-baseline.bst
+++ b/bst-prototype/elements/recc-baseline.bst
@@ -29,7 +29,7 @@ environment:
       RECC_ACTION_CACHE_SERVER: grpc://frontend.buildbarn.svc.cluster.local:8980
       RECC_ACTION_UNCACHEABLE: "0"
       RECC_ENABLE_METRICS: "1"
-      RECC_METRICS_FILE: "%{build-root}/recc-metrics.txt"
+      RECC_METRICS_FILE: "%{install-root}/recc-metrics.txt"
   - recc == "passthrough":
       RECC_PASSTHROUGH: "1"
   - recc == "cache-only":
@@ -57,10 +57,11 @@ config:
     run_cxx -std=c++17 -Wl,--build-id=none \
       "%{build-root}/message.o" "%{build-root}/main.o" \
       -o "%{build-root}/recc-baseline"
-    if [ -f "%{build-root}/recc-metrics.txt" ]; then
+    if [ -f "%{install-root}/recc-metrics.txt" ]; then
       while IFS= read -r METRIC; do
         printf '[RECC_METRICS] %s\n' "${METRIC}"
-      done < "%{build-root}/recc-metrics.txt"
+      done < "%{install-root}/recc-metrics.txt"
+      rm -f "%{install-root}/recc-metrics.txt"
     fi
   install-commands:
   - |


### PR DESCRIPTION
Route RECC StatsD output through the BuildStream install-root mount, print it before removing it, and keep the final artifact unchanged. This makes cache-hit/miss evidence visible to the workflow collector.