### PR TITLE
fix(argocd): correct root Application names back to testing-lab/testing-lab-infra

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -66,14 +66,14 @@ setup-arc-github-secret pem="" app_id="" installation_id="" namespace="arc-runne
 
 # Force ArgoCD to sync now instead of waiting for the next poll interval
 argocd-sync:
-    argocd app sync lab lab-infra --timeout 120
-    argocd app wait lab --health --timeout 120
-    argocd app wait lab-infra --health --timeout 120
+    argocd app sync testing-lab testing-lab-infra --timeout 120
+    argocd app wait testing-lab --health --timeout 120
+    argocd app wait testing-lab-infra --health --timeout 120
 
 # Show ArgoCD sync status for the test suite
 argocd-status:
-    argocd app get lab
-    argocd app get lab-infra
+    argocd app get testing-lab
+    argocd app get testing-lab-infra
 
 # ── Test execution ───────────────────────────────────────────────────────────
 

--- a/argocd/application.yaml
+++ b/argocd/application.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: lab
+  name: testing-lab
   namespace: argocd
   labels:
     app.kubernetes.io/part-of: lab

--- a/argocd/infra-application.yaml
+++ b/argocd/infra-application.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: lab-infra
+  name: testing-lab-infra
   namespace: argocd
   labels:
     app.kubernetes.io/part-of: lab

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -152,10 +152,10 @@ Per-template ceilings live in [`/AGENTS.md`](/AGENTS.md) under **Resource Limits
 
 **Trigger an ArgoCD sync:**
 ```bash
-KUBECONFIG=~/.kube/bluespeed.yaml kubectl -n argocd annotate application lab \
+KUBECONFIG=~/.kube/bluespeed.yaml kubectl -n argocd annotate application testing-lab \
   argocd.argoproj.io/refresh=normal --overwrite
 # or via argocd CLI:
-argocd app sync lab
+argocd app sync testing-lab
 ```
 
 **If the local ArgoCD port-forward drops**, restart it and verify the health endpoint
@@ -167,14 +167,14 @@ curl -sf http://127.0.0.1:18080/healthz
 
 **Read ArgoCD Application state:**
 ```bash
-KUBECONFIG=~/.kube/bluespeed.yaml kubectl get application lab-infra -n argocd \
+KUBECONFIG=~/.kube/bluespeed.yaml kubectl get application testing-lab-infra -n argocd \
   -o jsonpath='{.status.sync.status} {.status.health.status}'
 ```
 Key fields: `.status.operationState.phase`, `.status.sync.status`, `.status.operationState.message`, `.status.operationState.operation.sync.revision`
 
 **Cancel a stuck operation** (PreSync hook looping):
 ```bash
-KUBECONFIG=~/.kube/bluespeed.yaml kubectl patch application lab -n argocd \
+KUBECONFIG=~/.kube/bluespeed.yaml kubectl patch application testing-lab -n argocd \
   --type=json -p='[{"op":"remove","path":"/operation"}]'
 ```
 
@@ -184,11 +184,11 @@ KUBECONFIG=~/.kube/bluespeed.yaml kubectl patch application lab -n argocd \
    -> if not: push first.
 
 2. just argocd-status
-   -> expected: `lab` is synced to a revision that matches or post-dates your commit.
+   -> expected: `testing-lab` is synced to a revision that matches or post-dates your commit.
    -> if older: just argocd-sync
 
 3. just argocd-status
-   -> expected: `lab` is Healthy.
+   -> expected: `testing-lab` is Healthy.
    -> if not Healthy: inspect the reported condition, fix the rejected field in git, push again, then repeat step 2.
 
 4. argo template get -n argo <name>
@@ -368,7 +368,7 @@ Expected steady state:
 
 ## 13. llm-d local inference node
 
-`llm-d` is managed by the `lab-infra` ArgoCD Application (`manifests/llm-d.yaml`) and is **enabled by default** with one replica.
+`llm-d` is managed by the `testing-lab-infra` ArgoCD Application (`manifests/llm-d.yaml`) and is **enabled by default** with one replica.
 The vLLM container requests one `amd.com/gpu` device so the ROCm device plugin exposes the GPU into the pod.
 
 **Model choice:** the deployment serves `unsloth/Llama-3.2-3B-Instruct` through vLLM on the OpenAI-compatible endpoint at `http://<ghost-ip>:30800/v1`.

--- a/docs/skills/gitops-argocd/SKILL.md
+++ b/docs/skills/gitops-argocd/SKILL.md
@@ -33,8 +33,8 @@ metadata:
 
 | Application | Git path | Namespace | What it manages |
 |---|---|---|---|
