### PR TITLE
docs: align SSH and storage guidance

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,8 +5,8 @@
 #   - Workflow submission and monitoring: use these just targets (argo/kubectl CLI).
 #   - These recipes are the canonical interface for all routine lifecycle operations.
 #   - Agents use these recipes or call argo/kubectl directly. No MCP required.
-#   - ssh jorge@ghost is permitted for OS-level tasks only (k3s restart, systemd, brew).
-#   - No recipe SSHes to ghost; do NOT add workstation SSH hops.
+#   - No workstation SSH to ghost or exo-0; use just/argo/kubectl/API-driven operations.
+#   - SSH in this repo is reserved for workflow pods connecting to explicit test VMs.
 #   - Cluster bootstrap (setup-ssh-secret, setup-argocd) runs once from workstation.
 
 image     := env_var_or_default("BLUEFIN_IMAGE", "ghcr.io/projectbluefin/bluefin:testing")

--- a/Justfile
+++ b/Justfile
@@ -6,7 +6,8 @@
 #   - These recipes are the canonical interface for all routine lifecycle operations.
 #   - Agents use these recipes or call argo/kubectl directly. No MCP required.
 #   - No workstation SSH to ghost or exo-0; use just/argo/kubectl/API-driven operations.
-#   - SSH in this repo is reserved for workflow pods connecting to explicit test VMs.
+#   - Routine/public-agent SSH is only from workflow/probe pods to explicit test VMs.
+#   - Retained host-maintenance SSH is operator-only via an approved private channel.
 #   - Cluster bootstrap (setup-ssh-secret, setup-argocd) runs once from workstation.
 
 image     := env_var_or_default("BLUEFIN_IMAGE", "ghcr.io/projectbluefin/bluefin:testing")

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -52,6 +52,8 @@ The repo is intentionally GitOps-first: cluster state should converge from git, 
 - Do not SSH from a workstation into `ghost` or `exo-0` for inspection, recovery, or file transfer.
 - In-workflow SSH into explicit test VMs and probe-pod-to-guest SSH remain valid because
   they originate inside the cluster and are part of the test harness, not node administration.
+- Host storage migration, node bootstrap, and host-service recovery are private
+  maintainer procedures; they are not normal public workstation guidance.
 
 ## Image, disk, and VM model
 

--- a/docs/ops/bootstrap.md
+++ b/docs/ops/bootstrap.md
@@ -146,7 +146,9 @@ if already present.
 
 Kernel arguments and SSH login policy are host-level maintenance, not
 Argo WorkflowTemplate operations. Do not submit retired workflow-based
-helpers for those changes; follow the maintainer-approved host procedures.
+helpers for those changes. These are private maintainer procedures; do not use
+workstation SSH to `ghost` or `exo-0`, and do not treat host commands as normal
+public bootstrap steps.
 
 ---
 
@@ -158,7 +160,7 @@ leave at any time (useful for laptops and gaming machines).
 **Full onboarding steps: `/docs/reference/agent-cheatsheet.md` section 14.**
 
 Quick summary:
-1. Get join token: `ssh core@<control-plane-ip> "sudo cat /var/lib/rancher/k3s/server/node-token"`
+1. Have a maintainer provision the join token through the approved secure enrollment process; do not retrieve it with workstation SSH.
 2. On the new node: `sudo mkdir -p /var/usrlocal/bin` then run the k3s install script with `INSTALL_K3S_BIN_DIR=/var/usrlocal/bin`
 3. Disable auto-start: `sudo systemctl disable k3s-agent`
 4. Install `~/Justfile` with `just k8s-on/off/status` commands

--- a/docs/ops/k3s-tuning.md
+++ b/docs/ops/k3s-tuning.md
@@ -4,6 +4,13 @@ Canonical reference for tuning the k3s server on ghost.
 Applied once via `/etc/rancher/k3s/config.yaml` and a service restart.
 This is not a GitOps manifest — it lives outside ArgoCD's reconciliation scope.
 
