### PR TITLE
docs(recc): align all current lab guidance

### DIFF
--- a/docs/adr/0006-elastic-bst-build-grid.md
+++ b/docs/adr/0006-elastic-bst-build-grid.md
@@ -91,10 +91,14 @@ matches the user policy of scheduler-driven, no-pinning placement.
 - The `workflow-controller` PriorityClass on the worker is unchanged. Large
   `bst-build` pods (PriorityClass `bst-build`, higher) can still preempt a
   worker if a node is overcommitted.
-- Fine-grained C/C++ compilation distribution is enabled via RECC (`recc` wrapper)
-  targeting `frontend.buildbarn.svc.cluster.local:8980` (following GNOME `gnome-build-meta!4704`
-  and FreeDesktop-SDK `freedesktop-sdk#1961`), fanning out compiler commands across
-  the active worker pool.
+- Fine-grained C/C++ compilation distribution is prepared through the isolated
+  RECC pilot (`recc` wrapper) targeting
+  `frontend.buildbarn.svc.cluster.local:8980`, following GNOME
+  `gnome-build-meta!4704` and FreeDesktop-SDK `freedesktop-sdk#1961`. Production
+  lanes do not enable nested RECC until the pinned runner consumes
+  `remoteApisSocketPath` and the pilot produces trustworthy action-level
+  evidence. See `docs/reference/recc-baseline.md` and
+  `docs/research/2026-07-31-recc-run-results.md`.
 
 ## Connection to the onboarding mission
 

