### PR TITLE
fix(recc): collect cache pilot metrics from BuildStream logs

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -388,6 +388,7 @@ spec:
           EOF
           BST_CONF=/work/buildstream.conf
           echo "=== BuildStream configuration ready ==="
+          RECC_LOG_PATTERN='(^|[^[:alnum:]_])RECC(_VERBOSE|_METRICS)?([^[:alnum:]_-]|$)'
 
           collect_recc_buildstream_logs() {
             local destination="$1"
@@ -399,10 +400,10 @@ spec:
               return
             fi
             while IFS= read -r -d '' log; do
-              if grep -Eiq 'RECC(_VERBOSE|_METRICS)?|recc\.' "${log}"; then
+              if grep -Eiq "${RECC_LOG_PATTERN}" "${log}"; then
                 found=1
                 printf '\n=== BuildStream element log: %s ===\n' "${log}" >> "${destination}"
-                grep -Ei 'RECC(_VERBOSE|_METRICS)?|recc\.' "${log}" >> "${destination}"
+                grep -Ei "${RECC_LOG_PATTERN}" "${log}" >> "${destination}"
               fi
             done < <(find "${BST_LOGDIR}" -type f -print0 | sort -z)
             if [[ "${found}" -eq 0 ]]; then
@@ -439,7 +440,7 @@ spec:
               build "${ELEMENT}" >> "${phase_log}" 2>&1 || rc=$?
             collect_recc_buildstream_logs "${phase_log}"
             if [[ "${MODE}" != "buildstream-only" ]] && \
-              ! grep -Eiq '\[RECC_METRICS\]|RECC_VERBOSE|recc\.' "${phase_log}"; then
+              ! grep -Eiq "${RECC_LOG_PATTERN}" "${phase_log}"; then
               echo "RECC metrics/log evidence missing from BuildStream logdir" >> "${phase_log}"
               EVIDENCE_FAILED=1
             fi

--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -375,8 +375,11 @@ spec:
             echo "unexpected BuildStream project name: ${PROJECT_NAME}" >&2
             exit 1
           }
+          BST_LOGDIR=/work/buildstream-logs
+          mkdir -p "${BST_LOGDIR}"
           cp /etc/buildstream/buildstream.conf /work/buildstream.conf
           cat >> /work/buildstream.conf <<EOF
+          logdir: ${BST_LOGDIR}
           projects:
             ${PROJECT_NAME}:
               artifacts:
@@ -385,6 +388,28 @@ spec:
           EOF
           BST_CONF=/work/buildstream.conf
           echo "=== BuildStream configuration ready ==="
