### PR TITLE
fix(kde): point the soak gate evaluator at the actual kde-smoke results file

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -145,7 +145,7 @@ run-aurora-kde-sabotage:
 # Evaluate the rolling KDE soak window. A qualified result still needs human
 # approval before the suite is promoted to CI gating.
 evaluate-kde-soak:
-    python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-smoke.json
+    python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-kde-smoke.json
 
 # ── Observation ─────────────────────────────────────────────────────────────
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -277,10 +277,17 @@ triggers, and retains failed workflows for seven days.
 Each live run must publish the structured result and screenshot through
 `run-kde-tests`, and persist the result/artifact bundle before teardown. A
 qualified 30-run window is evidence only: retain the Argo workflow URL, the
-published `docs/results/aurora-testing-smoke.json` history, screenshot URL,
-and any filed issue URL for every classified infrastructure flake. Live-run
-evidence is required after ArgoCD reconciles the Git change; local lint cannot
-substitute for that evidence.
+published `docs/results/aurora-testing-kde-smoke.json` history, screenshot
+URL, and any filed issue URL for every classified infrastructure flake.
+Live-run evidence is required after ArgoCD reconciles the Git change; local
+lint cannot substitute for that evidence.
+
+`aurora-testing-kde-smoke.json` (suite `kde-smoke`, the name `nightly-kde` and
+`aurora-qa-pipeline` pass to `run-kde-tests`) is a distinct file from the
+pre-existing `aurora-testing-smoke.json`, which belongs to the unrelated
+generic `bluefin-qa-pipeline` smoke/developer/software suites triggered by
+`image-poll-aurora-testing`. Do not conflate the two: `just evaluate-kde-soak`
+and the soak gate only ever read the `kde-smoke` file.
 
 ### `aurora-kde-sabotage`
 

--- a/docs/results/aurora-testing-kde-smoke.json
+++ b/docs/results/aurora-testing-kde-smoke.json
@@ -1,0 +1,1 @@
+{"variant":"aurora-testing","suite":"kde-smoke","last_run":null,"workflow_name":null,"status":"pending","scenarios":0,"failed":0,"failed_scenarios":[],"failed_scenarios_detailed":[],"duration_seconds":0,"screenshot_url":"https://projectbluefin.github.io/lab/screenshots/aurora-testing-kde-smoke-latest.png","history":[]}


### PR DESCRIPTION
Relates to #466 (Gate C: soak to ≥95% pass rate over 30 runs).

## What I found

Auditing the Gate C tooling (already substantially built by #493's
`evaluate_kde_soak.py` / `publish_test_results.py` / `nightly-kde`
CronWorkflow), I found a filename mismatch that would have silently
broken the entire soak-evidence pipeline:

- `just evaluate-kde-soak` and `docs/reference/WORKFLOWS.md` both point
  at `docs/results/aurora-testing-smoke.json`.
- Every KDE soak workflow (`nightly-kde` → `aurora-qa-pipeline` →
  `run-kde-tests`, and the `aurora-kde-sabotage` runner) passes
  `suite: kde-smoke`. `publish_test_results.py` builds its output
  filename as `{IMG_SLUG}-{suite}.json`, so real KDE runs actually write
  `docs/results/aurora-testing-kde-smoke.json`.
- `aurora-testing-smoke.json` is a **different, pre-existing** file
  (predates the KDE soak effort — see its git history) owned by the
  unrelated generic `bluefin-qa-pipeline` smoke/developer/software
  suites that `image-poll-aurora-testing` triggers on digest changes.

Because both files share the `aurora-testing-` prefix, the soak
evaluator was reading the wrong dataset — one KDE runs never touch — so
the gate would have reported `pending` forever even after 30 real KDE
soak runs completed, defeating the purpose of #466 without any visible
error.

## Changes

- `Justfile`: `evaluate-kde-soak` now reads
  `docs/results/aurora-testing-kde-smoke.json`.
- `docs/reference/WORKFLOWS.md`: fixed the same filename reference and
  added an explicit note so future changes don't re-conflate the two
  `aurora-testing-*` files.
- `docs/results/aurora-testing-kde-smoke.json`: added the missing
  pending placeholder (same shape as the existing
  `aurora-testing-{developer,software}.json` placeholders) so the file
  exists ahead of the first live run.

## Why this is scoped the way it is

I don't have access to the `ghost`/`exo-0` lab cluster, so I can't
produce the 30 real nightly KDE runs #466 needs, and Gate B (#465) —
a hard dependency — is still open. Rather than fabricate soak data or
leave the issue untouched, this PR fixes the one concrete, verifiable
defect in the already-implemented gate mechanism so that real evidence
will actually land in the file the gate reads once Gate B ships and
`nightly-kde` starts running for real. The live-evidence checkboxes in
#466 still require human sign-off after 30 real runs; this PR doesn't
and can't close that issue.

## Validation

- `python3 -m pytest tests/unit/` — 307 passed, 1 skipped (skip is
  pre-existing/unrelated).
- `python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-kde-smoke.json`
  runs cleanly against the new placeholder, reports `pending`.
- `python3 -m json.tool docs/results/aurora-testing-kde-smoke.json` validates.
- `just --list` still resolves `evaluate-kde-soak`.
- `just lint` could not run in this sandbox (`argo` CLI unavailable);
  no workflow/manifest YAML was touched by this change.