### PR TITLE
docs: align container QA architecture references

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ lab/
 │   │   ├── run-gnome-tests.yaml          VM-backed behave + qecore + Dogtail tests
 │   │   ├── run-incluster-tests.yaml      in-cluster (kubectl-based) tests
 │   │   ├── run-flatcar-tests.yaml        Flatcar OS test runner
-│   │   ├── provision-flatcar-vm.yaml     provision Flatcar test VM (hostDisk)
+│   │   ├── provision-flatcar-vm.yaml     provision Flatcar test VM (containerDisk)
 │   │   ├── provision-gnomeos-vm.yaml     provision GNOME OS test VM
 │   │   ├── teardown-vm.yaml          delete explicit VM-backed test guests
 │   │   ├── collect-vm-logs.yaml          gather VM journal logs post-test

--- a/README.md
+++ b/README.md
@@ -43,22 +43,25 @@ The lab continuously validates the core operating system family across multiple 
 
 | Image | Tag | Schedule / Trigger | Purpose / Suite |
 |---|---|---|---|
-| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + 10-minute digest polling | Container-only: digest `smoke`; nightly `smoke,developer,system` |
-| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke` |
-| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + 10-minute digest polling | Container-only: digest `smoke`; nightly `smoke,developer,system` |
-| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke` |
+| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC; digest poll every 10 minutes at :00 | Container-only: digest `smoke`; nightly `smoke,developer,system` |
+| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC; digest poll every 10 minutes at :04 | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke` |
+| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC; digest poll every 10 minutes at :02 | Container-only: digest `smoke`; nightly `smoke,developer,system` |
+| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC; digest poll every 10 minutes at :06 | Container-only: digest `smoke,common,developer,software,system`; nightly `smoke` |
 | `ghcr.io/ublue-os/aurora` | `testing`, `stable` | Every 3 hours + OCI digest polling | KDE variant validation (system suite) |
 | `ghcr.io/frostyard/snow` | `latest` | Every 3 hours + on every OCI digest change | Snosi GNOME desktop profile (smoke/developer/system suites) |
-| `ghcr.io/projectbluefin/dakota` | `testing` | 10-minute digest polling; nightly trigger suspended | BuildStream (BST) flatcar-substrate variant; container-only QA after publication |
+| `ghcr.io/projectbluefin/dakota` | `testing` | Digest poll every 10 minutes at :08; nightly 03:00 UTC trigger suspended | BuildStream (BST) variant; container-only QA against the published image |
 
 **Image-poll trigger:** image-poll CronWorkflows check OCI registry digests against
-`image-polling-digests` (10-minute lanes for Bluefin/LTS/Dakota; slower pollers for
-other images). When a digest changes, `image-poller` fans out
-`run-container-tests` and only persists the new digest after QA succeeds.
+`image-polling-digests` (the Bluefin/LTS lanes are staggered at :00/:02/:04/:06,
+and Dakota at :08). A changed Bluefin/LTS digest goes through the standard
+`image-poller` → `bluefin-qa-pipeline` path; Dakota's active manifest routes it to
+`dakota-qa-pipeline`. The standard poller persists its new digest only after QA
+succeeds.
 
 **Result publication:** each selected `run-container-tests` lane writes
-`results.json`, then runs `scripts/publish_test_results.py` to push structured
-per-suite results back into this repo for dashboard consumers.
+`results.json` and attempts `scripts/publish_test_results.py` when
+`GITHUB_TOKEN` is available. Publication failures are warnings; the suite exit
+status remains the QA result.
 
 See [/docs/reference/bluefin-integration.md](/docs/reference/bluefin-integration.md) for full details.
 
@@ -99,11 +102,13 @@ image-poller CronWorkflow
         │
         ├─ unchanged ───────────────► exit cleanly
         │
-        └─ changed ─────────────────► `run-container-tests` fan-out
+        └─ changed ─────────────────► matching Bluefin/Dakota QA pipeline
                                       │
-                                      ├─ qecore + behave inside the bootc OCI image
-                                      ├─ publish per-suite results back to this repo
-                                      └─ update stored digest only after QA succeeds
+                                      └─ `run-container-tests` fan-out
+                                         │
+                                         ├─ qecore + behave inside the bootc OCI image
+                                         ├─ attempt per-suite result publication
+                                         └─ standard poller updates stored digest after QA
 ```
 
 **GitOps loop:**
@@ -154,7 +159,7 @@ lab/
 │   │   ├── bst-commit-poller.yaml       Shared Dakota/Cosmic commit polling and BST admission
 │   │   ├── dakota-qa-pipeline.yaml      container-only Dakota suite fan-out
 │   │   ├── knuckle-qa-pipeline.yaml     Knuckle installer QA pipeline