--- a/docs/research/2026-07-30-recc-buildstream-buildbarn.md
+++ b/docs/research/2026-07-30-recc-buildstream-buildbarn.md
@@ -1,0 +1,227 @@
+# RECC with BuildStream and BuildBarn
+
+## Executive summary
+
+RECC is a compiler launcher for the Remote Execution API (REAPI). BuildStream
+uses REAPI at element granularity; RECC adds a second, finer-grained layer
+inside a BuildStream element by caching and distributing individual C/C++
+compile (and optionally link) actions.
+
+The GNOME presentation explicitly describes this model: BuildStream caches
+whole builds, while RECC caches individual files and can run as a nested
+remote-execution client inside a BuildStream sandbox. The accompanying
+Mastodon post says the integration is already used by `gnome-build-meta` and
+points to BuildStream issue #1751 and GNOME MR !4704.
+
+The lab now has an isolated operator-only RECC cache pilot. Production
+BuildStream, QA, and warmup lanes remain fail-closed: the pinned BuildBarn
+runner does not implement the `remoteApisSocketPath`/LocalCAS handoff required
+for nested RECC. The pilot pins a freedesktop-sdk compiler/provider junction,
+uses a privileged `bst2` script container for bubblewrap, and records
+BuildStream/BuildBarn evidence. See
+`docs/research/2026-07-31-recc-run-results.md` for measured runs and their
+explicit RECC-metric limitation.
+
+## What RECC does
+
+For a compiler command, RECC:
+
+1. hashes the command, inputs, environment, and declared outputs;
+2. checks the REAPI action cache;
+3. downloads a cached object file when available;
+4. otherwise executes locally or submits the compile action to a remote worker;
+5. stores the result in the remote cache.
+
+This complements rather than replaces BuildStream:
+
+- **BuildStream:** distributes complete element builds and caches element
+  artifacts.
+- **RECC:** distributes individual C/C++ compiler invocations inside one
+  element.
+- **Linking:** remains local unless explicitly enabled with `RECC_LINK`; large
+  link steps may therefore remain the critical path.
+- **Rust and other languages:** receive no benefit unless an equivalent
+  compiler wrapper exists.
+
+Sources:
+
+- GNOME `State of GNOME OS` slide 24:
+  <https://events.gnome.org/event/306/contributions/1637/attachments/897/1597/presentation.pdf>
+- RECC documentation:
+  <https://buildgrid.gitlab.io/recc/>
+- BuildStream issue #1751:
+  <https://github.com/apache/buildstream/issues/1751>
+
+## What GNOME actually shipped
+
+GNOME MR !4704 adds a complete BuildStream integration:
+
+- `include/recc.yml` adds `/usr/recc/bin` to `PATH`, points RECC at the local
+  `unix:/tmp/casd.sock`, enables nested remote execution, and defines explicit
+  modes:
+  `passthrough`, `cache-only`, `remote-execution`, and
+  `upload-local-build`.
+- `elements/buildsystems/recc-wrapper.bst` installs the wrapper and links
+  compiler names such as `gcc`, `g++`, `clang`, and `clang++` to it.
+- `include/gcc-for-recc.yml` and `include/clang-for-recc.yml` use
+  BuildStream's `digest-environment` to export the compiler dependency tree
+  digest as `RECC_REMOTE_PLATFORM_chrootRootDigest`.
+- `project.conf` exposes the `recc` option and defaults it to
+  `remote-execution`.
+- A later GNOME optimization commit enables `RECC_USE_LOCALCAS` and
+  `RECC_USE_JOBSERVER` behind a `recc_optimisations` option.
+
+The wrapper refuses to run unless
+`RECC_REMOTE_PLATFORM_chrootRootDigest` is present. This prevents remote
+compilation from using a worker with the wrong compiler/sysroot.
+
+Sources:
+
+- MR metadata and benchmark:
+  <https://gitlab.gnome.org/api/v4/projects/GNOME%2Fgnome-build-meta/merge_requests/4704>
+- MR file changes:
+  <https://gitlab.gnome.org/api/v4/projects/GNOME%2Fgnome-build-meta/merge_requests/4704/changes>
+- Current GNOME `include/recc.yml`:
+  <https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/master/include/recc.yml>
+- Current GNOME `recc-wrapper.bst`:
+  <https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/master/elements/buildsystems/recc-wrapper.bst>
+
+GNOME's published comparison is important for rollout planning:
+
+| Mode | Build time |
+| --- | ---: |
+| No RECC | 1h31m |
+| RECC, cold cache | 2h50m |
+| RECC, warm cache | 50m |
+
+RECC can therefore make a warm incremental build faster while making a cold
+build substantially slower. GNOME specifically calls out RECC overhead,
+`RECC_USE_LOCALCAS`, unconverted freedesktop-sdk elements, and Rust as current
+limitations.
+
+## Current lab state
+
+The active `bst2` contract contains:
+
+- `bst --version`: 2.7.0
+- `recc --version`: 1.3.53
+- `buildbox-casd`: present
+- BuildBarn frontend: `grpc://frontend.buildbarn.svc.cluster.local:8980`
+
+The shared ConfigMap contains:
+
+```yaml
+RECC_SERVER: "frontend.buildbarn.svc.cluster.local:8980"
+RECC_CAS_SERVER: "frontend.buildbarn.svc.cluster.local:8980"
+RECC_ACTION_CACHE_SERVER: "frontend.buildbarn.svc.cluster.local:8980"
+RECC_ACTION_UNCACHEABLE: "0"
+RECC_PROJECT_ROOT: "/workspace"
+RECC_VERBOSE: "1"
+```
+
+The operator pilot adds the checkout-local wrapper, GCC
+`digest-environment`, pinned GCC/RECC provider, and a deterministic two-compile
+fixture. The production lanes mount the same preparation contract but refuse
+before build work until a capable runner is proven. The pilot's first
+successful runs measured outer BuildStream and BuildBarn timings/CAS deltas;
+RECC action-level fields remain unavailable because the sandbox metrics-file
+handoff has not been proven.
+
+## BuildBarn blocker
+
+BuildStream 2.6 introduced the exact two features needed for nested RECC:
+
+- `remote-apis-socket`: expose a worker-local REAPI socket inside the sandbox.
+- `digest-environment`: export a dependency tree digest to the sandbox.
+
+BuildStream's BuildBox sandbox sends `remoteApisSocketPath` as an action
+platform property. BuildBox's own runner supports that property when LocalCAS
+is enabled and passes the socket to the staged sandbox.
+
+The lab's current BuildBarn `bb_runner` configuration only enables
+`chrootIntoInputRoot`; its worker platform advertises only `ISA=x86-64` and
+`OSFamily=linux`. The current upstream `bb-remote-execution` source contains no
+`remoteApisSocketPath` implementation. Therefore simply adding the GNOME
+project config will not work reliably: the BuildBarn runner must first gain a
+worker-local LocalCAS socket and honor the nested socket platform property.
+
+Relevant sources:
+
+- BuildStream 2.6 release notes:
+  <https://raw.githubusercontent.com/apache/buildstream/master/NEWS>
+- BuildStream sandbox implementation in the active image:
+  `/usr/lib/python3.13/site-packages/buildstream/sandbox/_sandboxbuildboxrun.py`
+- BuildBox nested socket implementation:
+  <https://gitlab.com/BuildGrid/buildbox/-/blob/master/common/buildboxcommon_runner.cpp>
+- Lab BuildBarn worker configuration:
+  `manifests/buildbarn-config.yaml`
+  and `manifests/buildbarn-worker.yaml`
+
+## Recommended adoption path
+
+### Phase 1: prove the cache path without remote compile — completed
+
+The lab built the isolated `recc-baseline.bst` fixture with
+`recc=cache-only`. This validated:
+
+- compiler wrapper installation;
+- stable output digest;
+- BuildStream and BuildBarn evidence capture.
+
+The run did not produce trustworthy RECC action-cache hit/miss fields, so the
+results do not claim RECC cache effectiveness.
+
+### Phase 2: add nested REAPI support to the worker
+
+Choose one of these implementation paths:
+
+1. **Preferred:** run a BuildBox LocalCAS-capable runner for BuildStream actions,
+   with a worker-local `buildbox-casd` socket backed by the lab BuildBarn
+   frontend.
+2. **Alternative:** extend or replace `bb_runner` so it recognizes
+   `remoteApisSocketPath`, stages the socket, and exposes it at the requested
+   path.
+3. **Fallback for experiments only:** run RECC against the BuildBarn frontend
+   over a network path from inside the sandbox. This weakens the sandbox
+   boundary and is not the desired production design.
+
+The worker must advertise and honor the nested socket capability before the
+BuildStream project enables `remote-apis-socket`.
+
+### Phase 3: consume upstream GNOME integration
+
+Once the worker path works, use the upstream GNOME files rather than copying
+them into the lab:
+
+- update the GNOME junction/ref used by the Dakota/Cosmic projects;
+- enable `recc=remote-execution`;
+- enable `recc_optimisations` only after baseline measurements;
+- make sure the BuildStream image includes `recc`, `buildbox-casd`, and the
+  wrapper runtime dependency.
+
+The lab workflow should append only the outer project remote-execution config;
+the nested RECC policy belongs in the upstream BuildStream project.
+
+### Phase 4: benchmark before broad rollout — partially completed
+
+Measure separately:
+
+1. BuildStream only, cold cache.
+2. BuildStream only, warm cache.
+3. RECC cache-only, cold and warm.
+4. RECC nested remote execution, cold and warm.
+5. RECC with and without `RECC_USE_LOCALCAS`.
+
+The control and cache-only runs collected total wall time, deterministic output
+digest, and BuildBarn CAS deltas. RECC action-level metrics remained
+`unavailable`, so no rollout decision can be based on RECC hit/miss or
+compiler-time improvement yet. Nested remote execution was not measured.
+
+## Bottom line
+
+RECC is the right mechanism for the specific problem of large BuildStream
+elements whose internal C/C++ compilation is not parallel enough at element
+granularity. It is not a fix for the current one-slot workflow semaphore or
+upstream source-fetch latency. The lab already has the client binary, but the
+nested worker socket path is missing; that infrastructure seam must be solved
+before enabling the upstream GNOME integration.

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -92,6 +92,14 @@ The workflow authoring guidance is split by topic:
   that consumes it — especially disk/image and host-root parameters. Trace
   every contract parameter through the call-site arguments.
 - Any `script:` template without `resources:` limits