+> [!CAUTION]
+> This is a private maintainer/operator procedure for host-level maintenance,
+> not a public agent recipe. Do not SSH from a workstation to `ghost` or
+> `exo-0`; use the approved private maintenance channel. Routine cluster
+> inspection and workload control remain API-driven through `just`, `argo`, and
+> `kubectl`.
+
 ---
 
 ## Why
@@ -88,7 +95,8 @@ etcd-snapshot-compress: true
 
 ## Apply Procedure
 
-1. SSH to ghost (or use a terminal session directly):
+1. In the approved private host-maintenance session (not workstation SSH), edit
+   the file:
 
    ```
    sudo nano /etc/rancher/k3s/config.yaml

--- a/docs/ops/lab-operations.md
+++ b/docs/ops/lab-operations.md
@@ -13,9 +13,11 @@ Pair with:
 > [!WARNING]
 > **Use the CLI-first hierarchy for cluster operations:** `just` for routine
 > lifecycle actions, then `argo` or `kubectl` for direct inspection and control.
-> MCP is optional and must not block an operation. The only acceptable SSH path
-> in this repo is **in-cluster** access from workflow/probe pods into test VMs
-> when the test harness or post-mortem artifact collection requires it.
+> MCP is optional and must not block an operation. Routine/public-agent SSH is
+> limited to **in-cluster** workflow/probe pods accessing explicit test VMs when
+> the test harness or post-mortem artifact collection requires it. Retained
+> host-maintenance SSH is operator-only through an approved private channel;
+> never use workstation SSH to administer `ghost` or `exo-0`.
 >
 > There is no workstation-SSH exception for host maintenance. Starting or
 > stopping k3s is a private maintainer procedure and is intentionally not

--- a/docs/ops/lab-operations.md
+++ b/docs/ops/lab-operations.md
@@ -17,7 +17,9 @@ Pair with:
 > in this repo is **in-cluster** access from workflow/probe pods into test VMs
 > when the test harness or post-mortem artifact collection requires it.
 >
-> **Exception:** SSH to ghost is permitted exclusively to start or stop the `k3s` service — you cannot stop the API server via the API itself. See [§ Turning k8s on/off](#turning-k8s-onoff).
+> There is no workstation-SSH exception for host maintenance. Starting or
+> stopping k3s is a private maintainer procedure and is intentionally not
+> published as a workstation command.
 
 ---
 
@@ -78,7 +80,7 @@ For agents and automated systems:
 - Workflow reads / logs / control → Argo MCP
 - Pod, VM, Secret, and node reads / mutations → Kubernetes MCP
 - GitOps changes → edit tracked YAML, push to git, let ArgoCD reconcile
-- No SSH to ghost, exo-1, or any node — except `sudo systemctl start|stop k3s` on ghost (see below)
+- No workstation SSH to ghost, exo-0, or any node.
 
 ---
 
@@ -103,7 +105,7 @@ Use `argo logs` or the Argo UI instead of shelling into pods.
 
 ### 4.4 Updating files without workstation `scp`
 
-If you need to push helper files or test content into the cluster, do **not** `scp` them to ghost or exo-1 from a workstation. Use a ConfigMap plus a short-lived Job created through Kubernetes MCP (`kubernetes-mcp-resources_create_or_update`):
+If you need to push helper files or test content into the cluster, do **not** `scp` them to ghost or exo-0 from a workstation. Use a ConfigMap plus a short-lived Job created through Kubernetes MCP (`kubernetes-mcp-resources_create_or_update`):
 
 1. Create or update a ConfigMap containing the files.
 2. Create a scheduler-admitted Job that mounts the ConfigMap and writes only to
@@ -265,17 +267,9 @@ After rotation:
 
 ## 10. Turning k8s on/off
 
-The **only** legitimate reason to SSH from a workstation to the control plane is to start or stop the `k3s` service. The API server cannot shut itself down — SSH is required.
-
-```bash
-# Stop all of Kubernetes (API, etcd, all pods go down)
-ssh core@<control-plane-ip> "sudo systemctl stop k3s"
-
-# Start it back up
-ssh core@<control-plane-ip> "sudo systemctl start k3s"
-
-# Verify
-ssh core@<control-plane-ip> "sudo systemctl is-active k3s"
-```
-
-Everything else — pod management, workflow control, ConfigMaps, scaling — goes through MCP. No other workstation SSH to ghost is permitted.
+Starting or stopping the host `k3s` service is a private maintainer/operator
+procedure, not public workstation guidance. The Kubernetes API cannot start a
+stopped control plane, so if the API is unavailable, escalate through the
+approved host-maintenance channel rather than using workstation SSH. Once the
+API is available again, use `just`, `argo`, and `kubectl` for all verification
+and workload control.

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -11,7 +11,9 @@
 > - [`/AGENTS.md`](/AGENTS.md) — hard policy and tenets
 
 > [!NOTE]
-> **CLI-first.** Tool hierarchy: `just` (lifecycle recipes) → `argo`/`kubectl` (cluster ops) → `ssh core@<control-plane>` (OS-level only).
+> **CLI/API-first.** Tool hierarchy: `just` (lifecycle recipes) → `argo`/`kubectl`
+> (cluster ops). Never use workstation SSH to `ghost` or `exo-0`; SSH examples
+> in this repository are for workflow pods connecting to explicit test VMs.
 > MCP tools are optional — never block on them. One bash call beats a tool search + MCP roundtrip every time.
 
 ## 1. Command selector — what should I run?
@@ -392,13 +394,20 @@ kubectl -n llm-d scale deploy/llm-d-modelserver --replicas=1
 2. Memory fits: ghost has ~62.5Gi allocatable; the manifest requests 16Gi/24Gi and 1 GPU. Check for other large pods consuming RAM if you see `Insufficient memory`.
 
 **If k3s is down** (kubectl returns "connection refused"):
-k3s can stop after host sleep/resume. Recovery:
+k3s can stop after host sleep/resume. Do not recover it with workstation SSH.
+Host-service recovery is a private maintainer procedure; escalate through the
+approved operator channel. Once the API returns, delete the
+`amdgpu-device-plugin` pod through Kubernetes so it re-registers with the
+current kubelet socket:
 ```bash