-│   │   ├── image-poller.yaml            Digest poller: compare → run-container-tests → publish → persist
+│   │   ├── image-poller.yaml            Digest poller: compare → QA pipeline → publish → persist
 │   │   ├── pr-poller.yaml               PR label poller for CI gate
 │   │   ├── register-wec.yaml             register a cluster with KubeStellar
 │   │   ├── kubestellar-smoke-test.yaml   verify downsync + status upsync
@@ -187,7 +192,7 @@ lab/
 │   ├── pr-image-gc.yaml                  CronWorkflow: GC PR container images
 │   ├── image-poll-bluefin-testing.yaml   CronWorkflow: poll bluefin:testing digest
 │   ├── image-poll-bluefin-stable.yaml    CronWorkflow: poll bluefin:stable digest
-│   ├── image-poll-bluefin-main.yaml      CronWorkflow: poll bluefin:latest digest
+│   ├── image-poll-bluefin-main.yaml      CronWorkflow: poll ublue-os/bluefin:latest digest
 │   ├── image-poll-lts-testing.yaml       CronWorkflow: poll bluefin-lts:testing digest
 │   ├── image-poll-lts-stable.yaml        CronWorkflow: poll bluefin-lts:stable digest
 │   ├── image-poll-dakota.yaml             CronWorkflow: poll dakota:testing digest
@@ -241,10 +246,10 @@ lab/
 
 | Phase | Suite | Trigger |
 |---|---|---|
-| 1 — Smoke | `smoke` | Every PR, nightly |
-| 2 — Developer tooling | `developer` | Nightly, targeted |
-| 3 — Software management | `software` | Targeted |
-| 4 — Atomic OS contract | `system` | Nightly, every image build |
+| 1 — Smoke | `smoke` | Every PR, digest poll, nightly |
+| 2 — Developer tooling | `developer` | Testing-lane nightlies, targeted |
+| 3 — Software management | `software` | Stable/latest digest polls, targeted |
+| 4 — Atomic OS contract | `system` | Testing-lane nightlies, selected digest polls |
 | 5 — Flatcar substrate | `flatcar` | Dedicated workflow |
 | — Migration validation | `migration` | On rechunk → chunkah switches |
 | — Dakota BST | `dakota` | Every Dakota PR; see [Dakota PR review](docs/skills/dakota-pr-review/SKILL.md) for exact-SHA build, E2E, repair, and direct-merge policy |
@@ -307,8 +312,8 @@ just run-tests
 |---|---|
 | `argo` | Argo Workflows + ArgoCD (control plane) |
 | `argocd` | ArgoCD controller |
-| `bluefin-test` | `latest` test VMs |
-| `bluefin-lts-test` | `lts` test VMs |
+| `bluefin-test` | Explicit VM-backed Bluefin/migration test VMs |
+| `bluefin-lts-test` | Explicit VM-backed Bluefin-LTS test VMs |
 | `flatcar-test` | Flatcar test VMs |
 | `gnomeos-test` | GNOME OS test VMs |
 | `llm-d` | Local inference namespace (vLLM on ROCm; managed by ArgoCD with 1 GPU-backed replica) |

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -45,8 +45,10 @@ coverage.
 | Loki | log aggregation | `http://<ghost-ip>:30100` | Captures workflow pod logs |
 | ArgoCD | GitOps controller | `https://<ghost-ip>` | Reconciles this repo into the cluster |
 
-All KubeVirt VMs are pinned to ghost. Container QA runs on the control-plane seat on
-ghost; other workflow pods may land on exo-0 according to template constraints.
+Container QA runs on the control-plane graphical seat on ghost. Flatcar VMs float
+across KubeVirt-capable nodes. Knuckle VMs co-schedule on the node holding their
+local-path PVC. Other workflow pods may land on exo-0 according to template
+constraints.
 
 ## GitOps ownership
 
@@ -141,7 +143,7 @@ Argo Workflow (argo namespace)
 
 | Symptom | Root cause | Durable fix |
 |---|---|---|
-| `Permission denied (publickey)` during SSH wait | A fresh VM's golden disk contains an old public key | Re-patch or rebuild the golden disk; escalate host-storage changes to a human operator |
+| `Permission denied (publickey)` during SSH wait | Ephemeral VM cloud-init or installer key provisioning did not install the expected authorized key | Verify the `ssh-pubkey`/`ssh-key-secret` inputs and cloud-init or installer completion, then inspect VMI and runner logs before rerunning |
 | Workflow hangs before GUI steps start | VM boot or SSH readiness never completed | Inspect VMI readiness and runner logs, then re-run the appropriate recovery path |
 | `TypeError` involving `requireResult` | Stale dogtail step pattern | Replace with `findChildren(...)` or `findChild(..., retry=False)` |
 | Clock / quick-settings scenarios miss their targets | GNOME Shell AT-SPI geometry gap | Drive the interaction via `Shell.Eval` |

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -20,7 +20,7 @@ Two steady-state execution paths exist:
 | Path | Purpose | Persistent state |
 |---|---|---|
 | Container-only Bluefin/Dakota path | Image and PR QA | No persistent VM or host-disk state |