+- The isolated `recc-baseline-pipeline` script missing
+  `privileged: true` with `seLinuxOptions.type: spc_t`; BuildStream's
+  bubblewrap sandbox then fails mounting `/newroot/proc` before compiler
+  execution. This privilege is for the pilot sandbox only and does not prove
+  nested RECC runner support.
+- A production lane passing `--pilot-cache-only` or `--runner-capability`
+  without the corresponding isolated-pilot boundary and live
+  `remoteApisSocketPath` proof.
 - Templates in `argo/workflow-templates/` applied with `kubectl apply` (not via git)
 - A `pr-poller` (or any PR-gating workflow) that skips on ANY existing commit status — it must skip only `pending` (in-flight) and `success` (already passed), and re-test on `error`/`failure`. Skipping `error` means stale statuses from deleted workflows permanently block retests.
 - A VM or build pipeline that uses a node selector to reach local storage. Use
@@ -205,6 +213,12 @@ Before marking any WorkflowTemplate change done:
 - [ ] File name matches `metadata.name` (e.g. `provision-containerdisk-vm.yaml` for `name: provision-containerdisk-vm`)
 - [ ] Any VM pipeline semaphore is justified by documented cross-workflow
       memory contention and is attached at template level, not workflow scope
+- [ ] The isolated RECC pilot uses the privileged `bst2` sandbox contract and
+      its live template has been re-read after GitOps reconciliation
+- [ ] RECC evidence keeps missing action-level fields unavailable; a successful
+      outer BuildStream build is not reported as nested RECC success
+- [ ] Production RECC lanes remain fail-closed until the runner's
+      `remoteApisSocketPath`/LocalCAS handoff is proven by a canary
 - [ ] VM pipeline spec has `activeDeadlineSeconds` (1h or 2h) so stuck VMs self-evict
 - [ ] No `nodeSelector: kubernetes.io/hostname: ghost` in VM specs — VMs float to any KubeVirt-capable node
 - [ ] GitHub Contents API write-backs use curl+jq, not inline Python; output is

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -206,16 +206,28 @@ permitted`. This requirement is specific to the pilot container; it does not
 enable nested RECC or relax the production runner admission gate.
 
 **RECC (Remote Execution C/C++ Compiler) integration:**
-The build grid supports fine-grained C/C++ compiler distribution via RECC
-(`recc` wrapper) following GNOME `gnome-build-meta` MR 4704 (`!4704`) and
-FreeDesktop-SDK work item 1961 (`freedesktop-sdk#1961`).
+The lab has a checkout-local RECC overlay and worker-local `buildbox-casd`
+preparation seam. The isolated operator pilot is the only supported cache
+experiment; production BuildStream/QA/warmup lanes fail closed until a pinned
+runner demonstrably consumes BuildStream's `remoteApisSocketPath` and stages
+the pod-local LocalCAS socket.
 - **Macro level:** BuildStream schedules element builds across BuildBarn workers.