-ssh core@<control-plane> "sudo systemctl start k3s"
+kubectl delete pod -n kube-system -l app.kubernetes.io/name=amdgpu-device-plugin
 ```
-After restart, delete the `amdgpu-device-plugin` pod so it re-registers with the new kubelet socket.
 
-**kubelet device-plugin socket path:** `/var/lib/kubelet/device-plugins/kubelet.sock` (standard path — NOT the rancher/k3s path). Verify with: `ssh core@<control-plane> "sudo ss -lx | grep kubelet"`.
+Verify device-plugin health through the API:
+```bash
+kubectl get daemonset amdgpu-device-plugin -n kube-system
+kubectl get node exo-0 -o jsonpath='{.status.allocatable.amd\.com/gpu}{"\n"}'
+```
 
 **If pod is CrashLoopBackOff:** Check the container logs first:
 ```bash
@@ -416,15 +425,21 @@ The model will be cached in the pod's `emptyDir` at `/root/.cache/huggingface` u
 
 ## 14. Node onboarding — adding a worker to the cluster
 
+> [!CAUTION]
+> Node onboarding is a private maintainer/operator procedure, not a routine
+> agent recipe. Never retrieve a join token with workstation SSH to `ghost` or
+> `exo-0`; a maintainer must provision the token through an approved secure
+> channel. The commands below run on the new node or through the Kubernetes API.
+
 All nodes in this cluster run image-based, atomic operating systems (Bluefin, Dakota, Bazzite — ostree-based).
 `/usr/local/bin` is a symlink to `/var/usrlocal/bin` (the writable overlay). The k3s install
 script must be told to use this path or it fails on a fresh system.
 