-| Fresh VM path | Lanes that explicitly require KubeVirt | Golden disk under `/var/tmp/bluefin-golden/<tag>/disk.raw` |
+| Explicit VM-backed lanes | Flatcar smoke and Knuckle installer QA | Ephemeral KubeVirt resources; no shared Bluefin golden disk |
 
 ### Container-only QA contract
 
@@ -70,12 +70,13 @@ The repo is intentionally GitOps-first: cluster state should converge from git, 
 
 | Object | Backing location | Used by | Notes |
 |---|---|---|---|
-| Golden disk (`latest`) | `/var/tmp/bluefin-golden/latest/disk.raw` | Fresh-VM pipeline | Built by `bib-build-and-push` |
-| Golden disk (`lts`) | `/var/tmp/bluefin-golden/lts/disk.raw` | Fresh-VM pipeline | Built by `bib-build-and-push` |
-| Per-run hostDisk clone | `/var/tmp/bluefin-golden/*-runs/...` | Provisioned fresh VMs | Removed by teardown or orphan cleanup |
+| Published OCI image | Registry image and digest | Bluefin/Dakota container-only QA | `bluefin-qa-pipeline` and `dakota-qa-pipeline` run `run-container-tests`; no VM or disk is created |
+| Flatcar test VM | Ephemeral KubeVirt VM with generated Flatcar containerDisk | `flatcar-smoke-test` | Provisioned from the current Flatcar image and torn down after the run; no golden disk or hostDisk |
+| Knuckle test VM | Ephemeral KubeVirt VM with per-run local-path PVC and ISO containerDisk | `knuckle-qa-pipeline` | Teardown removes the VM, root-disk PVC, and per-run ISO containerDisk |
 
-The SSH secret lives in the `bluefin-test-ssh-key` Kubernetes secret in namespace `argo`.
-Golden-disk key rotation and other host-storage changes remain maintainer-gated.
+The `bluefin-test-ssh-key` Kubernetes secret in namespace `argo` is used only for
+in-cluster access to explicit VM-backed test guests. Container-only Bluefin/Dakota
+QA does not require SSH, golden disks, or hostDisk state.
 
 ## Test execution stack
 

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -22,6 +22,19 @@ Two steady-state execution paths exist:
 | Container-only Bluefin/Dakota path | Image and PR QA | No persistent VM or host-disk state |
 | Fresh VM path | Lanes that explicitly require KubeVirt | Golden disk under `/var/tmp/bluefin-golden/<tag>/disk.raw` |
 
+### Container-only QA contract
+
+`bluefin-qa-pipeline` and `dakota-qa-pipeline` both fan out
+`run-container-tests` inside the published OCI image. The runner clones
+`projectbluefin/testsuite`, starts the nested systemd/Wayland session, and
+attempts to publish `results.json` when `GITHUB_TOKEN` is available. A
+publication warning does not change the suite exit status.
+
+The Bluefin/LTS digest pollers are staggered at minutes `:00`, `:02`, `:04`,
+and `:06` of each ten-minute interval. Dakota's active poller runs at `:08`,
+routes to `dakota-qa-pipeline`, and the suspended `nightly-dakota` is not active
+coverage.
+
 ## Cluster topology
 
 | Host | Role | IP | Notes |

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -143,7 +143,7 @@ Argo Workflow (argo namespace)
 
 | Symptom | Root cause | Durable fix |
 |---|---|---|
-| `Permission denied (publickey)` during SSH wait | Ephemeral VM cloud-init or installer key provisioning did not install the expected authorized key | Verify the `ssh-pubkey`/`ssh-key-secret` inputs and cloud-init or installer completion, then inspect VMI and runner logs before rerunning |
+| `Permission denied (publickey)` during SSH wait | Ephemeral VM cloud-init or installer key provisioning did not install the expected authorized key | Verify the `ssh-pubkey`/`ssh-key-secret` inputs and cloud-init or installer completion. For the `bluefin-migration-test`/`provision-containerdisk-vm` path, confirm `bluefin-test-ssh-pubkey` is wired through `accessCredentials.sshPublicKey` with `qemuGuestAgent`, then wait for VMI `AccessCredentialsSynchronized=True` before retrying SSH; inspect VMI and runner logs |
 | Workflow hangs before GUI steps start | VM boot or SSH readiness never completed | Inspect VMI readiness and runner logs, then re-run the appropriate recovery path |
 | `TypeError` involving `requireResult` | Stale dogtail step pattern | Replace with `findChildren(...)` or `findChild(..., retry=False)` |
 | Clock / quick-settings scenarios miss their targets | GNOME Shell AT-SPI geometry gap | Drive the interaction via `Shell.Eval` |

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -193,8 +193,9 @@ QA pipelines.
 
 ### `provision-flatcar-vm` (template: `provision-vm`)
 