-| `lab` | `argo/workflow-templates/` | argo | WorkflowTemplates |
-| `lab-infra` | `manifests/` | argo + others | CronWorkflows, RBAC, NodePorts, ConfigMaps |
+| `testing-lab` | `argo/workflow-templates/` | argo | WorkflowTemplates |
+| `testing-lab-infra` | `manifests/` | argo + others | CronWorkflows, RBAC, NodePorts, ConfigMaps |
 | `kubestellar-applications` | selected files in `argocd/` | argocd | KubeStellar PostgreSQL, core, and Console Applications |
 | `arc-systems` | `argocd/arc-controller-app.yaml` | arc-systems | ARC controller |
 | `arc-runners` | `argocd/arc-runners-app.yaml` | arc-runners | Org `ghost-runners` scale set |
@@ -46,15 +46,15 @@ App-of-apps sync waves require Application health evaluation. The `argocd-cm`
 patch in `manifests/argocd-tuning.yaml` marks child Applications Progressing
 until they are both Synced and Healthy, so later waves do not race ahead of
 PostgreSQL or KubeStellar core.
-The root `lab` and `lab-infra` Applications are applied manually once because
-ArgoCD cannot create its own initial definitions. `lab-infra` then creates the
+The root `testing-lab` and `testing-lab-infra` Applications are applied manually once because
+ArgoCD cannot create its own initial definitions. `testing-lab-infra` then creates the
 `kubestellar-applications` parent, which owns only the three KubeStellar child
 Application manifests selected from `argocd/`.
 
 **`prune: true`** — resources removed from git are deleted from the cluster.
 **`selfHeal: true`** — manual cluster changes are reverted within ~3 minutes.
 
-`lab-infra` excludes `manifests/flatcar-update-*.yaml`; those resources are owned by the
+`testing-lab-infra` excludes `manifests/flatcar-update-*.yaml`; those resources are owned by the
 separate `flatcar-update` Application. Keep that split to avoid duplicate ownership and
 persistent `OutOfSync` drift from overlapping Namespace/ConfigMap management.
 
@@ -138,7 +138,7 @@ the scheduler; do not add a hostname selector. Size application retention below
 PVC capacity so WAL, compaction, or other temporary files cannot fill the
 volume.
 
-**Subdirectories and namespaces:** `lab-infra` runs with
+**Subdirectories and namespaces:** `testing-lab-infra` runs with
 `directory.recurse: true` (live-patched 2026-07-25; the Application object is
 manually applied, not git-tracked) so nested paths like
 `manifests/catalog-apps/<app>/manifest.yaml` sync. It also sets
@@ -153,26 +153,26 @@ resources silently never appear.
 # Check status
 just argocd-status
 # or
-argocd app get lab
-argocd app get lab-infra
+argocd app get testing-lab
+argocd app get testing-lab-infra
 
 # Force sync
 just argocd-sync
 # or
-argocd app sync lab lab-infra --timeout 120
+argocd app sync testing-lab testing-lab-infra --timeout 120
 ```
 
 If a template change is in git but not yet live:
-1. Check `argocd app get lab` — is it Synced?
+1. Check `argocd app get testing-lab` — is it Synced?
 2. If OutOfSync, run `just argocd-sync`
 3. If sync fails, check ArgoCD logs: `kubectl logs -n argocd -l app.kubernetes.io/name=argocd-application-controller`
 
 #### The WorkflowTemplate Snapshot Gotcha (CRITICAL):
 - **Snapshot at Submit Time**: In Argo Workflows, a WorkflowTemplate is snapshotted inside the cluster at the *exact moment a workflow is submitted*.
 - **Sync Race Condition**: If you push a fix to git and immediately run `argo submit` or trigger a build, the workflow may snapshot a stale template version if ArgoCD has not yet completed its poll or sync loop.
-- **Native Kubernetes Hard Sync Patch**: When a port-forward is unavailable or the local CLI config is out-of-sync, you can bypass the `argocd` CLI and trigger an immediate hard refresh and synchronization of the `lab` (or other) Application directly via `kubectl`:
+- **Native Kubernetes Hard Sync Patch**: When a port-forward is unavailable or the local CLI config is out-of-sync, you can bypass the `argocd` CLI and trigger an immediate hard refresh and synchronization of the `testing-lab` (or other) Application directly via `kubectl`:
   ```bash
