### PR TITLE
fix(recc): create metrics output mount

### DIFF
--- a/bst-prototype/elements/recc-baseline.bst
+++ b/bst-prototype/elements/recc-baseline.bst
@@ -43,6 +43,7 @@ config:
   - |
     set -eu
     mkdir -p "%{build-root}"
+    mkdir -p "%{install-root}"
     run_cxx() {
       if [ -n "${CXX_LAUNCHER}" ]; then
         "${CXX_LAUNCHER}" "${CXX}" "$@"


### PR DESCRIPTION
Create the BuildStream install-root mount before RECC emits StatsD metrics, so the sandbox can write the file that the fixture prints into the workflow evidence log.