-Same shape for Flatcar — accepts an `ssh-pubkey` parameter directly instead
-of relying on the bluefin-test secret for cloud-init injection.
+Same shape for Flatcar — `flatcar-smoke-test` leaves `ssh-pubkey` empty by
+default. After cloud-init, `bluefin-test-ssh-key` supplies `id_ed25519.pub`
+through the QEMU guest agent before the readiness step returns the VM IP.
 
 ### `run-gnome-tests` (template: `run-gnome-tests`)
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -9,8 +9,9 @@ Conventions:
 - All templates live in `argo/workflow-templates/*.yaml` and are reconciled
   to namespace `argo` by the ArgoCD `lab` Application.
 - Workflow-level parameters listed below are passed via `-p name=value`.
-- Wall-clock targets are warm-cache numbers; cold-cache figures (BIB build
-  on a missing golden disk) add ~5–10 min.
+- Wall-clock targets are warm-cache numbers; cold-cache figures for explicit
+  VM/containerDisk lanes add several minutes. Container-only Bluefin/Dakota
+  runs do not build a disk or boot a VM.
 - The agent contract: prefer the **top-level** templates (`bluefin-qa-pipeline`,
   `dakota-qa-pipeline`). The supporting templates (provision, run, teardown)
   are called as `templateRef` and rarely submitted directly.
@@ -39,6 +40,33 @@ Wall-clock: depends on the selected suite set and container-qa semaphore.
 
 ```
 argo submit --from workflowtemplate/bluefin-qa-pipeline \
+  -p image-tag=testing -p suites=smoke --wait
+```
+
+### `dakota-qa-pipeline`
+
+Container-only Dakota pipeline: validate the requested suites, fan out
+`run-container-tests` inside the published Dakota OCI image, and return a
+summary. It does not build a containerDisk, boot a VM, or use the legacy
+`dakota-container-qa-pipeline` image-smoke path.
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `image` | `ghcr.io/projectbluefin/dakota` | Published OCI image repository. |
+| `image-tag` | `testing` | Image tag to test. |
+| `image-digest` | empty | Optional digest pin for exact-image QA. |
+| `suites` | `smoke,common,developer,software,system` | Comma list of supported suites. |
+| `variant` | `dakota` | Selects Dakota test fixtures. |
+| `branch` | `main` | Lab branch passed to workflow metadata. |
+| `testsuite-branch` | `main` | `projectbluefin/testsuite` branch to clone. |
+
+The active `image-poll-dakota` CronWorkflow requests only `smoke` against
+`ghcr.io/projectbluefin/dakota:testing`. Full-suite manual runs use
+`just run-dakota-qa`; the Dakota BuildStream pipeline publishes its build
+artifacts to local Zot separately.
+
+```
+argo submit --from workflowtemplate/dakota-qa-pipeline \
   -p image-tag=testing -p suites=smoke --wait
 ```
 
@@ -151,19 +179,17 @@ Env vars passed to the test container: `TEST_NAMESPACE`, `TEST_LANE`,
 `tests/service_catalog/shared/` (deploy, persistence, reachability,
 redeploy, teardown).
 
-### `bib-build-and-push` (template: `ensure-disk`)
+### `build-bluefin-migration-containerdisk` (template: `build-containerdisk`)
 
-Builds the golden raw disk via `bootc-image-builder` if missing or stale.
-Stale detection compares the upstream image digest (via skopeo) against the
-`source-digest` marker written next to the disk on hostPath.
+Builds the containerDisk used only by the explicit Bluefin migration workflow.
+It is not part of `bluefin-qa-pipeline` or `dakota-qa-pipeline`, which run
+directly in OCI images.
 
-Outputs: no `outputs.parameters`; side effect is
-`/var/tmp/bluefin-golden/<image-tag>/disk.raw` and `source-digest` on ghost.
+### `provision-containerdisk-vm` (template: `provision-vm`)
 
-### `provision-bluefin-vm` (template: `provision-vm`)
-
-btrfs `cp --reflink=auto` from the golden disk, applies SVirt label, creates
-a KubeVirt VM, waits for SSH/IP, emits `vm-ip` as an output parameter.
+Provisions an explicit KubeVirt VM from a containerDisk and emits `vm-ip`.
+This is a VM-backed support path, not part of the container-only Bluefin/Dakota
+QA pipelines.
 
 ### `provision-flatcar-vm` (template: `provision-vm`)
 
@@ -273,10 +299,10 @@ just run-aurora-kde-sabotage
 Same shape for Flatcar; uses `core` as the SSH user and runs pytest+dogtail
 fixtures from `tests/flatcar/`.
 
-### `teardown-bluefin-vm` / `teardown-flatcar-vm`
+### `teardown-vm`
 