-### Get the join token (run from ghost or this workstation)
+### Provision the join token
 
-```bash
-ssh core@<control-plane-ip> "sudo cat /var/lib/rancher/k3s/server/node-token"
-```
+The k3s join token is a host secret. A maintainer provisions it through the
+approved private enrollment process; do not copy it from a cluster node with
+workstation SSH.
 
 ### Bootstrap a new worker node (run ON the new node, with sudo)
 

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -12,8 +12,10 @@
 
 > [!NOTE]
 > **CLI/API-first.** Tool hierarchy: `just` (lifecycle recipes) → `argo`/`kubectl`
-> (cluster ops). Never use workstation SSH to `ghost` or `exo-0`; SSH examples
-> in this repository are for workflow pods connecting to explicit test VMs.
+> (cluster ops). Routine/public-agent SSH is limited to workflow/probe pods
+> connecting to explicit test VMs. Retained host-maintenance SSH is
+> operator-only through an approved private channel; never use workstation SSH
+> to administer `ghost` or `exo-0`.
 > MCP tools are optional — never block on them. One bash call beats a tool search + MCP roundtrip every time.
 
 ## 1. Command selector — what should I run?

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -28,7 +28,9 @@ metadata:
 ## Core Process
 
 1. Resolve tool/library docs in Context7 first (kubectl/k3s/K8sGPT/BuildStream as needed).
-2. Prefer `just` recipes, then `kubectl`/`argo`, then host SSH only when k8s API cannot do it.
+2. Prefer `just` recipes, then `kubectl`/`argo` and other API-driven operations.
+   Host-level work is private maintainer maintenance; never use workstation SSH
+   to `ghost` or `exo-0` from the public agent path.
 3. For BST lanes, configure local and upstream cache fallback in workflow configs:
    - never configure external cache credentials/keys in cluster workflows
    - set `override-project-caches: false` to allow the project's own upstream caches (for example Freedesktop SDK and GNOME OS) to be used as read-only fallbacks, preventing extremely slow, full OS recompilations of basic bootstrap toolchains.

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -307,7 +307,15 @@ state must persist between workflow steps. It must use the `local-path` StorageC
 with the explicit GitOps node-to-data-mount mapping. Never use `/var/tmp`, a
 root filesystem, or a node-local `hostPath` cache.
 
-### 5. Buildbarn durable shard backup / restore
+### 5. Private maintainer procedure — Buildbarn durable shard backup / restore
+
+> [!CAUTION]
+> This section is retained for maintainers who have explicitly approved a
+> storage maintenance window and backup plan. It is not a normal public recipe:
+> host-path copies, retained PVC/PV deletion, and restore commands can destroy
+> data. Never run it from a workstation or use workstation SSH to `ghost` or
+> `exo-0`; use the approved private operator channel. Routine Buildbarn
+> operations remain API-driven through `just`, `argo`, `kubectl`, and GitOps.
 
 #### What is durable vs. disposable
 - **Durable**: the `storage` StatefulSet's per-ordinal `local-path` PVCs. `manifests/buildbarn-storage.yaml` defines two replicas (`storage-0`, `storage-1`) with **required** podAntiAffinity, plus two PVCs per ordinal: `cas` mounted at `/storage-cas` and `ac` mounted at `/storage-ac`.

--- a/docs/skills/cluster-tooling/node-recovery.md
+++ b/docs/skills/cluster-tooling/node-recovery.md
@@ -6,6 +6,12 @@ description: >
 
 # Node Recovery and Quirks
 