-- **Micro level (RECC):** C/C++ compilation commands (`gcc`, `g++`, `clang`)
-  inside build elements fan out as parallel remote execution actions directly
-  to `frontend.buildbarn.svc.cluster.local:8980`.
-- **Configuration:** Injected via `recc-environment.conf` ConfigMap in
-  `manifests/buildstream-remote-cache-config.yaml` (`RECC_SERVER=frontend.buildbarn.svc.cluster.local:8980`,
-  `RECC_PROJECT_ROOT=/workspace`, `RECC_PREFIX=recc`).
+- **Micro level (RECC):** RECC can cache or distribute individual C/C++
+  compiler invocations inside one element; it is distinct from outer
+  BuildStream remote execution. Linking and non-C++ toolchains remain local
+  unless separately wrapped.
+- **Configuration:** `recc-environment.conf` supplies the shared server,
+  CAS, action-cache, project-root, and policy values. Toolchain elements must
+  supply `RECC_REMOTE_PLATFORM_chrootRootDigest`; the lab does not invent a
+  global digest or set `RECC_PREFIX`.
+- **Pilot:** Run `just run-recc-baseline mode=cache-only cache-policy=both`.
+  Keep the source revision, pinned freedesktop-sdk provider, `bst2` image,
+  and worker set fixed. See `docs/reference/recc-baseline.md` and the measured
+  results in `docs/research/2026-07-31-recc-run-results.md`.
+- **Evidence boundary:** A successful outer BuildStream build is not RECC
+  evidence. The collector preserves missing RECC action fields as
+  `unavailable`; current runs have real BuildStream/BuildBarn timing and CAS
+  data but no trustworthy RECC hit/miss metrics.
 
 ### 1. Shared Buildbarn frontend
 - **Endpoint**: `grpc://frontend.buildbarn.svc.cluster.local:8980`


### PR DESCRIPTION
Update the RECC research note, BuildStream/Argo skills, and ADR 0006 to match the merged operator pilot, measured run results, explicit evidence limitations, privileged sandbox contract, and fail-closed nested-runner gate.