### PR TITLE
docs(kde): clarify screenshot persistence and QEMU screendump rationale

### DIFF
--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -288,7 +288,15 @@ spec:
           IMG_SLUG="aurora-${{inputs.parameters.containerdisk-tag}}"
         fi
 
-        # Screenshot discovery; GHCR upload is disabled, retained locally only.
+        # Screenshot discovery. Screenshots are captured in-guest by the
+        # selenium-webdriver-at-spi/KPipeWire session. KubeVirt's
+        # virt-launcher does not expose a QEMU monitor, so a monitor-based
+        # screendump helper (the approach testsuite's disabled fallback
+        # script relies on) is impossible here and is intentionally never
+        # invoked by this template. GHCR OCI artifact publication of the
+        # screenshot is disabled repo-wide — see
+        # docs/superpowers/specs/2026-07-30-block-ghcr-pushes-design.md —
+        # so the screenshot is retained only in the hostPath results bundle.
         SHOT=$(find /tmp/results -type f -name '*.png' -print -quit)
         if [[ -z "${SHOT}" || ! -f "${SHOT}" ]]; then
           echo "ERROR: KDE test did not produce a screenshot artifact" >&2

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -214,12 +214,16 @@ starts the VM's `selenium-webdriver-at-spi-run` service, waits for its
 `/status` endpoint, and runs `tests/kde-smoke/features` with Behave. Results
 and in-guest PNG screenshots are copied back even when Behave fails, then
 persisted under the standard ghost test-results host path. `faillog_*`
-directories are retained alongside `.tar.gz` bundles, and the first screenshot
-is pushed as the stable `desktop-screenshot` OCI artifact. The GitHub
-credential, ORAS tool, screenshot, artifact persistence, and result publication
-are required and fail the runner when unavailable. QEMU-level screendumps are
-not used because
-KubeVirt's `virt-launcher` does not expose a QEMU monitor.
+directories are retained alongside `.tar.gz` bundles. The first screenshot is
+required as evidence but its GHCR/`oras push` publication is disabled
+repo-wide (see
+`docs/superpowers/specs/2026-07-30-block-ghcr-pushes-design.md`); it is
+retained only in the hostPath results bundle, and the runner reports "GHCR
+screenshot publication disabled" instead of silently claiming success. The
+GitHub credential, screenshot presence, artifact persistence, and result
+publication are required and fail the runner when unavailable. QEMU-level
+screendumps are not used because KubeVirt's `virt-launcher` does not expose a
+QEMU monitor.
 
 The runner accepts `failure-class: test|infra` and `failure-issue-url`
 parameters. A failed run classified as infrastructure must include the URL of


### PR DESCRIPTION
## Summary

Closes #464 by auditing `run-kde-tests.yaml` against its acceptance criteria and fixing the remaining gaps.

## What was already done (via #487/#493/#503)

- Results written to `/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}` (same structure as GNOME).
- `faillog_*` bundles are tarred via `python3 -m tarfile -c` and included in the results directory.
- `scripts/publish_test_results.py` is called on test completion.
- No reference to `qemu_screendump` anywhere in the KDE lab workflow.

## What this PR fixes

1. **Inline template documentation** (acceptance criterion: "Documentation comment in template explaining why QEMU screendumps are not used"). The screenshot-collection step in `run-kde-tests.yaml` only had a one-line comment ("GHCR upload is disabled, retained locally only") with no explanation of *why* QEMU-level screendumps aren't used. Added a comment explaining that KubeVirt's virt-launcher does not expose a QEMU monitor, so a monitor-based screendump fallback is impossible and intentionally never invoked, and that in-guest screenshots are retained in the hostPath results bundle.

2. **Stale docs fix**: `docs/reference/WORKFLOWS.md` still described the *old* behavior — "the first screenshot is pushed as the stable `desktop-screenshot` OCI artifact" and "ORAS tool ... required" — which was removed by #503's GHCR-push-blocking change but the doc wasn't updated to match. Fixed to describe the actual (disabled) publish behavior.

## Note on the "oras push" acceptance criterion

This issue predates (2026-07-28) the repo-wide GHCR-push-blocking design (merged 2026-07-31, #503), which explicitly and intentionally disabled screenshot `oras push` publication for both `run-gnome-tests` and `run-kde-tests` — see `docs/superpowers/specs/2026-07-30-block-ghcr-pushes-design.md`. This is enforced by regression tests (`tests/unit/test_no_ghcr_push_destinations.py::test_screenshot_templates_are_disabled_unconditionally`, `tests/unit/test_workflow_defaults.py::test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots`) that assert `"oras push" not in kde`. Re-adding an `oras push` for screenshots would violate that later, intentional security decision and fail CI, so this PR keeps publication disabled and instead documents the rationale as requested by the issue's other acceptance criteria.

## Verification

- Manually re-checked all string-based assertions from `tests/unit/test_workflow_defaults.py::test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots` and `tests/unit/test_no_ghcr_push_destinations.py::test_screenshot_templates_are_disabled_unconditionally` against the edited file (no `pytest`/`argo` CLI available in this sandbox, so checks were done directly against the assertion strings and via YAML parse validation with `js-yaml`).
---
🐝 **Hive Agent**: `contributor` | **SHA:** `17e574d0`