-Delete the VM, wait for the VMI object to drain, then `rm` the per-run
-hostDisk clone. Invoked as `onExit` from the pipeline templates.
+Deletes a named KubeVirt VM in its namespace. Invoked as `onExit` by the
+explicit VM-backed pipeline templates.
 
 ---
 
@@ -463,7 +489,13 @@ Lives in `manifests/`, applied via the `lab-infra` ArgoCD app:
 | `nightly-smoke-stable` | 03:00 UTC | `bluefin-qa-pipeline` (`stable`, `smoke`) | Stable image regression coverage |
 | `nightly-smoke-lts` | 02:30 UTC | `bluefin-qa-pipeline` (`testing`) | LTS regression coverage |
 | `nightly-smoke-lts-stable` | 03:30 UTC | `bluefin-qa-pipeline` (`stable`, `smoke`) | Stable LTS regression coverage |
-| `image-poll-dakota` | Every 10 min | `dakota-qa-pipeline` (`testing`) | Active Dakota digest-triggered QA |
+| `image-poll-bluefin-testing` | Every 10 min at :00 | `bluefin-qa-pipeline` (`testing`, `smoke`) | Active Bluefin digest-triggered QA |
+| `image-poll-lts-testing` | Every 10 min at :02 | `bluefin-qa-pipeline` (`testing`, `smoke`) | Active Bluefin-LTS digest-triggered QA |
+| `image-poll-bluefin-stable` | Every 10 min at :04 | `bluefin-qa-pipeline` (`stable`, full suite) | Active Bluefin stable digest-triggered QA |
+| `image-poll-lts-stable` | Every 10 min at :06 | `bluefin-qa-pipeline` (`stable`, full suite) | Active Bluefin-LTS stable digest-triggered QA |
+| `image-poll-dakota` | Every 10 min at :08 | `dakota-qa-pipeline` (`testing`, `smoke`) | Active Dakota digest-triggered QA |
+| `image-poll-bluefin-main` | Every 3h at :12 | `bluefin-qa-pipeline` (`latest`, full suite) | Active upstream Bluefin digest-triggered QA |
+| `image-poll-snosi-latest` | Every 3h at :30 | `bluefin-qa-pipeline` (`latest`, `smoke,developer,system`) | Active Snosi digest-triggered QA |
 | `nightly-dakota` | 03:00 UTC | `dakota-qa-pipeline` (`latest`) | Suspended; does not provide active coverage |
 | `orphan-vm-cleanup` | every 2h | inline | GC stale per-run hostDisks in bluefin, flatcar, and knuckle namespaces |
 

--- a/docs/reference/bluefin-integration.md
+++ b/docs/reference/bluefin-integration.md
@@ -11,12 +11,12 @@ release consumers.
 
 | Image | Tag | Trigger | QA path |
 |---|---|---|---|
-| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
-| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
-| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
-| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC + 10-minute digest polling | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` |
-| `ghcr.io/frostyard/snow` | `latest` | Every 3 hours + digest change | Poller → `bluefin-qa-pipeline` container lane |
-| `ghcr.io/projectbluefin/dakota` | `testing` | 10-minute digest polling; nightly trigger suspended | `image-poll-dakota` → `dakota-qa-pipeline` → `run-container-tests` |
+| `ghcr.io/projectbluefin/bluefin` | `testing` | Nightly 02:00 UTC; digest poll every 10 minutes at :00 | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` (`smoke`) |
+| `ghcr.io/projectbluefin/bluefin` | `stable` | Nightly 03:00 UTC; digest poll every 10 minutes at :04 | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` (full suite) |
+| `ghcr.io/projectbluefin/bluefin-lts` | `testing` | Nightly 02:30 UTC; digest poll every 10 minutes at :02 | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` (`smoke`) |
+| `ghcr.io/projectbluefin/bluefin-lts` | `stable` | Nightly 03:30 UTC; digest poll every 10 minutes at :06 | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` (full suite) |
+| `ghcr.io/frostyard/snow` | `latest` | Every 3 hours at :30 + digest change | `image-poller` → `bluefin-qa-pipeline` → `run-container-tests` (`smoke,developer,system`) |
+| `ghcr.io/projectbluefin/dakota` | `testing` | Digest poll every 10 minutes at :08; nightly 03:00 UTC trigger suspended | `image-poll-dakota` → `dakota-qa-pipeline` → `run-container-tests` (`smoke`) |
 
 Bluefin and Bluefin-LTS `:testing` and `:stable` lanes are scheduled continuously.
 Dakota's nightly CronWorkflow is suspended; its active digest-poll lane tests the
@@ -70,16 +70,20 @@ Flatcar OS substrate tests. Not part of the Bluefin image pipelines; runs via
 
 ## Image-Poll Trigger
 
-The Bluefin, Bluefin-LTS, and Dakota image-poll CronWorkflows run every 10 minutes
-and call the `image-poller` WorkflowTemplate. Each run:
+The Bluefin and Bluefin-LTS image-poll CronWorkflows run every 10 minutes at
+staggered offsets (`:00`, `:02`, `:04`, and `:06`) and call the generic
+`image-poller` WorkflowTemplate. Dakota's `image-poll-dakota` CronWorkflow runs
+at `:08` and owns a small check-and-trigger DAG that calls the Dakota pipeline.
+Each poll run:
 
 1. Pulls the current digest for the target image from ghcr.io
 2. Reads the last-known digest from `image-polling-digests` in namespace `argo`
 3. If digests match: exits cleanly (no test run)
-4. If the digest changed: submits `bluefin-qa-pipeline` for Bluefin and Bluefin-LTS,
-   or `dakota-qa-pipeline` for Dakota; each fans out `run-container-tests`
-5. Each selected suite publishes its structured results back into this repo
-6. Only after the downstream workflow succeeds does `image-poller` persist the new digest
+4. If the digest changed: submits `bluefin-qa-pipeline` for Bluefin/LTS or
+   `dakota-qa-pipeline` for Dakota; each fans out `run-container-tests`
+5. Each selected suite attempts to publish its structured results back into this repo
+6. The generic Bluefin/LTS `image-poller` persists its new digest only after the
+   downstream workflow succeeds
 
 This means a changed Bluefin, Bluefin-LTS, or Dakota digest triggers
 container-only validation within 10 minutes, automatically, with no human action.
@@ -88,18 +92,22 @@ container-only validation within 10 minutes, automatically, with no human action
 
 ## Result Publication Pipeline
 
-`run-container-tests` writes `results.json` and then, when `github-token` is
-available, clones this repository and runs `scripts/publish_test_results.py` to
-merge the new suite outcome into the tracked results data. The publication flow is:
+`run-container-tests` writes `results.json` and, when `github-token` is
+available, clones this repository and attempts `scripts/publish_test_results.py`
+to merge the new suite outcome into the tracked results data. Publication is
+best-effort: a publication warning does not change the suite exit status. The
+publication flow is:
 
 1. Execute the selected behave suite inside the bootc OCI image
 2. Write `results.json`, `behave-rc.txt`, and a summary file under `/tmp/results`
 3. Clone `projectbluefin/lab` with `github-token`
 4. Run `scripts/publish_test_results.py` for the image/suite/workflow tuple
-5. Push the updated structured results back to the repo for dashboard consumers
+5. Attempt to push the updated structured results back to the repo for dashboard
+   consumers
 
-The result: a Bluefin or Dakota image is published → tests run in containers →
-the repo receives per-suite QA results without any VM-specific artifact handling.
+The result: a selected Bluefin or Dakota image is tested in containers, and the
+repo receives per-suite QA results when publication succeeds, without any
+VM-specific artifact handling.
 
 ---
 
@@ -115,8 +123,9 @@ just run-tests-tag lts-testing
 # Run the default testing/lts-testing matrix
 just run-tests-matrix
 
-# Submit a named workflow directly
-argo submit argo/bluefin-smoke-test.yaml --watch
+# Submit the container-only workflow directly
+argo submit --from workflowtemplate/bluefin-qa-pipeline \
+  -p image-tag=testing -p suites=smoke -n argo --watch
 ```
 
 The `just` wrappers are thin shims around `argo submit`. See `Justfile` for the

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -43,13 +43,11 @@ bridge that submits Argo Workflows from ephemeral ARC runners, see
 ### dakota-qa-pipeline
 - **Purpose:** Run Dakota suites directly inside the published bootc OCI image using
   the same container-only fan-out model as `bluefin-qa-pipeline`.
-- **VM boundary:** Dakota's composefs-oci image declares `bootloader = "systemd"`
-  but does not ship a UKI. The standard `build-containerdisk` →
-  `bootc install to-disk` path therefore stops with
-  `bootupd is required for ostree-based installs`; changing the bootloader
-  setting in the lab would not produce a bootable image. A VM path remains
-  blocked pending an upstream Dakota UKI/bootupd capability or a maintainer
-  decision to adopt a separate golden-disk/export path.
+- **VM boundary:** This active QA pipeline has no containerDisk build, VM boot,
+  reboot, or SSH stage. The separate Dakota migration/containerDisk experiment
+  remains blocked because the composefs-oci image declares `bootloader =
+  "systemd"` but does not ship a UKI; `bootc install to-disk` therefore stops
+  with `bootupd is required for ostree-based installs`.
 - **Current coverage:** `run-container-tests` provides the container-only suite
   fan-out, including the nested systemd/Wayland session used by qecore-headless.
   This lane provides image and GUI-session evidence, but not VM boot or reboot
@@ -167,8 +165,8 @@ infrastructure blockers and repair the lab before retrying.
 
 | Template | Role |
 | --- | --- |
