### PR TITLE
fix(argo): provision Aurora sabotage staging

### DIFF
--- a/argo/aurora-kde-sabotage.yaml
+++ b/argo/aurora-kde-sabotage.yaml
@@ -14,6 +14,16 @@ spec:
   serviceAccountName: argo
   activeDeadlineSeconds: 5400
   onExit: cleanup
+  volumeClaimGC:
+    strategy: OnWorkflowCompletion
+  volumeClaimTemplates:
+  - metadata:
+      name: staging
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 100Gi
   arguments:
     parameters:
     - name: vm-name

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -82,6 +82,10 @@ The workflow authoring guidance is split by topic:
   the matching `volumeClaimTemplates` entry; define the claim at workflow scope
   and set `volumeClaimGC.strategy: OnWorkflowCompletion` so failed builds do not
   leave staging storage behind.
+- A direct `Workflow` that calls a containerDisk builder with `templateRef`
+  but omits that builder's `staging` claim. A referenced task cannot define a
+  workflow-scoped PVC for its caller; put the `staging` `volumeClaimTemplates`
+  and `volumeClaimGC.strategy: OnWorkflowCompletion` on the submitted Workflow.
 - A workflow that declares `volumeClaimTemplates` without
   `volumeClaimGC.strategy: OnWorkflowCompletion` — completed runs leave staging
   PVCs behind.

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -354,6 +354,16 @@ def test_aurora_kde_sabotage_workflow_runs_both_controlled_failures():
     path = ROOT / "argo/aurora-kde-sabotage.yaml"
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert workflow["spec"]["onExit"] == "cleanup"
+    assert workflow["spec"]["volumeClaimGC"] == {"strategy": "OnWorkflowCompletion"}
+    assert workflow["spec"]["volumeClaimTemplates"] == [
+        {
+            "metadata": {"name": "staging"},
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "resources": {"requests": {"storage": "100Gi"}},
+            },
+        }
+    ]
     tasks = workflow["spec"]["templates"][0]["dag"]["tasks"]
     sabotage_tasks = [
         task for task in tasks if task["name"] in {"missing-binary", "kill-plasmashell"}


### PR DESCRIPTION
## Root cause

The retained fresh sabotage run stopped at Argo validation before any pod started: the direct workflow called the shared containerDisk builder without its required workflow-scoped `staging` PVC.

## Repair and proof

- declare and GC the 100Gi staging claim in the direct sabotage workflow
- regression test asserts the builder contract
- `pytest -q tests/unit/test_workflow_defaults.py` (27 passed)
- `just lint` (passed)

The diagnostic contained no source-pull, signature, bootc, filesystem, bootloader, capacity, or registry-push failure; this is a pre-build workflow-volume contract failure.