-  kubectl patch app lab -n argocd -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' --type=merge
+  kubectl patch app testing-lab -n argocd -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' --type=merge
   ```
   Always run this patch (or `just argocd-sync`) and verify that the target template's live version (`argo-mcp-get_workflow_template`) incorporates your changes **before** submitting or resubmitting any workflow runs.
 
@@ -189,9 +189,9 @@ curl -sf http://127.0.0.1:18080/healthz
 When the forward is healthy, refresh the Application state before resubmitting a workflow:
 
 ```bash
-argocd app get lab --refresh --hard-refresh
+argocd app get testing-lab --refresh --hard-refresh
 # or, if the CLI is unavailable, trigger the same refresh via kubectl:
-kubectl -n argocd patch application lab \
+kubectl -n argocd patch application testing-lab \
   --type=merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
 ```
 


### PR DESCRIPTION
## Problem

`just argocd-status` and `just argocd-sync` — the only documented, canonical
way for any agent to check or force ArgoCD reconciliation (see
`docs/skills/gitops-argocd/SKILL.md`) — fail 100% of the time on current
`main`:

```
$ argocd app get lab
{"level":"fatal","msg":"rpc error: code = PermissionDenied ..."}
$ kubectl get application lab -n argocd
Error from server (NotFound): applications.argoproj.io "lab" not found
```

## Root cause

- `cddf954d6 chore: rename repo from testing-lab to lab` correctly renamed
  the *repository*, and separately updated `argocd/application.yaml` /
  `argocd/infra-application.yaml`'s `metadata.name` from
  `testing-lab`/`testing-lab-infra` to `lab`/`lab-infra`.
- Per `docs/skills/gitops-argocd/SKILL.md`, the two root Applications are
  **applied manually once** — ArgoCD cannot create/rename its own initial
  definitions. Nobody re-applied the renamed manifest, so the live cluster
  objects are still named `testing-lab` / `testing-lab-infra`:

  ```
  $ kubectl get application -n argocd
  NAME                SYNC STATUS   HEALTH STATUS
  testing-lab         Synced        Healthy
  testing-lab-infra   Synced        Degraded
  ```

- `e9aed1c8c docs: align lab docs with current QA paths (#535)` then
  propagated the incorrect `lab`/`lab-infra` names into `Justfile`
  (`argocd-status`/`argocd-sync`) and `docs/skills/gitops-argocd/SKILL.md`,
  under the mistaken assumption the live objects had already been renamed.

This is a shared, agent-facing infra defect (every agent following the
canonical `docs/skills/gitops-argocd/SKILL.md` / cheatsheet guidance hits
the same failure), unrelated to and not owned by the currently active
`restore-qa-reconciliation`, `land-recc-metrics`, `repair-aurora-gate`, or
`verify-kde-linux` todos (confirmed against issue #543 and those branches'
diffs, which don't touch these files).

## Fix

Revert the git-tracked names back to match live cluster reality
(`testing-lab` / `testing-lab-infra`) in:
- `argocd/application.yaml`, `argocd/infra-application.yaml` (source of
  truth for any future manual re-bootstrap)
- `Justfile` (`argocd-status`, `argocd-sync`)
- `docs/skills/gitops-argocd/SKILL.md` and `docs/reference/agent-cheatsheet.md`
  (the two docs with copy-pasteable commands for this exact workflow)

No cluster mutation is performed — this is a git-only change that makes the
already-correct behavior of the live, manually-bootstrapped Applications
match what's documented and scripted. Automated sync (`prune: true`,
`selfHeal: true`) is unaffected; no duplicate/orphaned Application objects
are created.

## Verification

- `just lint` — passes.
- `kubectl apply --dry-run=client -f argocd/application.yaml -f argocd/infra-application.yaml` → `configured (dry run)` against the live objects (names now match).
- `kubectl get application testing-lab testing-lab-infra -n argocd` → both exist, Synced; `kubectl get application lab lab-infra -n argocd` → still correctly NotFound (no duplicates created).
- `just argocd-status` no longer fails on "not found" for the app names. The
  only remaining failure is a **pre-existing, separate, local ArgoCD CLI
  session token expiry** (`token has invalid claims: token is expired`),
  unrelated to this fix and out of GitOps scope — needs an operator to run
  `argocd login` to refresh their local session.

## Scope note

A broader, cosmetic documentation-drift sweep (README.md, RUNBOOK.md,
lab-operations.md, WORKFLOWS.md, authoring.md, etc. also contain informal
`lab`/`lab-infra` mentions from the same PR #535) was intentionally left out
of this PR to keep the fix minimal and reviewable; happy to follow up in a
separate docs-only PR if desired.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>