### PR TITLE
docs: align lab docs with current QA paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ labels: bug
 
 - Variant: <!-- latest / lts -->
 - GNOME Shell version: <!-- e.g. 50.1 -->
-- Workflow: <!-- e.g. bluefin-titan-smoke-abc12 -->
+- Workflow: <!-- e.g. bluefin-qa-pipeline-abc12 -->
 
 ## Acceptance criteria
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,13 +5,15 @@ Use [`../AGENTS.md`](/AGENTS.md) for repo policy and architecture, and use [`../
 Keep only these repo-specific inline reminders:
 
 - Use `just` entrypoints first; do not duplicate command tables here.
-- No SSH to ghost or exo-1.
+- No SSH to ghost or exo-0.
 - KubeStellar Console is the sole private cluster-admin/single-pane UI for the
   canonical local `ghost` k3s topology; Astro stays public and read-only,
   Prometheus stays backend-only, and Grafana or parallel dashboard frameworks
   are out of scope.
 - No `kubectl apply` for `argo/workflow-templates/` or `manifests/`; edit git-tracked YAML and let ArgoCD reconcile it.
-- All test runs use ephemeral KubeVirt VMs — no persistent titan VMs. `just list-vms` should show empty when no workflows run.
+- VM-backed test runs use ephemeral KubeVirt VMs — no persistent titan VMs. Container-only
+  Bluefin/Dakota QA does not create VMs; `just list-vms` should show empty when no VM
+  workflows run.
 - After pushing a fix, verify the live template via `argo-mcp-get_workflow_template` before resubmitting — templates snapshot at submit time.
 - Never enable shell tracing in Argo scripts that call authenticated APIs; workflow logs must be inspected for secret redaction before being linked to PRs.
 - Treat `pr/needs-review` as a hard maintainer gate; `automerge` and `chore/deps` labels alone do not authorize a PR-batch run.

--- a/Justfile
+++ b/Justfile
@@ -65,14 +65,14 @@ setup-arc-github-secret pem="" app_id="" installation_id="" namespace="arc-runne
 
 # Force ArgoCD to sync now instead of waiting for the next poll interval
 argocd-sync:
-    argocd app sync testing-lab testing-lab-infra --timeout 120
-    argocd app wait testing-lab --health --timeout 120
-    argocd app wait testing-lab-infra --health --timeout 120
+    argocd app sync lab lab-infra --timeout 120
+    argocd app wait lab --health --timeout 120
+    argocd app wait lab-infra --health --timeout 120
 
 # Show ArgoCD sync status for the test suite
 argocd-status:
-    argocd app get testing-lab
-    argocd app get testing-lab-infra
+    argocd app get lab
+    argocd app get lab-infra
 
 # ── Test execution ───────────────────────────────────────────────────────────
 

--- a/Justfile
+++ b/Justfile
@@ -118,13 +118,6 @@ run-migration-test tag=image_tag:
         -n {{ argo_ns }} \
         --watch
 
-# One-time: write SSH banner on ghost.
-setup-ghost-ssh-banner:
-    argo submit --from workflowtemplate/setup-ghost-ssh-banner \
-        -n {{ argo_ns }} \
-        --wait --log
-
-
 # —— [REMOVED] titan VM recipes ——
 # run-titan-smoke, run-titan-system, run-titan-developer, run-titan-software,
 # setup-titan-fixtures, run-titan-disk-cleanup
@@ -246,11 +239,6 @@ run-otel-patch:
 # Clear stale podman containers-storage lock files on ghost (run when no BIB workflows active)
 run-ghost-cleanup:
     argo submit --from workflowtemplate/ghost-cleanup \
-      -n {{ argo_ns }} --wait --log
-
-# Set Strix Halo performance kernel args on ghost via rpm-ostree (reboot required after)
-run-kernel-args:
-    argo submit --from workflowtemplate/ghost-kernel-args \
       -n {{ argo_ns }} --wait --log
 
 # ── Dakota BST builds ────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ The lab continuously validates the core operating system family across multiple 
 | Image | Tag | Schedule / Trigger | Purpose / Suite |
 |---|---|---|---|
 | `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + 10-minute digest polling | Container-only: digest `smoke`; nightly `smoke,developer,system` |
-| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke,developer,system` |
+| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke` |
 | `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + 10-minute digest polling | Container-only: digest `smoke`; nightly `smoke,developer,system` |
-| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke,developer,system` |
+| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke` |
 | `ghcr.io/ublue-os/aurora` | `testing`, `stable` | Every 3 hours + OCI digest polling | KDE variant validation (system suite) |
 | `ghcr.io/frostyard/snow` | `latest` | Every 3 hours + on every OCI digest change | Snosi GNOME desktop profile (smoke/developer/system suites) |
 | `ghcr.io/projectbluefin/dakota` | `testing` | 10-minute digest polling; nightly trigger suspended | BuildStream (BST) flatcar-substrate variant; container-only QA after publication |

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ explicitly need KubeVirt (Flatcar, Knuckle, migration, and similar lanes).
 Everything is declared in git, reconciled by ArgoCD, and orchestrated by Argo
 Workflows. GitOps.
 
-This instance runs as the CI infrastructure for Project Bluefin — every image
-publication triggers a fully automated test run with zero human intervention:
+This instance runs as the CI infrastructure for Project Bluefin — selected image
+poll lanes trigger fully automated test runs with zero human intervention:
 image-poller checks the digest, compares it with stored state, fans out
 `run-container-tests`, publishes per-suite results back into this repo, and only
 then records the new digest. This is Bluefin Server's first usecase.
@@ -43,14 +43,17 @@ The lab continuously validates the core operating system family across multiple 
 
 | Image | Tag | Schedule / Trigger | Purpose / Suite |
 |---|---|---|---|
-| `ghcr.io/projectbluefin/bluefin` | `testing`, `stable` | Nightly 02:00 UTC + on every OCI digest change | Primary standard GNOME image (full suite) |
-| `ghcr.io/projectbluefin/bluefin-lts` | `testing`, `stable` | Nightly 02:30 UTC + on every OCI digest change | Long-term support GNOME enterprise target |
-| `ghcr.io/ublue-os/aurora` | `testing`, `stable` | Hourly OCI digest poll on upstream change | KDE variant validation (system suite) |
+| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + 10-minute digest polling | Primary standard GNOME image (container-only full suite) |
+| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | Stable standard GNOME image (container-only full suite) |
+| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + 10-minute digest polling | Long-term support GNOME target (container-only full suite) |
+| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | Stable long-term support GNOME target (container-only full suite) |
+| `ghcr.io/ublue-os/aurora` | `testing`, `stable` | Every 3 hours + OCI digest polling | KDE variant validation (system suite) |
 | `ghcr.io/frostyard/snow` | `latest` | Every 3 hours + on every OCI digest change | Snosi GNOME desktop profile (smoke/developer/system suites) |
-| `ghcr.io/projectbluefin/dakota` | `latest` | Nightly 03:00 UTC + on every BST build trigger | BuildStream (BST) flatcar-substrate variant; USB4-gated BuildBarn remote execution is mandatory |
+| `ghcr.io/projectbluefin/dakota` | `testing` | 10-minute digest polling; nightly trigger suspended | BuildStream (BST) flatcar-substrate variant; container-only QA after publication |
 
-**Image-poll trigger:** hourly CronWorkflows check the OCI registry digest against
-`image-polling-digests`. When the digest changes, `image-poller` fans out
+**Image-poll trigger:** image-poll CronWorkflows check OCI registry digests against
+`image-polling-digests` (10-minute lanes for Bluefin/LTS/Dakota; slower pollers for
+other images). When a digest changes, `image-poller` fans out
 `run-container-tests` and only persists the new digest after QA succeeds.
 
 **Result publication:** each selected `run-container-tests` lane writes
@@ -157,7 +160,6 @@ lab/
 │   │   ├── kubestellar-smoke-test.yaml   verify downsync + status upsync
 │   │   ├── kubestellar-platform-verify.yaml  ordered platform acceptance gate
 │   │   ├── ghost-cleanup.yaml           Clear stale podman lock files on ghost
-│   │   └── ghost-kernel-args.yaml       Set Strix Halo performance kernel args
 │   │
 │   ├── bootstrap/                    # ← NOT ArgoCD managed — run once to set up cluster
 │   │   ├── README.md                     bootstrap guide
@@ -185,10 +187,11 @@ lab/
 │   ├── pr-image-gc.yaml                  CronWorkflow: GC PR container images
 │   ├── image-poll-bluefin-testing.yaml   CronWorkflow: poll bluefin:testing digest
 │   ├── image-poll-bluefin-stable.yaml    CronWorkflow: poll bluefin:stable digest
+│   ├── image-poll-bluefin-main.yaml      CronWorkflow: poll bluefin:latest digest
 │   ├── image-poll-lts-testing.yaml       CronWorkflow: poll bluefin-lts:testing digest
 │   ├── image-poll-lts-stable.yaml        CronWorkflow: poll bluefin-lts:stable digest
+│   ├── image-poll-dakota.yaml             CronWorkflow: poll dakota:testing digest
 │   ├── image-poll-snosi-latest.yaml      CronWorkflow: poll snosi snow:latest digest
-│   ├── image-poll-common.yaml            CronWorkflow: poll common image digest
 │   ├── pr-label-poller.yaml              CronWorkflow: poll PR labels for CI gate
 │   ├── workflow-controller-configmap.yaml TTL patch (7d success, 30d failure)
 │   ├── argo-default-sa-rbac.yaml         Argo executor RBAC
@@ -296,7 +299,7 @@ just run-tests
 | Host | Role | Specs |
 |---|---|---|
 | ghost | k3s control-plane + KubeVirt compute | Ryzen AI MAX+ 395, 16c/32t, 64GB RAM |
-| exo-1 | k3s worker (workflow pods only) | — |
+| exo-0 | k3s worker | Framework Desktop |
 
 **Namespaces:**
 
@@ -373,7 +376,7 @@ See [`projectbluefin/testsuite`](https://github.com/projectbluefin/testsuite) fo
 
 ## Related Projects
 
-- [Project Bluefin](https://projectbluefin.io) — primary subject under test; this lab validates every image publish
+- [Project Bluefin](https://projectbluefin.io) — primary subject under test; selected image-poll lanes validate new digests
 - [ublue-os/bluefin](https://github.com/ublue-os/bluefin) — upstream Bluefin image builds
 - [Project Dakota](https://github.com/projectbluefin/dakota) — BST-built Bluefin variant; Dakota PRs use the lab-authoritative [Dakota PR review process](docs/skills/dakota-pr-review/SKILL.md) and `dakota-qa-pipeline`
 - [projectbluefin/testsuite](https://github.com/projectbluefin/testsuite) — shared behave suites and container QA inputs

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ The lab continuously validates the core operating system family across multiple 
 
 | Image | Tag | Schedule / Trigger | Purpose / Suite |
 |---|---|---|---|
-| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + 10-minute digest polling | Primary standard GNOME image (container-only full suite) |
-| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | Stable standard GNOME image (container-only full suite) |
-| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + 10-minute digest polling | Long-term support GNOME target (container-only full suite) |
-| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | Stable long-term support GNOME target (container-only full suite) |
+| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + 10-minute digest polling | Container-only: digest `smoke`; nightly `smoke,developer,system` |
+| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke,developer,system` |
+| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + 10-minute digest polling | Container-only: digest `smoke`; nightly `smoke,developer,system` |
+| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke,developer,system` |
 | `ghcr.io/ublue-os/aurora` | `testing`, `stable` | Every 3 hours + OCI digest polling | KDE variant validation (system suite) |
 | `ghcr.io/frostyard/snow` | `latest` | Every 3 hours + on every OCI digest change | Snosi GNOME desktop profile (smoke/developer/system suites) |
 | `ghcr.io/projectbluefin/dakota` | `testing` | 10-minute digest polling; nightly trigger suspended | BuildStream (BST) flatcar-substrate variant; container-only QA after publication |
@@ -177,8 +177,8 @@ lab/
 │   └── one-shot-delete-golden-disks.yaml  emergency: delete all golden disks to reclaim space
 │
 ├── manifests/                        # ← ArgoCD (lab-infra App) auto-syncs these
-│   ├── nightly-smoke.yaml                CronWorkflow: nightly latest @ 02:00 UTC
-│   ├── nightly-smoke-lts.yaml            CronWorkflow: nightly lts @ 02:30 UTC
+│   ├── nightly-smoke.yaml                CronWorkflow: nightly bluefin:testing @ 02:00 UTC
+│   ├── nightly-smoke-lts.yaml            CronWorkflow: nightly bluefin-lts:testing @ 02:30 UTC
 │   ├── nightly-dakota.yaml               CronWorkflow: nightly dakota @ 03:00 UTC
 │   ├── nightly-knuckle.yaml              CronWorkflow: nightly knuckle @ 03:30 UTC
 │   ├── orphan-vm-cleanup.yaml            CronWorkflow: clean orphaned VMs every 2h

--- a/argo/bootstrap/README.md
+++ b/argo/bootstrap/README.md
@@ -8,8 +8,10 @@ as runnable idempotent runbooks.
 
 ArgoCD with `prune: true` would delete a resource the moment it's removed from git.
 Bootstrap templates exist for long-term reference and re-execution (e.g., re-running
-`ghost-kernel-args` after an OS update, or `setup-ghost-ssh-banner` after reimaging).
-They belong in git as documentation and runbooks, not in the ArgoCD sync path.
+them during cluster setup). Host-level kernel and SSH changes are not bootstrap
+WorkflowTemplates; use the maintainer-approved host procedures for those operations.
+Bootstrap templates belong in git as documentation and runbooks, not in the ArgoCD
+sync path.
 
 ## Applying
 
@@ -27,8 +29,6 @@ kubectl apply -f argo/bootstrap/ -n argo
 | `install-cdi.yaml` | `install-cdi` | Install CDI (disk import support) | New cluster |
 | `install-kubevirt-manager.yaml` | `install-kubevirt-manager` | Web UI at NodePort :30180 | Optional |
 | `install-test-vms.yaml` | `install-test-vms` | Apply initial test VM manifests | After KubeVirt ready |
-| `ghost-kernel-args.yaml` | `ghost-kernel-args` | Strix Halo performance kernel args | New node / after OS update |
-| `setup-ghost-ssh-banner.yaml` | `setup-ghost-ssh-banner` | API-only SSH warning banner | New node |
 | `setup-otel.yaml` | `setup-otel` | Deploy observability stack | Optional |
 
 KubeStellar installation is owned by the `kubestellar-applications` ArgoCD
@@ -40,12 +40,6 @@ ArgoCD.
 
 ```bash
 argo submit --from workflowtemplate/<name> -n argo --wait --log
-```
-
-Example — re-run kernel arg tuning after a Bluefin update:
-```bash
-argo submit --from workflowtemplate/ghost-kernel-args -n argo --wait --log
-# Schedule reboot after completion
 ```
 
 ## Full setup sequence

--- a/docs/homelab-contracts.md
+++ b/docs/homelab-contracts.md
@@ -1,7 +1,7 @@
 # Homelab Validation Contracts
 
 This document defines the in-cluster workload validation contracts for the
-testing-lab QA factory. It covers the workload matrix (#57), shared-storage
+lab QA factory. It covers the workload matrix (#57), shared-storage
 and RWX limits (#62), storage observability surface (#70, #78), the
 fleet-client vs. cluster-node boundary (#72), the HTTPS service-exposure lane (#58), and the deferred non-core service follow-up for Home Assistant-class workloads (#69).
 
@@ -147,7 +147,7 @@ The lab hardware has two distinct roles that **must not be conflated**:
 
 | Role | Hosts | k3s member | KubeVirt capable | In scope for cluster workload validation |
 |---|---|---|---|---|
-| **Cluster node** | ghost, exo-1 | Yes | ghost only | Yes |
+| **Cluster node** | ghost, exo-0 | Yes | ghost only | Yes |
 | **Bootc client** | jorge's Bluefin laptop, other contributor machines | No | No | No |
 
 ### What this repo validates for bootc clients

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -5,42 +5,42 @@
 ## Architecture summary
 
 ```
-Git push / manual submit
+Git push / image digest change / manual submit
         │
         ▼
 Argo Workflow (argo namespace)
         │
-        ├─ ensure-disk (optional) ─► build or verify golden disk on ghost hostPath
-        ├─ provision-vm           ─► reflink golden disk into a per-run KubeVirt VM
-        ├─ run-gnome-tests        ─► runner pod clones repo, SSHes VM, executes qecore + behave
-        └─ teardown (onExit)      ─► delete VM + per-run hostDisk clone
+        ├─ bluefin-qa-pipeline  ─► run-container-tests inside the published OCI image
+        ├─ dakota-qa-pipeline   ─► run-container-tests inside the published OCI image
+        └─ explicit VM lanes    ─► provision, run, and tear down ephemeral KubeVirt VMs
 ```
 
 Two steady-state execution paths exist:
 
 | Path | Purpose | Persistent state |
 |---|---|---|
-| Titan fast path | Test-only iteration against always-on VMs | Titan disk under `/var/home/jorge/VMs/titans/...` |
-| Fresh VM path | Image and golden-disk validation | Golden disk under `/var/tmp/bluefin-golden/<tag>/disk.raw` |
+| Container-only Bluefin/Dakota path | Image and PR QA | No persistent VM or host-disk state |
+| Fresh VM path | Lanes that explicitly require KubeVirt | Golden disk under `/var/tmp/bluefin-golden/<tag>/disk.raw` |
 
 ## Cluster topology
 
 | Host | Role | IP | Notes |
 |---|---|---|---|
 | ghost | k3s control-plane + KubeVirt compute | `<ghost-ip>` | Runs VM workloads and Argo control-plane services |
-| exo-1 | k3s worker | `<exo-1-ip>` | Workflow pods only |
+| exo-0 | k3s worker | `<exo-0-ip>` | Build and workflow pods |
 | Argo UI | external entrypoint | `http://<ghost-ip>:32746` | Host-local service also exposed on port 2746 |
 | Loki | log aggregation | `http://<ghost-ip>:30100` | Captures workflow pod logs |
 | ArgoCD | GitOps controller | `https://<ghost-ip>` | Reconciles this repo into the cluster |
 
-All KubeVirt VMs are pinned to ghost. Workflow pods may land on ghost or exo-1 depending on template constraints.
+All KubeVirt VMs are pinned to ghost. Container QA runs on the control-plane seat on
+ghost; other workflow pods may land on exo-0 according to template constraints.
 
 ## GitOps ownership
 
 | Area | Source of truth | Reconciler |
 |---|---|---|
-| WorkflowTemplates | `argo/workflow-templates/*.yaml` | ArgoCD application `testing-lab` |
-| Cluster infra and CronWorkflows | `manifests/*.yaml` | ArgoCD application `testing-lab-infra` |
+| WorkflowTemplates | `argo/workflow-templates/*.yaml` | ArgoCD application `lab` |
+| Cluster infra and CronWorkflows | `manifests/*.yaml` | ArgoCD application `lab-infra` |
 | Operator entrypoints | `Justfile` | Local operator / MCP tooling |
 
 The repo is intentionally GitOps-first: cluster state should converge from git, not from manual template applies or node SSH.
@@ -49,8 +49,9 @@ The repo is intentionally GitOps-first: cluster state should converge from git, 
 
 - Use Kubernetes MCP and Argo MCP for workstation-side cluster reads and mutations.
 - Prefer the `just` entrypoints when they exist; they are the human-facing wrappers around the same API-driven workflow.
-- Do not SSH from a workstation into `ghost` or `exo-1` for inspection, recovery, or file transfer.
-- In-workflow SSH into test VMs and probe-pod-to-titan SSH remain valid because they originate inside the cluster and are part of the test harness, not node administration.
+- Do not SSH from a workstation into `ghost` or `exo-0` for inspection, recovery, or file transfer.
+- In-workflow SSH into explicit test VMs and probe-pod-to-guest SSH remain valid because
+  they originate inside the cluster and are part of the test harness, not node administration.
 
 ## Image, disk, and VM model
 
@@ -58,17 +59,16 @@ The repo is intentionally GitOps-first: cluster state should converge from git, 
 |---|---|---|---|
 | Golden disk (`latest`) | `/var/tmp/bluefin-golden/latest/disk.raw` | Fresh-VM pipeline | Built by `bib-build-and-push` |
 | Golden disk (`lts`) | `/var/tmp/bluefin-golden/lts/disk.raw` | Fresh-VM pipeline | Built by `bib-build-and-push` |
-| Titan Bluefin disk | `/var/home/jorge/VMs/titans/titan-bluefin/image/disk.raw` | `titan-bluefin` | Persistent fast-path disk |
-| Titan LTS disk | `/var/home/jorge/VMs/titans/image/disk.raw` | `titan-lts` | Persistent fast-path disk |
 | Per-run hostDisk clone | `/var/tmp/bluefin-golden/*-runs/...` | Provisioned fresh VMs | Removed by teardown or orphan cleanup |
 
 The SSH secret lives in the `bluefin-test-ssh-key` Kubernetes secret in namespace `argo`.
-Golden disks can be patched by workflow after key rotation; titan disk key refresh is intentionally human-gated. <!-- TODO: replace with MCP tool when available -->
+Golden-disk key rotation and other host-storage changes remain maintainer-gated.
 
 ## Test execution stack
 
 | Component | Responsibility |
 |---|---|
+| `run-container-tests` | Run Bluefin/Dakota GUI and contract suites inside the target OCI image |
 | `git-sync` initContainer | Clone the requested repo ref into the runner pod |
 | `run-gnome-tests` | Copy suites to the VM and orchestrate execution |
 | `qecore-headless` | Start the Wayland GNOME session inside the VM |
@@ -127,7 +127,7 @@ Argo Workflow (argo namespace)
 
 | Symptom | Root cause | Durable fix |
 |---|---|---|
-| `Permission denied (publickey)` during SSH wait | Golden disk or titan disk contains an old public key | Re-patch or rebuild the golden disk; escalate titan key refresh to a human operator |
+| `Permission denied (publickey)` during SSH wait | A fresh VM's golden disk contains an old public key | Re-patch or rebuild the golden disk; escalate host-storage changes to a human operator |
 | Workflow hangs before GUI steps start | VM boot or SSH readiness never completed | Inspect VMI readiness and runner logs, then re-run the appropriate recovery path |
 | `TypeError` involving `requireResult` | Stale dogtail step pattern | Replace with `findChildren(...)` or `findChild(..., retry=False)` |
 | Clock / quick-settings scenarios miss their targets | GNOME Shell AT-SPI geometry gap | Drive the interaction via `Shell.Eval` |
@@ -140,7 +140,7 @@ Argo Workflow (argo namespace)
 | Service-catalog deploy step fails with "No manifests found" | Lane directory missing `manifests.yaml` | Create `tests/service_catalog/<lane>/manifests.yaml` per the contract |
 | Service-catalog test step fails with "No test suite" | Lane directory missing under `tests/service_catalog/` | Create the lane test directory with at least one `test_*.py` file |
 | Service-catalog namespace stuck terminating | Finalizer or PVC not released | Check for stuck PVCs or pods with `kubectl get all -n <ns>`, delete manually if needed |
-| `testing-lab-infra` sync wedged "waiting for healthy state of DaemonSet/..." | A DaemonSet pod is unhealthy on some node (e.g. hostPath missing on that host), blocking every subsequent manifests/ change | Fix or scope the DaemonSet (capability-label nodeSelector), then terminate the stuck operation so ArgoCD retries: `kubectl patch application testing-lab-infra -n argocd --type=merge -p '{"status":{"operationState":{"phase":"Terminating"}}}'` |
+| `lab-infra` sync wedged "waiting for healthy state of DaemonSet/..." | A DaemonSet pod is unhealthy on some node (e.g. hostPath missing on that host), blocking every subsequent manifests/ change | Fix or scope the DaemonSet (capability-label nodeSelector), then terminate the stuck operation so ArgoCD retries: `kubectl patch application lab-infra -n argocd --type=merge -p '{"status":{"operationState":{"phase":"Terminating"}}}'` |
 | KubeStellar app sync stuck at kubeflex-controller-manager | Postgres hook deadlock under ArgoCD | Keep `installPostgreSQL: false` + separate `kubestellar-postgres` app; see `docs/skills/kubestellar/SKILL.md` |
 | Workflow pod rejected `failed quota: argo-quota` | Template missing resources requests/limits | Add explicit cpu+memory requests and limits to every container/script |
 | Lab QA ran but no `testing-lab / <repo>` Check Run appears on the factory PR | Half-enrolled repo — the poller dispatched `lab-check` but the target repo has no `.github/workflows/lab-check.yml` receiver, so the dispatch is silently dropped | Confirm the poll succeeded: `kubectl get workflows -n argo -l workflows.argoproj.io/cron-workflow=pr-label-poller`. Confirm the per-PR QA workflow exists and completed. Then confirm the receiver exists: `gh api repos/projectbluefin/<repo>/contents/.github/workflows/lab-check.yml` — a `404` means the repo is only sender-enrolled (in `AUTO_REPOS`) and needs the receiver added on the target repo's default branch. See [`docs/skills/argo-workflows/patterns.md`](../skills/argo-workflows/patterns.md) §20aa. |

--- a/docs/ops/bootstrap.md
+++ b/docs/ops/bootstrap.md
@@ -121,7 +121,7 @@ Both applications use `automated: { prune: true, selfHeal: true }` — resources
 removed from git are removed from the cluster, and manual changes are reverted.
 This is the [recommended Argo CD GitOps model](https://argo-cd.readthedocs.io/en/stable/user-guide/auto_sync/).
 
-`testing-lab-infra` also creates the `kubestellar-applications` app-of-apps,
+`lab-infra` also creates the `kubestellar-applications` app-of-apps,
 which reconciles PostgreSQL, KubeStellar core, and KubeStellar Console in that
 order. Do not apply the child Applications manually.
 
@@ -144,20 +144,9 @@ if already present.
 
 ## 7. Configure Ghost-Specific Settings (Strix Halo hardware)
 
-For the Ryzen AI MAX+ Strix Halo node, set performance kernel args. This is a
-one-time operation (requires reboot):
-
-```bash
-just run-kernel-args
-# Schedule a maintenance window and reboot ghost when ready
-```
-
-Install the API-only warning banner on ghost's SSH login (prevents operators from
-running kubectl/argo from the host shell):
-
-```bash
-just setup-ghost-ssh-banner
-```
+Kernel arguments and SSH login policy are host-level maintenance, not
+Argo WorkflowTemplate operations. Do not submit retired workflow-based
+helpers for those changes; follow the maintainer-approved host procedures.
 
 ---
 
@@ -200,11 +189,8 @@ Run a smoke test end-to-end to verify the full pipeline:
 just run-tests
 ```
 
-This will:
-1. Pull (or reuse) the containerDisk from Zot
-2. Boot a KubeVirt VM from the containerDisk
-3. SSH in, run behave + qecore GNOME tests
-4. Delete the VM on exit
+This submits the container-only `bluefin-qa-pipeline`, which runs the selected
+suite directly inside the published OCI image and cleans up its pods on exit.
 
 ---
 
@@ -218,8 +204,6 @@ Run them once during initial cluster setup.
 | `install-kubevirt` | `workflowtemplate/install-kubevirt` | Install KubeVirt (CNCF Incubating) |
 | `install-cdi` | `workflowtemplate/install-cdi` | Install CDI for disk import |
 | `install-kubevirt-manager` | `workflowtemplate/install-kubevirt-manager` | Web UI at :30180 |
-| `ghost-kernel-args` | `workflowtemplate/ghost-kernel-args` | Strix Halo kernel tuning |
-| `setup-ghost-ssh-banner` | `workflowtemplate/setup-ghost-ssh-banner` | API-only SSH warning |
 | `setup-otel` | `workflowtemplate/setup-otel` | OTel observability stack |
 
 > These templates must be applied to the cluster before they can be run:

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -460,9 +460,9 @@ Lives in `manifests/`, applied via the `lab-infra` ArgoCD app:
 | Schedule | Cron | Template called | Purpose |
 |---|---|---|---|
 | `nightly-smoke` | 02:00 UTC | `bluefin-qa-pipeline` (`testing`) | Catch upstream regressions |
-| `nightly-smoke-stable` | 03:00 UTC | `bluefin-qa-pipeline` (`stable`) | Stable image regression coverage |
+| `nightly-smoke-stable` | 03:00 UTC | `bluefin-qa-pipeline` (`stable`, `smoke`) | Stable image regression coverage |
 | `nightly-smoke-lts` | 02:30 UTC | `bluefin-qa-pipeline` (`testing`) | LTS regression coverage |
-| `nightly-smoke-lts-stable` | 03:30 UTC | `bluefin-qa-pipeline` (`stable`) | Stable LTS regression coverage |
+| `nightly-smoke-lts-stable` | 03:30 UTC | `bluefin-qa-pipeline` (`stable`, `smoke`) | Stable LTS regression coverage |
 | `image-poll-dakota` | Every 10 min | `dakota-qa-pipeline` (`testing`) | Active Dakota digest-triggered QA |
 | `nightly-dakota` | 03:00 UTC | `dakota-qa-pipeline` (`latest`) | Suspended; does not provide active coverage |
 | `orphan-vm-cleanup` | every 2h | inline | GC stale per-run hostDisks in bluefin, flatcar, and knuckle namespaces |

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -7,12 +7,12 @@ invocation. No bash, no `kubectl apply`, no SSH.
 Conventions:
 
 - All templates live in `argo/workflow-templates/*.yaml` and are reconciled
-  to namespace `argo` by the ArgoCD `testing-lab` Application.
+  to namespace `argo` by the ArgoCD `lab` Application.
 - Workflow-level parameters listed below are passed via `-p name=value`.
 - Wall-clock targets are warm-cache numbers; cold-cache figures (BIB build
   on a missing golden disk) add ~5–10 min.
 - The agent contract: prefer the **top-level** templates (`bluefin-qa-pipeline`,
-  `bluefin-titan-smoke`). The supporting templates (provision, run, teardown)
+  `dakota-qa-pipeline`). The supporting templates (provision, run, teardown)
   are called as `templateRef` and rarely submitted directly.
 
 ---
@@ -21,23 +21,25 @@ Conventions:
 
 ### `bluefin-qa-pipeline`
 
-Full pipeline: ensure golden disk → reflink + boot a fresh KubeVirt VM →
-run test suites → teardown VM on exit.
+Container-only pipeline: validate the requested suites, fan out
+`run-container-tests` inside the published OCI image, publish selected results,
+and return a summary. This path does not build a containerDisk, boot a VM, or
+SSH into a guest.
 
 | Parameter | Default | Notes |
 |---|---|---|
-| `image` | `ghcr.io/ublue-os/bluefin` | Source image. Tag is appended from `image-tag` for some callers; pass with tag if invoking directly. |
-| `image-tag` | `latest` | `latest`, `lts`, etc. Also used as the golden-disk dir name. |
-| `namespace` | `bluefin-test` | KubeVirt VM namespace. Use `bluefin-lts-test` for LTS. |
-| `suites` | `smoke,developer` | Comma list; valid: `smoke`, `developer`, `software`. |
-| `variant` | `bluefin` | Selects test fixtures (e.g. `dakota` for Ghostty). |
-| `ssh-key-secret` | `bluefin-test-ssh-key` | Secret in `argo` ns with `id_ed25519`. |
+| `image` | `ghcr.io/projectbluefin/bluefin` | Published OCI image repository. |
+| `image-tag` | `testing` | Image tag to test. |
+| `suites` | `smoke,common,developer,software,system` | Comma list of supported suites. |
+| `variant` | `bluefin` | Selects test fixtures. |
+| `branch` | `main` | Lab branch passed to the workflow metadata. |
+| `testsuite-branch` | `main` | `projectbluefin/testsuite` branch to clone. |
 
-Wall-clock: ~5 min (warm), ~10–14 min (cold BIB rebuild).
+Wall-clock: depends on the selected suite set and container-qa semaphore.
 
 ```
 argo submit --from workflowtemplate/bluefin-qa-pipeline \
-  -p image-tag=latest -p suites=smoke --wait
+  -p image-tag=testing -p suites=smoke --wait
 ```
 
 ### `knuckle-qa-pipeline`
@@ -53,7 +55,7 @@ smoke tests against the installed system.
 | `namespace` | `knuckle-test` | KubeVirt namespace for the ephemeral installer VM. |
 | `suite` | `smoke` | Single GNOME test suite to run after install. |
 | `ssh-key-secret` | `bluefin-test-ssh-key` | Secret in `argo` ns used for installer access and installed-system SSH. |
-| `tests-branch` | `main` | `testing-lab` branch cloned by `run-gnome-tests`. |
+| `tests-branch` | `main` | Lab branch cloned by `run-gnome-tests`. |
 
 Wall-clock: ~12–20 min depending on ISO build cache and Flatcar download time.
 
@@ -85,43 +87,6 @@ argo submit --from workflowtemplate/iso-e2e-pipeline \
   -p iso-sha256=<sha256> -p iso-ref=<immutable-iso-sha> --wait
 ```
 
-### `bluefin-titan-smoke`
-
-Runs smoke tests against the **persistent** titan VMs (`titan-bluefin`,
-`titan-lts`). Skips BIB and VM provisioning entirely. Use when iterating on
-tests or when BIB is slow/broken.
-
-Prerequisites: both titan VMs running. Fetch IPs:
-
-```
-kubectl get vmi titan-bluefin -n bluefin-test -o jsonpath='{.status.interfaces[0].ipAddress}'
-kubectl get vmi titan-lts    -n bluefin-lts-test -o jsonpath='{.status.interfaces[0].ipAddress}'
-```
-
-| Parameter | Default | Notes |
-|---|---|---|
-| `vm-ip-latest` | *(required)* | titan-bluefin IP |
-| `vm-ip-lts` | *(required)* | titan-lts IP |
-| `suite` | `smoke` | Single suite name. |
-| `ssh-key-secret` | `bluefin-test-ssh-key` | |
-| `issue-title` | `titan smoke run` | Free-text label, appears in pod annotation. |
-
-Wall-clock: ~3 min (test-only, no provisioning).
-
-```
-argo submit --from workflowtemplate/bluefin-titan-smoke \
-  -p vm-ip-latest=10.42.x.y -p vm-ip-lts=10.42.x.z --wait
-```
-
-### `patch-golden-disk`
-
-One-shot maintenance: re-runs the disk configuration step (SSH key,
-selinux=0, sudoers) on an existing golden disk without rebuilding it.
-
-| Parameter | Default | Notes |
-|---|---|---|
-| `image-tag` | `latest` | Disk dir under `/var/tmp/bluefin-golden/`. |
-
 ### `service-catalog-pipeline`
 
 K8s-native service-catalog validation pipeline. Deploys a lane's workload
@@ -133,7 +98,7 @@ directly against k8s-hosted workloads.
 |---|---|---|
 | `lane` | `media` | Lane name — must match a directory under `tests/service_catalog/<lane>/` and `tests/service_catalog/<lane>/manifests.yaml` |
 | `image-tag` | `latest` | Passed to lane manifests (available for future per-lane image selection) |
-| `branch` | `main` | testing-lab branch to clone for manifests and tests |
+| `branch` | `main` | Lab branch to clone for manifests and tests |
 
 Wall-clock: ~3–5 min (depends on image pull and test count).
 
@@ -176,7 +141,7 @@ submit them directly only for diagnosis.
 
 ### `run-service-tests` (template: `run-pytest`)
 
-Non-GNOME test runner for service-catalog lanes. Clones testing-lab,
+Non-GNOME test runner for service-catalog lanes. Clones this lab repository,
 discovers the test suite under `tests/service_catalog/<lane>/`, and runs
 pytest with JUnit XML output. Emits a summary line (`N/M pytest checks
 passed`) to stdout for Argo/Loki consumption.
@@ -207,7 +172,7 @@ of relying on the bluefin-test secret for cloud-init injection.
 
 ### `run-gnome-tests` (template: `run-gnome-tests`)
 
-`git-sync` initContainer clones testing-lab → main container SSHes to the VM
+`git-sync` initContainer clones this lab repository → main container SSHes to the VM
 IP → installs deps (skipped if present) → runs qecore-headless + behave →
 captures `results.json` to pod stdout (Loki + `argo logs`).
 
@@ -490,12 +455,16 @@ Installed apps are tracked in `docs/data/catalog/installed.json`.
 
 ## CronWorkflows
 
-Lives in `manifests/`, applied via the `testing-lab-infra` ArgoCD app:
+Lives in `manifests/`, applied via the `lab-infra` ArgoCD app:
 
 | Schedule | Cron | Template called | Purpose |
 |---|---|---|---|
-| `nightly-smoke` | 02:00 UTC | `bluefin-qa-pipeline` (latest) | Catch upstream regressions |
-| `nightly-smoke-lts` | 02:30 UTC | `bluefin-qa-pipeline` (lts)    | Same, for LTS branch; first fire builds the missing golden disk |
+| `nightly-smoke` | 02:00 UTC | `bluefin-qa-pipeline` (`testing`) | Catch upstream regressions |
+| `nightly-smoke-stable` | 03:00 UTC | `bluefin-qa-pipeline` (`stable`) | Stable image regression coverage |
+| `nightly-smoke-lts` | 02:30 UTC | `bluefin-qa-pipeline` (`testing`) | LTS regression coverage |
+| `nightly-smoke-lts-stable` | 03:30 UTC | `bluefin-qa-pipeline` (`stable`) | Stable LTS regression coverage |
+| `image-poll-dakota` | Every 10 min | `dakota-qa-pipeline` (`testing`) | Active Dakota digest-triggered QA |
+| `nightly-dakota` | 03:00 UTC | `dakota-qa-pipeline` (`latest`) | Suspended; does not provide active coverage |
 | `orphan-vm-cleanup` | every 2h | inline | GC stale per-run hostDisks in bluefin, flatcar, and knuckle namespaces |
 
 ---
@@ -503,7 +472,7 @@ Lives in `manifests/`, applied via the `testing-lab-infra` ArgoCD app:
 ## KubeStellar workflows
 
 Reusable WorkflowTemplates in `argo/workflow-templates/`, reconciled by the
-`testing-lab` ArgoCD Application. KubeStellar installation and upgrades are
+`lab` ArgoCD Application. KubeStellar installation and upgrades are
 owned by the `kubestellar-applications` ArgoCD parent Application.
 
 ### `register-wec`

--- a/docs/reference/bluefin-integration.md
+++ b/docs/reference/bluefin-integration.md
@@ -76,7 +76,8 @@ and call the `image-poller` WorkflowTemplate. Each run:
 1. Pulls the current digest for the target image from ghcr.io
 2. Reads the last-known digest from `image-polling-digests` in namespace `argo`
 3. If digests match: exits cleanly (no test run)
-4. If the digest changed: submits `bluefin-qa-pipeline`, which fans out `run-container-tests`
+4. If the digest changed: submits `bluefin-qa-pipeline` for Bluefin and Bluefin-LTS,
+   or `dakota-qa-pipeline` for Dakota; each fans out `run-container-tests`
 5. Each selected suite publishes its structured results back into this repo
 6. Only after the downstream workflow succeeds does `image-poller` persist the new digest
 

--- a/docs/reference/bluefin-integration.md
+++ b/docs/reference/bluefin-integration.md
@@ -1,9 +1,9 @@
 # Bluefin Integration
 
-This homelab instance is the CI backend for Project Bluefin. Every image publish
-results in a full acceptance test run with zero human intervention; structured
-per-suite results are published back into this repo for dashboard and release
-consumers.
+This homelab instance is the CI backend for Project Bluefin. Selected image-poll
+lanes trigger container-only acceptance runs when their registry digest changes;
+structured per-suite results are published back into this repo for dashboard and
+release consumers.
 
 ---
 
@@ -11,14 +11,16 @@ consumers.
 
 | Image | Tag | Trigger | QA path |
 |---|---|---|---|
-| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + digest change | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
-| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + digest change | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
+| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
+| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
+| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
+| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
 | `ghcr.io/frostyard/snow` | `latest` | Every 3 hours + digest change | Poller → `bluefin-qa-pipeline` container lane |
-| `ghcr.io/projectbluefin/dakota` | latest BST build | Nightly 03:00 UTC + BST build | `dakota-qa-pipeline` → `run-container-tests` |
+| `ghcr.io/projectbluefin/dakota` | `testing` | 10-minute digest polling; nightly trigger suspended | `image-poll-dakota` → `dakota-qa-pipeline` → `run-container-tests` |
 
-`:testing` is the only production branch tested continuously. `:stable` runs are
-supported but not scheduled by default. Never use `:latest` or date tags in
-automation — `bluefin-lts` has no `:latest` tag.
+Bluefin and Bluefin-LTS `:testing` and `:stable` lanes are scheduled continuously.
+Dakota's nightly CronWorkflow is suspended; its active digest-poll lane tests the
+published `:testing` image. Never use date tags in automation.
 
 ---
 
@@ -68,8 +70,8 @@ Flatcar OS substrate tests. Not part of the Bluefin image pipelines; runs via
 
 ## Image-Poll Trigger
 
-Hourly CronWorkflows (`image-poll-bluefin-testing`, `image-poll-lts-testing`) call
-the `image-poller` WorkflowTemplate. Each run:
+The Bluefin, Bluefin-LTS, and Dakota image-poll CronWorkflows run every 10 minutes
+and call the `image-poller` WorkflowTemplate. Each run:
 
 1. Pulls the current digest for the target image from ghcr.io
 2. Reads the last-known digest from `image-polling-digests` in namespace `argo`
@@ -78,8 +80,8 @@ the `image-poller` WorkflowTemplate. Each run:
 5. Each selected suite publishes its structured results back into this repo
 6. Only after the downstream workflow succeeds does `image-poller` persist the new digest
 
-This means every new Bluefin image publish triggers container-only validation
-within one hour, automatically, with no human action.
+This means a changed Bluefin, Bluefin-LTS, or Dakota digest triggers
+container-only validation within 10 minutes, automatically, with no human action.
 
 ---
 
@@ -95,8 +97,8 @@ merge the new suite outcome into the tracked results data. The publication flow 
 4. Run `scripts/publish_test_results.py` for the image/suite/workflow tuple
 5. Push the updated structured results back to the repo for dashboard consumers
 
-The result: a Bluefin release is published → tests run in containers → the repo
-receives per-suite QA results without any VM-specific artifact handling.
+The result: a Bluefin or Dakota image is published → tests run in containers →
+the repo receives per-suite QA results without any VM-specific artifact handling.
 
 ---
 
@@ -154,6 +156,7 @@ To force a run outside `AUTO_REPOS`: add the `test-on-lab` label to a PR in the
 ## Dakota
 
 Dakota runs through `dakota-qa-pipeline` rather than `bluefin-qa-pipeline`, but
-the QA lane now uses the same container-only fan-out through `run-container-tests`.
-BuildStream artifact builds remain separate in `dakota-build-pipeline`. Dakota PRs
-can also use the `test-on-lab` label via the PR label poller.
+the QA lane uses the same container-only fan-out through `run-container-tests`.
+BuildStream artifact builds remain separate in `dakota-build-pipeline`; the active
+`image-poll-dakota` lane tests the resulting `:testing` image. Dakota PRs can also
+use the `test-on-lab` label via the PR label poller.

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -50,9 +50,10 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
   setting in the lab would not produce a bootable image. A VM path remains
   blocked pending an upstream Dakota UKI/bootupd capability or a maintainer
   decision to adopt a separate golden-disk/export path.
-- **Current coverage:** `dakota-container-qa-pipeline` is the safe repository-local
-  stopgap for image-level, non-GUI checks. It does not provide VM-boot, reboot, or
-  qecore-headless GUI evidence because a pod lacks the full systemd/GDM session.
+- **Current coverage:** `run-container-tests` provides the container-only suite
+  fan-out, including the nested systemd/Wayland session used by qecore-headless.
+  This lane provides image and GUI-session evidence, but not VM boot or reboot
+  evidence.
 - **Parameters:** `image`, `image-tag`, `suites`, `variant`, `branch`, `pr-number`, `sha`,
   `repo`, `testsuite-branch`, `testsuite-repo`.
 - **DAG:** `validate-suites` → parallel `test-lane` items (`smoke`, `common`, `developer`,
@@ -197,6 +198,8 @@ must fail for repair; it must not use an Ethernet, local, or cache-only fallback
 | `dakota-commit-poller` | every 5 min at minute +2 | shared `bst-commit-poller` → `dakota-build-pipeline` when `dakota:testing` changes | Dakota BuildStream cache/execution path |
 | `cosmic-commit-poller` | every 5 min at minute +4 | shared `bst-commit-poller` → `cosmic-build-pipeline` when `cosmic-build-meta:main` changes | Cosmic BuildStream cache/execution path |
 | `image-poll-bluefin-{testing,stable}` / `image-poll-lts-{testing,stable}` | 10 min | `image-poller` when the respective GHCR tag digest changes | Bluefin/LTS container-only QA freshness plus result publication |
+| `image-poll-dakota` | 10 min | `image-poller` when `dakota:testing` changes | Dakota container-only QA plus result publication |
+| `image-poll-bluefin-main` | 3h | `image-poller` when `bluefin:latest` changes | Bluefin latest container-only QA |
 | `image-poll-snosi-latest` | 30 min past every 3 hours | `bluefin-qa-pipeline` when `ghcr.io/frostyard/snow:latest` changes | Snosi GNOME desktop image coverage |
 | `flatcar-kernel-poller` | 10 min | `flatcar-kernel-build` when kernel.org's latest stable version changes | Flatcar kernel build cache |
 | `flatcar-kernel-gate` | 30 min | (gate/promotion check, see `/docs/skills/flatcar-node-onboarding/SKILL.md`) | N/A |
@@ -240,8 +243,10 @@ the next cycle.
 | CronWorkflow | Time (UTC) | Pipeline | Parameters |
 | --- | --- | --- | --- |
 | `nightly-smoke` | 02:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin` |
+| `nightly-smoke-stable` | 03:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=stable`, `suites=smoke,developer,system`, `variant=bluefin` |
 | `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin-lts` |
-| `nightly-dakota` | — | `dakota-qa-pipeline` | Tests pre-built images only — does not build/warm cache. Currently `suspend: true`. |
+| `nightly-smoke-lts-stable` | 03:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=stable`, `suites=smoke,developer,system`, `variant=bluefin-lts` |
+| `nightly-dakota` | 03:00 | `dakota-qa-pipeline` | Tests pre-built `dakota:latest` only; currently `suspend: true`. |
 | `nightly-knuckle` | 03:30 | `knuckle-qa-pipeline` | `branch=main`, `namespace=knuckle-test`, `suite=smoke`, `tests-branch=main` |
 
 ## Priority Classes

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -243,9 +243,9 @@ the next cycle.
 | CronWorkflow | Time (UTC) | Pipeline | Parameters |
 | --- | --- | --- | --- |
 | `nightly-smoke` | 02:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin` |
-| `nightly-smoke-stable` | 03:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=stable`, `suites=smoke,developer,system`, `variant=bluefin` |
+| `nightly-smoke-stable` | 03:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=stable`, `suites=smoke`, `variant=bluefin` |
 | `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin-lts` |
-| `nightly-smoke-lts-stable` | 03:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=stable`, `suites=smoke,developer,system`, `variant=bluefin-lts` |
+| `nightly-smoke-lts-stable` | 03:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=stable`, `suites=smoke`, `variant=bluefin-lts` |
 | `nightly-dakota` | 03:00 | `dakota-qa-pipeline` | Tests pre-built `dakota:latest` only; currently `suspend: true`. |
 | `nightly-knuckle` | 03:30 | `knuckle-qa-pipeline` | `branch=main`, `namespace=knuckle-test`, `suite=smoke`, `tests-branch=main` |
 

--- a/docs/skills/argo-workflows/authoring.md
+++ b/docs/skills/argo-workflows/authoring.md
@@ -372,7 +372,7 @@ When a template is renamed, merged, or deleted, standalone submit Workflows that
 2. Push to `main` and let ArgoCD sync, or force sync with a port-forward:
    ```bash
    kubectl port-forward svc/argocd-server -n argocd 18080:443 &
-   argocd app sync testing-lab
+   argocd app sync lab
    ```
 3. Verify the live template exists before resubmitting dependent workflows:
    ```bash
@@ -391,11 +391,13 @@ When a WorkflowTemplate is superseded:
 1. Delete the file from `argo/workflow-templates/` in the same PR that removes the dependency
 2. Automated sync with `prune: true` will remove it on the next ArgoCD cycle, but a manual `argocd app sync` without `--prune` will report "requires pruning" and leave the old template in the cluster. To prune immediately:
    ```bash
-   argocd app sync testing-lab --prune
+   argocd app sync lab --prune
    ```
 3. Do not leave templates with `DEPRECATED` annotations in git — they accumulate and confuse agents
 
-One-shot bootstrap templates (`install-*`, `setup-*`, `titan-disk-cleanup`) should not persist indefinitely in the cluster. If they have no git backing, `kubectl delete workflowtemplate -n argo <name>` is safe since ArgoCD won't recreate what isn't in git.
+One-shot bootstrap templates (`install-*`, `setup-*`) should not persist indefinitely
+in the cluster. If they have no git backing, `kubectl delete workflowtemplate -n argo
+<name>` is safe since ArgoCD won't recreate what isn't in git.
 
 Two CronWorkflows at the same schedule covering overlapping namespaces → consolidate into one. Check `kubectl get cronworkflows -n argo` before adding a new cleanup job.
 

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -171,7 +171,7 @@ Do not guess flags, chart schema, or MCP method names. The K8sGPT MCP server exp
 ## Verification
 
 - [ ] `just lint` passes after any WorkflowTemplate change.
-- [ ] ArgoCD reports `Synced` for `testing-lab` after the push.
+- [ ] ArgoCD reports `Synced` for `lab` after the push.
 - [ ] The submitted build pod is scheduler-admitted without a node selector:
       `kubectl get pod -n argo <pod> -o jsonpath='{.spec.nodeName}'` returns
       a Ready node with adequate allocatable resources.

--- a/docs/skills/gitops-argocd/SKILL.md
+++ b/docs/skills/gitops-argocd/SKILL.md
@@ -138,7 +138,7 @@ the scheduler; do not add a hostname selector. Size application retention below
 PVC capacity so WAL, compaction, or other temporary files cannot fill the
 volume.
 
-**Subdirectories and namespaces:** `testing-lab-infra` runs with
+**Subdirectories and namespaces:** `lab-infra` runs with
 `directory.recurse: true` (live-patched 2026-07-25; the Application object is
 manually applied, not git-tracked) so nested paths like
 `manifests/catalog-apps/<app>/manifest.yaml` sync. It also sets
@@ -170,9 +170,9 @@ If a template change is in git but not yet live:
 #### The WorkflowTemplate Snapshot Gotcha (CRITICAL):
 - **Snapshot at Submit Time**: In Argo Workflows, a WorkflowTemplate is snapshotted inside the cluster at the *exact moment a workflow is submitted*.
 - **Sync Race Condition**: If you push a fix to git and immediately run `argo submit` or trigger a build, the workflow may snapshot a stale template version if ArgoCD has not yet completed its poll or sync loop.
-- **Native Kubernetes Hard Sync Patch**: When a port-forward is unavailable or the local CLI config is out-of-sync, you can bypass the `argocd` CLI and trigger an immediate hard refresh and synchronization of the `testing-lab` (or other) Application directly via `kubectl`:
+- **Native Kubernetes Hard Sync Patch**: When a port-forward is unavailable or the local CLI config is out-of-sync, you can bypass the `argocd` CLI and trigger an immediate hard refresh and synchronization of the `lab` (or other) Application directly via `kubectl`:
   ```bash
-  kubectl patch app testing-lab -n argocd -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' --type=merge
+  kubectl patch app lab -n argocd -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' --type=merge
   ```
   Always run this patch (or `just argocd-sync`) and verify that the target template's live version (`argo-mcp-get_workflow_template`) incorporates your changes **before** submitting or resubmitting any workflow runs.
 

--- a/docs/skills/kubestellar/SKILL.md
+++ b/docs/skills/kubestellar/SKILL.md
@@ -53,7 +53,7 @@ metadata:
 
 ## Install (GitOps, ADR-0003)
 
-The `testing-lab-infra` Application reconciles
+The `lab-infra` Application reconciles
 `manifests/kubestellar-applications.yaml`, which owns exactly three child
 Applications in order: PostgreSQL, KubeStellar core, then Console. Installation
 and upgrades happen through Git; do not apply the child Applications manually.

--- a/docs/skills/registry-catalog/SKILL.md
+++ b/docs/skills/registry-catalog/SKILL.md
@@ -154,7 +154,7 @@ The install WorkflowTemplate takes a `mode` parameter:
   inside a leaf template's input defaults never resolves (three live
   failures before the fix; see argo-workflows skill red flags).
 - Deployed bundles land in `manifests/catalog-apps/<app>/`, which requires
-  `directory.recurse: true` on the `testing-lab-infra` Application and a
+  `directory.recurse: true` on the `lab-infra` Application and a
   `Namespace` object in the bundle (`CreateNamespace=false`).
 
 Verified end-to-end 2026-07-25: jellyfin gitops install — workflow

--- a/docs/skills/test-authoring/dogtail-patterns.md
+++ b/docs/skills/test-authoring/dogtail-patterns.md
@@ -531,16 +531,13 @@ These are recognised by `TestSandbox.__init__` and `qecore-headless`. Pass them 
 | `QECORE_NO_CACHE=yes`          | Delete qecore cache on run start (forces fresh app registration).         |
 | `PRODUCTION=no`                | Disable HTML report embeds — useful when iterating locally.               |
 
-`STABILITY=10` is the de-facto pre-merge check for any new `@regression`. Submit via:
+Submit a targeted regression check with the supported `behave-tags` input:
 
 ```bash
 argo submit --from workflowtemplate/run-container-tests \
   --entrypoint run-container-tests -p suite=smoke \
   -p behave-tags="--tags @my_new_regression" -n argo --watch
 ```
-
-(If the workflow template doesn't expose the env var you need, add a passthrough rather
-than editing the runner ad-hoc — keep the GitOps contract.)
 
 ### 7.7 Useful `qecore-headless` flags
 

--- a/docs/skills/test-authoring/dogtail-patterns.md
+++ b/docs/skills/test-authoring/dogtail-patterns.md
@@ -648,7 +648,7 @@ shape for new suites.
       details (child indices, CSS classes).
 - [ ] `@regression` scenarios cite a real issue with `@<repo>_<issue#>`.
 - [ ] Scenario passes from a cold image, not just on a re-run.
-- [ ] New `@regression` proven stable via `STABILITY=10` (§7.6).
+- [ ] New `@regression` validated with the targeted `behave-tags` check (§7.6).
 
 **Mechanics:**
 - [ ] Every GUI scenario starts with `* GNOME Shell is accessible via AT-SPI`.

--- a/docs/skills/test-authoring/dogtail-patterns.md
+++ b/docs/skills/test-authoring/dogtail-patterns.md
@@ -5,11 +5,11 @@ this repo. Read this before adding a scenario, a step, or a new suite. Pair it w
 [`/AGENTS.md`](/AGENTS.md), [`/docs/ops/RUNBOOK.md`](/docs/ops/RUNBOOK.md), and the example suites under
 [`tests/`](/tests/).
 
-> **TL;DR for agents:** Tests run inside a real GNOME Wayland session on a KubeVirt VM. The
-> Argo runner SSHs in, sets up `qecore-headless`, and executes `behave` (+ optional `pytest`)
-> over the AT-SPI bus using `dogtail`. You write feature files + step defs locally, push to
-> `main` (or a PR branch), and submit a `just` target. Never SSH to ghost or `kubectl apply`
-> workflows.
+> **TL;DR for agents:** Bluefin and Dakota QA run inside a nested GNOME Wayland session in
+> the published OCI image via `run-container-tests`; explicit VM-backed lanes use the
+> `run-gnome-tests` runner. You write feature files + step defs locally, push to `main`
+> (or a PR branch), and submit a `just` target. Never SSH to a cluster node or
+> `kubectl apply` workflows.
 
 ## Upstream sources of truth
 
@@ -29,8 +29,8 @@ This repo follows the upstream conventions; when in doubt, the upstream docs win
 > legacy-maintained at `dogtail-1.x`). Upstream qecore tracks its own `X.Y` series. Any
 > historical "dogtail 4.16" mentions in repo comments refer to the qecore release pinned at
 > the time and predate the dogtail 2.x rename — treat them as qecore-version markers, not
-> dogtail versions. The runner installs the latest releases of both from PyPI on every fresh
-> VM and skips on persistent titans (see §3).
+> dogtail versions. The runner installs the latest releases of both from PyPI in each
+> fresh test environment (see §3).
 
 ---
 
@@ -38,7 +38,7 @@ This repo follows the upstream conventions; when in doubt, the upstream docs win
 
 | Layer                     | Role                                                                        |
 |---------------------------|-----------------------------------------------------------------------------|
-| **KubeVirt VM**           | Real Bluefin (`latest`/`lts`) boot on ghost. Wayland + GNOME Shell 50.      |
+| **KubeVirt VM**           | Explicit VM-backed lanes only; Bluefin images boot with Wayland + GNOME Shell 50. |
 | **gnome-ponytail-daemon** | Bridges AT-SPI coordinates → Wayland surface coordinates (input injection). |
 | **qecore-headless**       | Boots Wayland/GNOME session, sets `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`, activates ponytail-daemon. |
 | **qecore.TestSandbox**    | Per-test bookkeeping: app handles, journal scoping, screenshots, retries.   |
@@ -89,21 +89,16 @@ tests/
 ## 3. How a Test Run Executes (mental model)
 
 1. **You push** to `main` or a PR branch.
-2. **You submit** a workflow (e.g. `just run-titan-smoke` or `just run-tests`).
-3. **Argo** starts the `run-gnome-tests` pod on ghost.
-4. The pod's `git-sync` initContainer clones `lab @ <branch>` into a shared volume.
-5. The runner container waits for SSH on the target VM, then over SSH:
-   - Verifies/installs `qecore`, `behave`, `dogtail`, `pytest`, `python-uinput`,
-     `gnome-ponytail-daemon` (+ `python3-gnome-ponytail-daemon`).
-   - Ensures `/dev/uinput` is `chmod 0666` and SELinux-labelled.
-6. **rsyncs** `tests/<suite>/` and `tests/shared/wait_for_shell.py` to `/tmp/bluefin-tests/` on the VM.
-7. Runs:
-   ```
-   qecore-headless --session-type wayland --session-desktop gnome \
-     "bash -lc 'python3 .../wait_for_shell.py && exec behave .../features/ --format json.pretty --outfile /tmp/results/results.json'"
-   ```
-8. Repeats for `pytest` if `test_*.py` exist.
-9. SCPs `/tmp/results/` back, prints summary, exits non-zero on any failure.
+2. **You submit** `bluefin-qa-pipeline` or `dakota-qa-pipeline` (for example,
+   `just run-tests` or `just run-dakota-qa`).
+3. **Argo** starts `run-container-tests` on ghost, where the published OCI image
+   provides the nested systemd/Wayland session.
+4. The runner clones `projectbluefin/testsuite`, installs or verifies qecore,
+   behave, dogtail, pytest, and the Wayland input dependencies, then runs the
+   selected suite and writes structured results.
+5. Explicit VM-backed lanes use `run-gnome-tests` instead: the runner waits for
+   the ephemeral VM, uses SSH inside the cluster, and captures the same test
+   artifacts before teardown.
 
 **Important:** the readiness probe (`wait_for_shell.py`) runs inside the same
 `qecore-headless` session as `behave`, so `unsafe_mode` and AT-SPI state are guaranteed.
@@ -112,48 +107,36 @@ tests/
 
 ## 4. Submitting a Test Run
 
-### Fast path — persistent titan VMs (preferred for iterating on tests)
-
-| Command                    | What it runs                                | Approx. duration |
-|----------------------------|---------------------------------------------|------------------|
-| `just run-titan-smoke`     | `smoke` suite against `titan-bluefin` + `titan-lts` | ~5 min   |
-| `just run-titan-developer` | `developer` suite against both titans        | ~7 min          |
-| `just run-titan-software`  | `software` suite against both titans         | ~7 min          |
-
-Titans skip provisioning entirely. Dependency install is idempotent and skipped on
-re-runs.
-
-### Full pipeline (fresh VM, provisioning)
+### Container-only QA path (default for Bluefin and Dakota)
 
 | Command                          | Notes                                                         |
 |----------------------------------|---------------------------------------------------------------|
-| `just run-tests`                 | Smoke against `latest`.                                       |
-| `just run-tests-tag lts`         | Smoke against a specific tag.                                 |
-| `just run-tests-matrix`          | `latest` + `lts` in parallel.                                 |
-| `just run-developer-tests [tag]` | Smoke + developer on a fresh VM.                              |
-| `just run-software-tests [tag]`  | Smoke + developer + software on a fresh VM.                   |
+| `just run-tests`                 | Smoke against Bluefin `testing` in a container-only lane.     |
+| `just run-tests-tag lts-testing` | Smoke against Bluefin-LTS `testing`.                         |
+| `just run-tests-matrix`          | Bluefin `testing` and Bluefin-LTS `testing` in parallel.      |
+| `just run-dakota-qa`             | Dakota container-only suite fan-out against the published image. |
 
 ### Testing a PR branch without merging
 
 Set `BLUEFIN_TEST_BRANCH` so the runner's `git-sync` initContainer clones your branch:
 
 ```bash
-BLUEFIN_TEST_BRANCH=fix/clock-toggle-flake just run-titan-smoke
+argo submit --from workflowtemplate/bluefin-qa-pipeline \
+  -p testsuite-branch=fix/clock-toggle-flake -p suites=smoke -n argo --watch
 ```
 
 Or override per-submit:
 
 ```bash
-argo submit --from workflowtemplate/bluefin-titan-smoke \
-  -p vm-ip-latest=... -p vm-ip-lts=... -p branch=fix/clock-toggle-flake \
-  -p suite=smoke -n argo --watch
+argo submit --from workflowtemplate/bluefin-qa-pipeline \
+  -p testsuite-branch=fix/clock-toggle-flake -p suites=smoke -n argo --watch
 ```
 
 ### Filtering by behave tag
 
 ```bash
-argo submit --from workflowtemplate/bluefin-titan-smoke \
-  -p vm-ip-latest=... -p vm-ip-lts=... \
+argo submit --from workflowtemplate/run-container-tests \
+  --entrypoint run-container-tests -p suite=smoke \
   -p behave-tags="--tags @regression" -n argo --watch
 ```
 
@@ -506,16 +489,16 @@ than no test — it costs cluster time and trains agents to ignore red builds.
 6. **Regressions cite an issue.** Every `@regression` scenario carries a `@<repo>_<issue#>`
    tag and a comment referencing the upstream bug. This is how the project tracks coverage
    regressions over time and prevents test drift after a fix lands.
-7. **Tests must boot from a cold image.** Don't depend on state left by a previous scenario,
-   a previous run, or manual VM tweaks. Titan VMs are persistent for *speed*, not for
-   carrying state — the same scenario must pass on a fresh fully-provisioned VM
-   (`just run-tests`).
+7. **Tests must start from a clean image.** Don't depend on state left by a previous
+   scenario, a previous run, or manual environment tweaks. The same scenario must pass
+   in a fresh container-only QA run (`just run-tests`) and, when applicable, an
+   ephemeral VM-backed run.
 8. **Prove the negative.** When testing that an error dialog *doesn't* appear, write the
    detection with the same predicate you'd use to find it — don't just sleep and hope.
    Example: `assert not app.findChildren(lambda n: n.roleName == "dialog" and "error" in n.name.lower())`.
-9. **Verify on titan first, matrix second.** Iterating on a scenario? Use
-   `just run-titan-<suite>` (5 min). Only once green, re-run on a fresh VM with
-   `just run-tests` / `just run-tests-matrix` to catch first-boot races.
+9. **Verify container QA first, then VM lanes when applicable.** Iterate with the
+   container-only `bluefin-qa-pipeline` or `dakota-qa-pipeline`, then run the
+   relevant explicit KubeVirt lane to catch boot and first-session races.
 10. **Use `STABILITY=N`** (upstream qecore env var, §7.6) to prove a new scenario passes 10×
     in a row before merging anything tagged `@regression`. Flaky regressions erode trust
     immediately.
@@ -550,10 +533,9 @@ These are recognised by `TestSandbox.__init__` and `qecore-headless`. Pass them 
 `STABILITY=10` is the de-facto pre-merge check for any new `@regression`. Submit via:
 
 ```bash
-argo submit --from workflowtemplate/bluefin-titan-smoke \
-  -p vm-ip-latest=... -p vm-ip-lts=... \
-  -p behave-tags="--tags @my_new_regression" \
-  -p extra-env="STABILITY=10" -n argo --watch
+argo submit --from workflowtemplate/run-container-tests \
+  --entrypoint run-container-tests -p suite=smoke \
+  -p behave-tags="--tags @my_new_regression" -n argo --watch
 ```
 
 (If the workflow template doesn't expose the env var you need, add a passthrough rather
@@ -627,32 +609,14 @@ shape for new suites.
 2. **Look for `STEP_ERROR`** — `after_step` prints a full traceback for any errored step.
 3. **Inspect `/tmp/results/atspi_tree.txt`** — first smoke scenario writes it. Tells you
    which nodes exist and what their `roleName` / `name` actually are on this build.
-4. **Re-run with one scenario** via `behave-tags`:
+4. **Re-run with one scenario** via the container runner's `behave-tags` parameter:
    ```bash
-   argo submit --from workflowtemplate/bluefin-titan-smoke \
-     -p vm-ip-latest=... -p vm-ip-lts=... \
+   argo submit --from workflowtemplate/run-container-tests \
+     --entrypoint run-container-tests -p suite=smoke \
      -p behave-tags="--tags @bluefin_4612" -n argo --watch
    ```
-5. **In-cluster sanity** on a one-shot AT-SPI predicate (no workstation SSH — use a probe pod):
-   ```bash
-   # 1. Spin up a probe pod with the SSH key and wait for it to be Ready
-   kubectl run probe -n argo --image=quay.io/fedora/fedora:latest \
-     --overrides='{"spec":{"nodeSelector":{"kubernetes.io/hostname":"ghost"},"volumes":[{"name":"k","secret":{"secretName":"bluefin-test-ssh-key","defaultMode":384}}],"containers":[{"name":"probe","image":"quay.io/fedora/fedora:latest","command":["sleep","600"],"volumeMounts":[{"name":"k","mountPath":"/root/.ssh","readOnly":true}]}]}}'
-   kubectl wait -n argo pod/probe --for=condition=Ready --timeout=60s
-
-   # 2. Run the AT-SPI check from inside the probe pod
-   VM_IP=$(kubectl get vmi titan-bluefin -n bluefin-test -o jsonpath='{.status.interfaces[0].ipAddress}')
-   kubectl exec -n argo probe -- bash -c "
-     dnf install -y --quiet openssh-clients python3-pip 2>&1 | tail -2
-     pip install dogtail -q
-     ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519 bluefin-test@${VM_IP} \
-       'qecore-headless --session-type wayland --session-desktop gnome \
-        \"python3 -c \\\"from dogtail.tree import root; shell=root.application(\\\\\\\"gnome-shell\\\\\\\"); print([(c.roleName,c.name) for c in shell.children[:20]])\\\"\"'
-   "
-
-   # 3. Clean up
-   kubectl delete pod -n argo probe
-   ```
+5. **For VM-backed lanes**, inspect the ephemeral VMI and the `run-gnome-tests`
+   pod logs from the same Argo workflow. Do not assume a persistent test VM exists.
 6. **Common root causes**, in order: stale dogtail kwarg, GNOME 50 INT_MIN toggle,
    missing `unsafe_mode`, app a11y name drift, qecore version variable rename
    (`command_stdout` vs `last_command_output`).
@@ -667,11 +631,11 @@ shape for new suites.
 3. Add a top-of-feature tag (`@<suite>_suite`) and per-area tags.
 4. Submit via:
    ```bash
-   argo submit --from workflowtemplate/bluefin-titan-smoke \
-     -p vm-ip-latest=... -p vm-ip-lts=... -p suite=<suite> -n argo --watch
+   argo submit --from workflowtemplate/run-container-tests \
+     --entrypoint run-container-tests -p suite=<suite> -n argo --watch
    ```
-5. Once green on titans, add a `just run-titan-<suite>` recipe and/or include the suite in
-   `bluefin-qa-pipeline` via the `suites=` param.
+5. Once green in the container runner, include the suite in `bluefin-qa-pipeline`
+   via the `suites=` parameter or in `dakota-qa-pipeline` as appropriate.
 6. If the suite needs an extra RPM/Flatpak in the VM, update the `verify_test_dependencies`
    block in `argo/workflow-templates/run-gnome-tests.yaml` so the install is idempotent.
 
@@ -701,8 +665,8 @@ shape for new suites.
 
 **Validation:**
 - [ ] `just lint` passes.
-- [ ] Validated on titan VMs (`just run-titan-<suite>`).
-- [ ] Validated on a fresh VM (`just run-tests` or matrix) before requesting review.
+- [ ] Validated in a fresh container-only run (`just run-tests` or `just run-dakota-qa`).
+- [ ] Validated on an explicit fresh VM lane when the scenario depends on VM boot behavior.
 
 ---
 
@@ -804,12 +768,12 @@ kubectl annotate application lab -n argocd argocd.argoproj.io/refresh=normal --o
 Then verify `kubectl get application lab -n argocd -o jsonpath='{.status.sync.revision}'`
 matches your commit SHA before submitting a workflow.
 
-**Fresh titan disks have no default browser configured.**
+**Fresh VM disks have no default browser configured.**
 `xdg-settings get default-web-browser`, `xdg-mime query default x-scheme-handler/http`, and
-GIO all return empty on a titan VM that has never had a user-interactive browser session.
+GIO all return empty on a VM that has never had a user-interactive browser session.
 Flatpak Firefox is not pre-deployed to `/var/lib/flatpak/exports/share/applications/` on the
-base disk. Do not write scenarios that depend on a configured default browser unless the titan
-disk setup explicitly configures one.
+base disk. Do not write scenarios that depend on a configured default browser unless the
+VM image setup explicitly configures one.
 
 ---
 

--- a/docs/skills/test-authoring/dogtail-patterns.md
+++ b/docs/skills/test-authoring/dogtail-patterns.md
@@ -118,7 +118,8 @@ tests/
 
 ### Testing a PR branch without merging
 
-Set `BLUEFIN_TEST_BRANCH` so the runner's `git-sync` initContainer clones your branch:
+Set the `testsuite-branch` parameter so the runner's `git-sync` initContainer
+clones your testsuite branch:
 
 ```bash
 argo submit --from workflowtemplate/bluefin-qa-pipeline \


### PR DESCRIPTION
## Summary
- replace retired ArgoCD app names with `lab`/`lab-infra`
- remove stale workflow references and persistent-titan guidance
- align Bluefin/Dakota container-only QA, image-poll, nightly, publication, and exo-0 wording
- preserve maintainer-gated host SSH/storage procedures

## Validation
- `python3 scripts/validate-docs.py`
- `just lint`
- `python3 -m pytest -q tests/unit/test_container_only_qa_workflows.py tests/unit/test_workflow_defaults.py`
- additional internal-link checker unavailable; `validate-docs.py` link validation passed