### PR TITLE
fix(recc): require StatsD metric evidence

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -389,6 +389,7 @@ spec:
           BST_CONF=/work/buildstream.conf
           echo "=== BuildStream configuration ready ==="
           RECC_LOG_PATTERN='(^|[^[:alnum:]_])RECC(_VERBOSE|_METRICS)?([^[:alnum:]_-]|$)'
+          RECC_STATSD_PATTERN='\[RECC_METRICS\][[:space:]]+recc\.[[:alnum:]_]+:-?([0-9]+([.][0-9]*)?|[.][0-9]+)\|[[:alpha:]]+'
 
           collect_recc_buildstream_logs() {
             local destination="$1"
@@ -440,8 +441,8 @@ spec:
               build "${ELEMENT}" >> "${phase_log}" 2>&1 || rc=$?
             collect_recc_buildstream_logs "${phase_log}"
             if [[ "${MODE}" != "buildstream-only" ]] && \
-              ! grep -Eiq "${RECC_LOG_PATTERN}" "${phase_log}"; then
-              echo "RECC metrics/log evidence missing from BuildStream logdir" >> "${phase_log}"
+              ! grep -Eiq "${RECC_STATSD_PATTERN}" "${phase_log}"; then
+              echo "RECC StatsD metric evidence missing from BuildStream logdir" >> "${phase_log}"
               EVIDENCE_FAILED=1
             fi
             if [[ "${rc}" -eq 0 ]]; then

--- a/docs/reference/recc-baseline.md
+++ b/docs/reference/recc-baseline.md
@@ -95,7 +95,7 @@ The workflow sets BuildStream's supported `logdir` to `/work/buildstream-logs`
 and extracts RECC-marked lines from those per-element logs into the workflow
 evidence. This keeps the StatsD/log handoff outside the deterministic artifact;
 cache-only and upload-local-build phases fail closed when that handoff produces
-no RECC evidence.
+no valid RECC StatsD metric evidence.
 
 The acceptance comparison is mode-specific: `cache-only` and
 `upload-local-build` must prove stable action keys and a warm action-cache hit.

--- a/docs/research/2026-07-31-recc-run-results.md
+++ b/docs/research/2026-07-31-recc-run-results.md
@@ -28,7 +28,8 @@ runs predate the supported handoff now checked in for issue #532: the RECC
 metrics file is written under the ephemeral BuildStream build root, printed
 into the element log, and removed before artifact creation. The workflow
 collects that log through BuildStream's configured `/work/buildstream-logs`
-directory and fails closed if a RECC mode produces no metrics lines. A fresh
+directory and fails closed if a RECC mode produces no valid StatsD metric
+lines. A fresh
 cache-only run is required before claiming action-cache hits/misses, local
 fallbacks, or compiler timing from live evidence.
 

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -246,7 +246,7 @@ installing the deterministic artifact. The workflow points `logdir` at its
 This preserves artifact determinism while making action-cache hits/misses,
 local fallbacks, and compiler timing available to the collector. A cache-only
 or upload-local-build pilot must fail closed when the BuildStream logdir has no
-RECC evidence rather than report zeros or infer a warm hit from outer
+valid RECC StatsD metric evidence rather than report zeros or infer a warm hit from outer
 BuildStream success. This follows BuildStream's documented writable
 `%{build-root}`/`%{install-root}` sandbox paths and user-configured `logdir`
 (`source: /apache/buildstream`).

--- a/tests/unit/test_recc_baseline_workflow.py
+++ b/tests/unit/test_recc_baseline_workflow.py
@@ -158,7 +158,9 @@ def test_metadata_outputs_preserve_remote_cache_and_unavailable_fields():
     assert "logdir: ${BST_LOGDIR}" in text
     assert "BST_LOGDIR=/work/buildstream-logs" in text
     assert "collect_recc_buildstream_logs" in text
-    assert "RECC metrics/log evidence missing from BuildStream logdir" in text
+    assert "RECC_STATSD_PATTERN=" in text
+    assert "RECC StatsD metric evidence missing from BuildStream logdir" in text
+    assert 'grep -Eiq "${RECC_STATSD_PATTERN}" "${phase_log}"' in text
     assert "--prometheus-before" in text
     assert "--prometheus-after" in text
     assert "/work/recc.log" in text


### PR DESCRIPTION
Reopens #532 follow-up: cache-only pilots now fail closed unless the BuildStream logdir carries a valid RECC StatsD metric line. This prevents generic RECC markers from reporting a successful evidence capture.

Validation: targeted RECC pytest; just lint.