-| `image-poller` | Digest-comparison trigger for the bootc image-poll lane. Flow: fetch GHCR digest → compare with `image-polling-digests` → submit `bluefin-qa-pipeline` on change → persist digest only after downstream success. |
-| `run-container-tests` | Shared container-only runner for Bluefin/Dakota bootc images. Clones `projectbluefin/testsuite`, starts a Wayland session in the target OCI image, runs `behave`, publishes per-suite results back to this repo, and writes a summary file for workflow outputs. |
+| `image-poller` | Digest-comparison trigger for the Bluefin/LTS bootc image-poll lane. Flow: fetch GHCR digest → compare with `image-polling-digests` → submit `bluefin-qa-pipeline` on change → persist digest only after downstream success. Dakota uses the same digest comparison template but its custom CronWorkflow routes to `dakota-qa-pipeline`. |
+| `run-container-tests` | Shared container-only runner for Bluefin/Dakota bootc images. Clones `projectbluefin/testsuite`, starts a Wayland session in the target OCI image, runs `behave`, attempts best-effort result publication when `github-token` is available, and writes a summary file for workflow outputs. Publication warnings do not change the suite exit status. |
 | `provision-flatcar-vm` / `provision-gnomeos-vm` | VM-backed provisioning paths for the lanes that still need KubeVirt. Both set `priorityClassName: lab-test-vm`. |
 | `teardown-vm` | Deletes any KubeVirt test VM (and hostDisk/PVC where applicable). |
 | `run-gnome-tests` | Shared VM-backed test runner. Clones `projectbluefin/testsuite`, waits for SSH, installs dependencies, copies `tests/<suite>`, and runs `behave` against a live guest. |
@@ -197,10 +195,13 @@ must fail for repair; it must not use an Ethernet, local, or cache-only fallback
 | --- | --- | --- | --- |
 | `dakota-commit-poller` | every 5 min at minute +2 | shared `bst-commit-poller` → `dakota-build-pipeline` when `dakota:testing` changes | Dakota BuildStream cache/execution path |
 | `cosmic-commit-poller` | every 5 min at minute +4 | shared `bst-commit-poller` → `cosmic-build-pipeline` when `cosmic-build-meta:main` changes | Cosmic BuildStream cache/execution path |
-| `image-poll-bluefin-{testing,stable}` / `image-poll-lts-{testing,stable}` | 10 min | `image-poller` when the respective GHCR tag digest changes | Bluefin/LTS container-only QA freshness plus result publication |
-| `image-poll-dakota` | 10 min | `image-poller` when `dakota:testing` changes | Dakota container-only QA plus result publication |
-| `image-poll-bluefin-main` | 3h | `image-poller` when `bluefin:latest` changes | Bluefin latest container-only QA |
-| `image-poll-snosi-latest` | 30 min past every 3 hours | `bluefin-qa-pipeline` when `ghcr.io/frostyard/snow:latest` changes | Snosi GNOME desktop image coverage |
+| `image-poll-bluefin-testing` | every 10 min at :00 | `image-poller` when `ghcr.io/projectbluefin/bluefin:testing` changes | Bluefin container-only QA (`smoke`) |
+| `image-poll-lts-testing` | every 10 min at :02 | `image-poller` when `ghcr.io/projectbluefin/bluefin-lts:testing` changes | Bluefin-LTS container-only QA (`smoke`) |
+| `image-poll-bluefin-stable` | every 10 min at :04 | `image-poller` when `ghcr.io/projectbluefin/bluefin:stable` changes | Bluefin container-only QA (full suite) |
+| `image-poll-lts-stable` | every 10 min at :06 | `image-poller` when `ghcr.io/projectbluefin/bluefin-lts:stable` changes | Bluefin-LTS container-only QA (full suite) |
+| `image-poll-dakota` | every 10 min at :08 | custom digest DAG → `dakota-qa-pipeline` when `ghcr.io/projectbluefin/dakota:testing` changes | Dakota container-only QA (`smoke`) |
+| `image-poll-bluefin-main` | every 3h at :12 | `image-poller` when `ghcr.io/ublue-os/bluefin:latest` changes | Bluefin latest container-only QA (full suite) |
+| `image-poll-snosi-latest` | every 3h at :30 | `image-poller` when `ghcr.io/frostyard/snow:latest` changes | Snosi GNOME desktop image coverage |
 | `flatcar-kernel-poller` | 10 min | `flatcar-kernel-build` when kernel.org's latest stable version changes | Flatcar kernel build cache |
 | `flatcar-kernel-gate` | 30 min | (gate/promotion check, see `/docs/skills/flatcar-node-onboarding/SKILL.md`) | N/A |
 
@@ -246,7 +247,7 @@ the next cycle.
 | `nightly-smoke-stable` | 03:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=stable`, `suites=smoke`, `variant=bluefin` |
 | `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin-lts` |
 | `nightly-smoke-lts-stable` | 03:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=stable`, `suites=smoke`, `variant=bluefin-lts` |