+> [!CAUTION]
+> Host-root recovery and privileged `nsenter` actions are private
+> maintainer/operator procedures. Do not use workstation SSH to `ghost` or
+> `exo-0`; use Kubernetes API-driven recovery workflows and escalate host
+> maintenance through the approved private channel.
+
 ## Fedora CoreOS 44 (FCOS) Container Memory Limits and systemd-cgroup v2 Overhead
 
 On Fedora CoreOS, containers scheduled using unified cgroups v2 and the `systemd` cgroup driver undergo scope registration via dbus. This triggers kernel memory allocations, systemd-user accounting, and auditing, which requires a baseline overhead of 12-20 MiB of memory before any user workload even executes.
@@ -36,7 +42,7 @@ the Ready condition alone — check three signals via the k8s API:
    and containers are verifiably gone. That satisfies the documented precondition for
    `kubectl delete pod --grace-period=0 --force` (kubernetes/website:
    force-delete-stateful-set-pod.md — safe only when processes are confirmed terminated).
-3. **SSH exec probe**: if a shell opens and builtins (`echo`) work but any binary exec hangs,
+3. **In-cluster shell probe**: if a recovery shell opens and builtins (`echo`) work but any binary exec hangs,
    host root-filesystem I/O is wedged (D-state) — only a power cycle fixes it. Cordon the node.
 
 Cleanup order: cordon → force-delete orphaned pods (frees scheduler requests) → reschedule