+
+          collect_recc_buildstream_logs() {
+            local destination="$1"
+            local log
+            local found=0
+            if [[ ! -d "${BST_LOGDIR}" ]]; then
+              printf '[RECC_LOGDIR] missing BuildStream log directory: %s\n' \
+                "${BST_LOGDIR}" >> "${destination}"
+              return
+            fi
+            while IFS= read -r -d '' log; do
+              if grep -Eiq 'RECC(_VERBOSE|_METRICS)?|recc\.' "${log}"; then
+                found=1
+                printf '\n=== BuildStream element log: %s ===\n' "${log}" >> "${destination}"
+                grep -Ei 'RECC(_VERBOSE|_METRICS)?|recc\.' "${log}" >> "${destination}"
+              fi
+            done < <(find "${BST_LOGDIR}" -type f -print0 | sort -z)
+            if [[ "${found}" -eq 0 ]]; then
+              printf '[RECC_LOGDIR] no RECC-marked lines found in %s\n' \
+                "${BST_LOGDIR}" >> "${destination}"
+            fi
+          }
 
           run_phase() {
             local phase="$1"
@@ -403,6 +428,8 @@ spec:
             local cache_origin="unavailable"
             phase_start="$(date +%s)"
             find /root/.cache/buildstream -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+            rm -rf "${BST_LOGDIR}"
+            mkdir -p "${BST_LOGDIR}"
             printf '\n=== %s phase: BuildStream cache cleared; remote RECC cache preserved ===\n' "${phase}" > "${phase_log}"
             if ! capture_buildbarn_metrics "/work/prometheus-${phase}-before.txt"; then
               EVIDENCE_FAILED=1
@@ -410,6 +437,12 @@ spec:
             bst --config "${BST_CONF}" --no-interactive \
               --option recc "${MODE}" \
               build "${ELEMENT}" >> "${phase_log}" 2>&1 || rc=$?
+            collect_recc_buildstream_logs "${phase_log}"
+            if [[ "${MODE}" != "buildstream-only" ]] && \
+              ! grep -Eiq '\[RECC_METRICS\]|RECC_VERBOSE|recc\.' "${phase_log}"; then
+              echo "RECC metrics/log evidence missing from BuildStream logdir" >> "${phase_log}"
+              EVIDENCE_FAILED=1
+            fi
             if [[ "${rc}" -eq 0 ]]; then
               state="$(bst --config "${BST_CONF}" --no-interactive show \
                 --deps none --format '%{state}' "${ELEMENT}" 2>>"${phase_log}" \

--- a/bst-prototype/elements/recc-baseline.bst
+++ b/bst-prototype/elements/recc-baseline.bst
@@ -29,7 +29,7 @@ environment:
       RECC_ACTION_CACHE_SERVER: grpc://frontend.buildbarn.svc.cluster.local:8980
       RECC_ACTION_UNCACHEABLE: "0"
       RECC_ENABLE_METRICS: "1"
-      RECC_METRICS_FILE: "%{install-root}/recc-metrics.txt"
+      RECC_METRICS_FILE: "%{build-root}/recc-metrics.txt"
   - recc == "passthrough":
       RECC_PASSTHROUGH: "1"
   - recc == "cache-only":
@@ -58,11 +58,11 @@ config:
     run_cxx -std=c++17 -Wl,--build-id=none \
       "%{build-root}/message.o" "%{build-root}/main.o" \
       -o "%{build-root}/recc-baseline"
-    if [ -f "%{install-root}/recc-metrics.txt" ]; then
+    if [ -f "%{build-root}/recc-metrics.txt" ]; then
       while IFS= read -r METRIC; do
         printf '[RECC_METRICS] %s\n' "${METRIC}"
-      done < "%{install-root}/recc-metrics.txt"
-      rm -f "%{install-root}/recc-metrics.txt"
+      done < "%{build-root}/recc-metrics.txt"
+      rm -f "%{build-root}/recc-metrics.txt"
     fi
   install-commands:
   - |

--- a/docs/reference/recc-baseline.md
+++ b/docs/reference/recc-baseline.md
@@ -84,6 +84,14 @@ remain explicit `unavailable_fields` entries and are never represented as zero
 or a successful warm hit. The workflow emits compact `metadata` and `evidence`
 output parameters.
 
+RECC's metrics file is written under BuildStream's ephemeral `%{build-root}`,
+then printed into the element build log and removed before artifact creation.
+The workflow sets BuildStream's supported `logdir` to `/work/buildstream-logs`
+and extracts RECC-marked lines from those per-element logs into the workflow
+evidence. This keeps the StatsD/log handoff outside the deterministic artifact;
+cache-only and upload-local-build phases fail closed when that handoff produces
+no RECC evidence.
+
 The acceptance comparison is mode-specific: `cache-only` and
 `upload-local-build` must prove stable action keys and a warm action-cache hit.
 A successful outer BuildStream build alone is not RECC evidence.
@@ -91,7 +99,8 @@ A successful outer BuildStream build alone is not RECC evidence.
 The first lab measurements are recorded in
 `docs/research/2026-07-31-recc-run-results.md`. They include real
 BuildStream/BuildBarn timings and CAS deltas; RECC action-level fields remain
-unavailable until the sandbox metrics-file handoff is proven.
+available only when the workflow's BuildStream logdir handoff captures the
+metrics section.
 
 ## Evidence boundaries
 

--- a/docs/reference/recc-baseline.md
+++ b/docs/reference/recc-baseline.md
@@ -84,6 +84,11 @@ remain explicit `unavailable_fields` entries and are never represented as zero
 or a successful warm hit. The workflow emits compact `metadata` and `evidence`
 output parameters.
 
+RECC StatsD counters are interpreted conservatively: cache hit/miss counters
+are the action count, local execution counters report fallbacks, and execution
+timings are used only when their StatsD unit is milliseconds. Counter samples
+are never treated as compiler durations.
+
 RECC's metrics file is written under BuildStream's ephemeral `%{build-root}`,
 then printed into the element build log and removed before artifact creation.
 The workflow sets BuildStream's supported `logdir` to `/work/buildstream-logs`

--- a/docs/research/2026-07-31-recc-run-results.md
+++ b/docs/research/2026-07-31-recc-run-results.md
@@ -23,12 +23,14 @@ result.
 
 ## Evidence limitation
 
-The outer BuildStream and BuildBarn evidence is available. RECC-specific
-action-cache hits/misses, fallbacks, and compiler timings remain explicitly
-`unavailable` in the emitted evidence. RECC was configured with verbose/StatsD
-metrics, but the nested BuildStream sandbox did not expose its metrics file
-through the install-root handoff; the workflow therefore does not claim a
-RECC hit or miss from these runs.
+The outer BuildStream and BuildBarn evidence is available. These historical
+runs predate the supported handoff now checked in for issue #532: the RECC
+metrics file is written under the ephemeral BuildStream build root, printed
+into the element log, and removed before artifact creation. The workflow
+collects that log through BuildStream's configured `/work/buildstream-logs`
+directory and fails closed if a RECC mode produces no metrics lines. A fresh
+cache-only run is required before claiming action-cache hits/misses, local
+fallbacks, or compiler timing from live evidence.
 
 Nested RECC remote execution was not measured. The pinned upstream `bb_runner`
 source still lacks `remoteApisSocketPath`/LocalCAS socket handoff support, so

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -1,7 +1,11 @@
 ---
 name: cluster-buildstream
 description: >
-  USB4 admission rules, BuildStream distributed builds, and Buildbarn recovery.
+  Use when operating USB4 admission, BuildStream distributed builds, Buildbarn
+  recovery, or the isolated RECC pilot evidence path.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # BuildStream and Distributed Builds
@@ -228,6 +232,24 @@ the pod-local LocalCAS socket.
   evidence. The collector preserves missing RECC action fields as
   `unavailable`; current runs have real BuildStream/BuildBarn timing and CAS
   data but no trustworthy RECC hit/miss metrics.
+
+### RECC pilot evidence handoff
+
+The operator-only `recc-baseline-pipeline` must use BuildStream's configured
+`logdir` as the sandbox-to-workflow evidence path. The fixture writes its
+StatsD output under `%{build-root}`, prints each record with a
+`[RECC_METRICS]` marker into the element build log, and removes the file before
+installing the deterministic artifact. The workflow points `logdir` at its
+`/work` volume and extracts only RECC-marked lines; do not put metrics in
+`%{install-root}`, a checked-out artifact, or a host mount.
+
+This preserves artifact determinism while making action-cache hits/misses,
+local fallbacks, and compiler timing available to the collector. A cache-only
+or upload-local-build pilot must fail closed when the BuildStream logdir has no
+RECC evidence rather than report zeros or infer a warm hit from outer
+BuildStream success. This follows BuildStream's documented writable
+`%{build-root}`/`%{install-root}` sandbox paths and user-configured `logdir`
+(`source: /apache/buildstream`).
 
 ### 1. Shared Buildbarn frontend
 - **Endpoint**: `grpc://frontend.buildbarn.svc.cluster.local:8980`

--- a/scripts/collect_recc_run.py
+++ b/scripts/collect_recc_run.py
@@ -252,13 +252,15 @@ RECC_STATSD = re.compile(
 )
 
 
-def _parse_recc_statsd(text: str) -> dict[str, list[float]]:
-    metrics: dict[str, list[float]] = {}
+def _parse_recc_statsd(text: str) -> dict[str, list[tuple[float, str]]]:
+    metrics: dict[str, list[tuple[float, str]]] = {}
     for line in text.splitlines():
         match = RECC_STATSD.match(line)
         if not match:
             continue
-        metrics.setdefault(match.group("name"), []).append(float(match.group("value")))
+        metrics.setdefault(match.group("name"), []).append(
+            (float(match.group("value")), match.group("kind").lower())
+        )
     return metrics
 
 
@@ -655,7 +657,8 @@ def parse_recc_verbose(text: Any) -> dict[str, Any]:
         statsd = _parse_recc_statsd(text)
         if statsd:
             values["metrics"] = {
-                name: sum(samples) for name, samples in sorted(statsd.items())
+                name: sum(value for value, _ in samples)
+                for name, samples in sorted(statsd.items())
             }
             for metric_name, field in (
                 ("action_cache_hit", "cache_hits"),
@@ -663,12 +666,47 @@ def parse_recc_verbose(text: Any) -> dict[str, Any]:
                 ("fallback", "local_fallbacks"),
             ):
                 if metric_name in statsd:
-                    values[field] = sum(statsd[metric_name])
-            if values["cache_hits"] is not None or values["cache_misses"] is not None:
-                values["action_count"] = sum(
-                    value or 0
-                    for value in (values["cache_hits"], values["cache_misses"])
+                    values[field] = sum(value for value, _ in statsd[metric_name])
+            cache_action_counts = [
+                sum(value for value, kind in statsd[name] if kind in {"c", "count"})
+                for name in (
+                    "action_cache_hit",
+                    "action_cache_miss",
                 )
+                if name in statsd
+                and any(kind in {"c", "count"} for _, kind in statsd[name])
+            ]
+            if cache_action_counts:
+                values["action_count"] = sum(cache_action_counts)
+            else:
+                execution_action_counts = [
+                    sum(
+                        value
+                        for value, kind in statsd[name]
+                        if kind in {"c", "count"}
+                    )
+                    for name in (
+                        "execute_local_no_action_result",
+                        "execute_local_with_action_result",
+                        "execute_remote_with_action_result",
+                    )
+                    if name in statsd
+                    and any(
+                        kind in {"c", "count"} for _, kind in statsd[name]
+                    )
+                ]
+                if execution_action_counts:
+                    values["action_count"] = sum(execution_action_counts)
+            if "execute_local_no_action_result" in statsd:
+                local_fallbacks = sum(
+                    value
+                    for value, kind in statsd["execute_local_no_action_result"]
+                    if kind in {"c", "count"}
+                )
+                if local_fallbacks:
+                    values["local_fallbacks"] = (
+                        values["local_fallbacks"] or 0
+                    ) + local_fallbacks
             compile_values = [
                 value
                 for metric_name in (
@@ -676,7 +714,8 @@ def parse_recc_verbose(text: Any) -> dict[str, Any]:
                     "execute_local_with_action_result",
                     "execute_remote_with_action_result",
                 )
-                for value in statsd.get(metric_name, [])
+                for value, kind in statsd.get(metric_name, [])
+                if kind in {"ms", "millisecond", "milliseconds"}
             ]
             if compile_values:
                 values["compile_seconds"] = sum(compile_values) / 1000

--- a/tests/unit/test_collect_recc_run.py
+++ b/tests/unit/test_collect_recc_run.py
@@ -158,6 +158,41 @@ def test_recc_statsd_metrics_provide_action_cache_evidence():
     assert result["state"] == "available"
 
 
+def test_recc_statsd_counters_are_not_mistaken_for_compile_timings():
+    result = collector.parse_recc_verbose(
+        """
+        === BEGIN RECC_VERBOSE LOG ===
+        [RECC_METRICS] recc.action_cache_miss:2|c
+        [RECC_METRICS] recc.execute_local_no_action_result:2|c
+        === END RECC_VERBOSE LOG ===
+        """
+    )
+
+    assert result["action_count"] == 2
+    assert result["local_fallbacks"] == 2
+    assert result["compile_seconds"] is None
+
+
+def test_collected_run_preserves_recc_statsd_evidence_from_element_log():
+    result = collector.collect_run(
+        {"run_id": "cache-regression", "mode": "cache-only"},
+        recc_verbose="""
+        === BuildStream element log: recc-baseline.bst ===
+        [RECC_METRICS] recc.action_cache_hit:2|c
+        [RECC_METRICS] recc.action_cache_miss:1|c
+        [RECC_METRICS] recc.fallback:1|c
+        [RECC_METRICS] recc.execute_local_no_action_result:125|ms
+        """,
+    )
+
+    assert result["recc"]["state"] == "available"
+    assert result["recc"]["action_count"] == 3
+    assert result["recc"]["cache_hits"] == 2
+    assert result["recc"]["cache_misses"] == 1
+    assert result["recc"]["local_fallbacks"] == 1
+    assert result["recc"]["compile_seconds"] == 0.125
+
+
 def test_prometheus_names_are_discovered_and_deltas_are_label_aware():
     before = """
     # HELP bb_actions_total actions

--- a/tests/unit/test_recc_baseline_workflow.py
+++ b/tests/unit/test_recc_baseline_workflow.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+import shutil
 import subprocess
 
+import pytest
 import yaml
 
 
@@ -175,6 +177,9 @@ def test_justfile_exposes_all_operator_parameters():
 
 
 def test_justfile_named_recc_arguments_are_preserved_for_parsing():
+    if not shutil.which("just"):
+        pytest.skip("just is not installed in this test environment")
+
     result = subprocess.run(
         [
             "just",

--- a/tests/unit/test_recc_baseline_workflow.py
+++ b/tests/unit/test_recc_baseline_workflow.py
@@ -1,8 +1,6 @@
 from pathlib import Path
-import shutil
 import subprocess
 
-import pytest
 import yaml
 
 
@@ -26,6 +24,7 @@ def _run_template():
 def test_recc_fixture_generates_separate_launcher_and_compiler_arguments():
     fixture = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
     variables = fixture["variables"]
+    environment = fixture["environment"]["(?)"][0]['recc != "buildstream-only"']
     build_commands = fixture["config"]["build-commands"]
     command = build_commands[0]
 
@@ -40,6 +39,10 @@ def test_recc_fixture_generates_separate_launcher_and_compiler_arguments():
     assert command.count("run_cxx ") == 3
     assert command.count(" -c ") == 2
     assert '"$CXX" ' not in command
+    assert environment["RECC_METRICS_FILE"] == "%{build-root}/recc-metrics.txt"
+    assert '"%{build-root}/recc-metrics.txt"' in command
+    assert "rm -f \"%{build-root}/recc-metrics.txt\"" in command
+    assert "recc-metrics.txt" not in fixture["config"]["install-commands"][0]
 
 
 def test_recc_baseline_is_an_isolated_operator_only_template():
@@ -150,6 +153,10 @@ def test_metadata_outputs_preserve_remote_cache_and_unavailable_fields():
     assert '"evidence_capture"' in text
     assert '"unavailable_fields"' in text
     assert "remote RECC cache preserved" in text
+    assert "logdir: ${BST_LOGDIR}" in text
+    assert "BST_LOGDIR=/work/buildstream-logs" in text
+    assert "collect_recc_buildstream_logs" in text
+    assert "RECC metrics/log evidence missing from BuildStream logdir" in text
     assert "--prometheus-before" in text
     assert "--prometheus-after" in text
     assert "/work/recc.log" in text
@@ -168,9 +175,6 @@ def test_justfile_exposes_all_operator_parameters():
 
 
 def test_justfile_named_recc_arguments_are_preserved_for_parsing():
-    if not shutil.which("just"):
-        pytest.skip("just is not installed in this test environment")
-
     result = subprocess.run(
         [
             "just",


### PR DESCRIPTION
Closes #532

Retains the focused RECC logdir handoff, deterministic fixture metrics, bounded collector handling, regression tests, and documentation from fix/532-recc-metrics, rebased onto current main.

Validation: targeted RECC pytest; just lint.