-| `nightly-dakota` | 03:00 | `dakota-qa-pipeline` | Tests pre-built `dakota:latest` only; currently `suspend: true`. |
+| `nightly-dakota` | 03:00 | `dakota-qa-pipeline` | `image=ghcr.io/projectbluefin/dakota`, `image-tag=latest`, `suites=smoke,developer,system`, `variant=dakota`; currently `suspend: true`. |
 | `nightly-knuckle` | 03:30 | `knuckle-qa-pipeline` | `branch=main`, `namespace=knuckle-test`, `suite=smoke`, `tests-branch=main` |
 
 ## Priority Classes

--- a/docs/skills/test-authoring/dogtail-patterns.md
+++ b/docs/skills/test-authoring/dogtail-patterns.md
@@ -38,11 +38,11 @@ This repo follows the upstream conventions; when in doubt, the upstream docs win
 
 | Layer                     | Role                                                                        |
 |---------------------------|-----------------------------------------------------------------------------|
-| **KubeVirt VM**           | Explicit VM-backed lanes only; Bluefin images boot with Wayland + GNOME Shell 50. |
+| **KubeVirt VM**           | Explicit VM-backed lanes only; container-only Bluefin/Dakota QA does not boot a VM. |
 | **gnome-ponytail-daemon** | Bridges AT-SPI coordinates → Wayland surface coordinates (input injection). |
 | **qecore-headless**       | Boots Wayland/GNOME session, sets `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`, activates ponytail-daemon. |
 | **qecore.TestSandbox**    | Per-test bookkeeping: app handles, journal scoping, screenshots, retries.   |
-| **dogtail 4.16**          | AT-SPI tree traversal (`tree.root.application(...)`, `findChild(ren)`).     |
+| **dogtail 2.x**           | AT-SPI tree traversal (`tree.root.application(...)`, `findChild(ren)`).     |
 | **behave**                | BDD runner. Feature files in Gherkin; step defs in Python.                  |
 | **pytest**                | Adjacent suite for command/file/journal assertions (no GUI needed).         |
 | **Shell.Eval (gdbus)**    | Escape hatch for GNOME 50 gaps in AT-SPI / `uinput`.                        |
@@ -91,8 +91,8 @@ tests/
 1. **You push** to `main` or a PR branch.
 2. **You submit** `bluefin-qa-pipeline` or `dakota-qa-pipeline` (for example,
    `just run-tests` or `just run-dakota-qa`).
-3. **Argo** starts `run-container-tests` on ghost, where the published OCI image
-   provides the nested systemd/Wayland session.
+3. **Argo** starts `run-container-tests` on ghost's control-plane graphical seat,
+   where the published OCI image provides the nested systemd/Wayland session.
 4. The runner clones `projectbluefin/testsuite`, installs or verifies qecore,
    behave, dogtail, pytest, and the Wayland input dependencies, then runs the
    selected suite and writes structured results.
@@ -373,8 +373,8 @@ The `a11y_app_name` is the AT-SPI registration. Confirmed names in this repo:
 | Podman Desktop | `Podman Desktop` (Flatpak)            |
 
 When in doubt, run a scenario that calls `Dump gnome-shell AT-SPI tree to results` — the
-output is written to `/tmp/results/atspi_tree.txt`, retrieved by SCP, and printed to the
-pod's stderr.
+output is written to `/tmp/results/atspi_tree.txt` and printed to the runner pod's stderr
+for collection from Argo logs.
 
 ### 6.7 Flatpak / Podman Desktop
 
@@ -736,11 +736,11 @@ Mitigations applied:
 2. In any step that traverses the AT-SPI tree (especially overview search), catch
    `"does not exist"` / `"atspi_error"` exceptions and retry (up to ~6×, 2 s delay).
 
-**Headless sessions have no monitor output — test extension *state*, not visual actors.**
-`qecore-headless` sessions run without a physical or virtual display. Extensions that depend on
-a monitor to create visual actors (Dash to Dock dock actors, App Indicators panel statusArea
-actors) will never create those actors. Assertions that check dock actor count or panel children
-will always fail.
+**Headless sessions do not guarantee monitor-backed actors — test extension *state* first.**
+The container runner uses ghost's control-plane graphical seat, while `qecore-headless`
+manages the nested session. Extensions that depend on monitor output to create visual actors
+(Dash to Dock dock actors, App Indicators panel statusArea actors) may still omit those actors.
+Assertions that check dock actor count or panel children must therefore be conditional.
 
 Correct assertion pattern for headless extension coverage:
 ```python


### PR DESCRIPTION
## Summary
- align Bluefin/LTS/Dakota container-only QA wording with current WorkflowTemplates and Justfile
- document exact digest-poll offsets, current nightly coverage, publication best-effort behavior, and topology names
- remove retired workflow-template references from the canonical workflow docs

## Validation
- `python3 scripts/validate-docs.py`
- `just lint`
- `git diff --check`

Docs-only change. Do not merge automatically.