@@ -48,4 +54,3 @@ flip back to Delete after the node returns. Never delete the PV object while the
 Known trigger: hostPID build pods SIGTERMing host daemons (issue #268) — the same event can
 kill journald/sshd on workers and crash k3s on ghost (systemd restarts it; expect a short
 API outage and a wave of `connection refused` workflow errors that self-heal on next cron tick).
-

--- a/docs/skills/cluster-tooling/storage.md
+++ b/docs/skills/cluster-tooling/storage.md
@@ -6,6 +6,18 @@ description: >
 
 # Node Storage Maintenance
 
+> [!CAUTION]
+> The host-level diagnostics, filesystem changes, migration steps, and cache
+> relocation procedures in this file are **private maintainer/operator
+> procedures**, not normal public guidance. They can destroy data or strand
+> Kubernetes storage. Never run them from a workstation or use workstation SSH
+> to `ghost` or `exo-0`. Routine operations must use `just`, `argo`, `kubectl`,
+> GitOps, or an approved API-driven recovery workflow. Retain this detail only
+> for a maintainer who has explicitly approved the maintenance window and
+> backup plan.
+
+## Private maintainer procedure — host-level NVMe maintenance
+
 ## NVMe and PCIe Power Management Quirks on Strix Halo (e.g., exo-0)
 
 On Strix Halo platforms, DRAM-less NVMe controllers (like the Innogrit IG5220 / RainierQX) can experience active I/O timeouts (`QID 32 timeout`) and uninterruptible sleep state (`D` state) due to aggressive PCIe ASPM and APST power state transitions.
@@ -57,7 +69,7 @@ cat /sys/module/nvme_core/parameters/default_ps_max_latency_us
 # Expected output: 0 (APST disabled)
 ```
 
-### 3. Optimal Formatting and Mounting (Btrfs to XFS Migration)
+### Operator-only: formatting and mounting (Btrfs to XFS migration)
 
 The 4TB local data NVMe drives are mounted at `/var/mnt/ghost-data` on `ghost` and
 `/var/mnt/exo0-data` on `exo-0` (node-specific names — do not reuse `ghost-data` as the
@@ -92,7 +104,7 @@ Options=defaults,noatime,nodiratime,logbufs=8,logbsize=256k,allocsize=64m
 
 ---
 
-## 4TB SSD Migration Procedures (Btrfs to XFS)
+## Operator-only: 4TB SSD migration procedures (Btrfs to XFS)
 
 ### 1. Migrating `exo-0` (Ephemeral Cache Storage)
 `exo-0`'s 4TB drive is `/dev/nvme1n1`, mounted at `/var/mnt/exo0-data`; it holds
@@ -200,9 +212,12 @@ non-root local-path PVC data. **`/dev/nvme0n1` on `exo-0` is the live system dis
     but don't leave it indefinitely — it silently eats into the same 4TB drive that
     `bst-cache` and `local-path` PVCs need.
 
-### 3. Offloading Host User Caches and AI Datasets (ramalama, local buildstream, containers, and Flatpaks)
+### Operator-only: offloading host user caches and AI datasets
 
-To prevent the `ghost` system root disk from filling up and strictly enforce the "4TB NVMe SSD for all workloads, no exceptions" mandate, heavy host-level user directories under `/var/home/jorge/` are relocated to `/var/mnt/ghost-data/` and replaced with symbolic links. Additionally, all host-level Flatpaks must be completely uninstalled to preserve precious system root disk space.
+This is a maintainer-approved migration record, not a recommendation to
+relocate user data or uninstall software on a host. If a maintainer approves
+the migration, heavy host-level user directories under `/var/home/jorge/` may
+be relocated to `/var/mnt/ghost-data/` and replaced with symbolic links.
 
 #### Host-Level Flatpak Removal:
 All host-level Flatpaks (both system and user-level) must be completely uninstalled to prevent the root partition (under `/var/lib/flatpak` and `~/.local/share/flatpak`) from saturating. Run these commands to purge all Flatpaks from the host:
@@ -259,4 +274,3 @@ All folders are stored under `/var/mnt/ghost-data/` with exact ownership of `jor
    ```bash
    rm -rf /var/home/jorge/.local/share/ramalama.bak /var/home/jorge/.cache/buildstream.bak /var/home/jorge/.local/share/containers.bak /var/home/jorge/.lmstudio.bak /var/home/jorge/.cache/Homebrew.bak /var/home/jorge/.cache/uv.bak
    ```
-

--- a/docs/skills/kubevirt-vms/vm-lifecycle.md
+++ b/docs/skills/kubevirt-vms/vm-lifecycle.md
@@ -47,15 +47,14 @@ provision-containerdisk-vm (provision-containerdisk-vm.yaml)
 
 Check if a containerDisk exists:
 ```bash
-# Fast check — 0 bytes = image lost, rebuild required
-ssh ghost "wc -c /var/mnt/ghost-data/zot-local/bluefin-containerdisk/index.json"
-# Full check
+# API-driven registry check
 skopeo inspect --tls-verify=false docker://<lab-ip>:30500/bluefin-containerdisk:testing
 ```
 
-**Zot data loss:** The `zot-writable` pod (port 30500) loses its `index.json` on every pod or
-k3s restart — the manifest index goes to 0 bytes even though blobs may still exist. Always
-check before running the pipeline; rebuild if the index is empty.
+**Zot data loss:** The `zot-writable` pod (port 30500) can lose its manifest
+index on a pod or k3s restart even though blobs may still exist. Check the
+registry through its API before running the pipeline; rebuild if the manifest
+is unavailable. Do not inspect the host path with workstation SSH.
 
 ### 2a. Native bootc OCI boot — what is and isn't possible
 
@@ -426,4 +425,3 @@ cat /proc/sys/fs/inotify/max_user_watches   # should be >= 1048576
 ```
 
 The DaemonSet applies this on every node restart. Do not remove it.
-


### PR DESCRIPTION
## Summary
- align Justfile and public operational docs with the no-workstation-SSH policy for ghost/exo-0
- route routine operations through just/argo/kubectl/API-driven paths
- preserve in-workflow VM SSH examples while marking host storage, bootstrap, and recovery procedures maintainer-only
- replace the host-path Zot check with an API-driven registry check

## Validation
- `python3 scripts/validate-docs.py`
- `just lint`
- `npm test`

PR intentionally left unmerged.