### PR TITLE
fix(argo): install Qt private development files

### DIFF
--- a/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
+++ b/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
@@ -385,7 +385,7 @@ spec:
         FROM __SOURCE_IMAGE__
         RUN dnf install -y --setopt=install_weak_deps=False \
               cmake extra-cmake-modules gcc-c++ make git \
-              qt6-qtbase-devel qt6-qtwayland-devel \
+              qt6-qtbase-devel qt6-qtbase-private-devel qt6-qtwayland-devel \
               kf6-kwayland-devel kf6-kwindowsystem-devel kf6-kcoreaddons-devel \
               kpipewire-devel plasma-wayland-protocols-devel \
               libxkbcommon-devel wayland-devel \

--- a/docs/skills/argo-workflows/SKILL.md
+++ b/docs/skills/argo-workflows/SKILL.md
@@ -120,6 +120,8 @@ The workflow authoring guidance is split by topic:
 - Prebaking a DUT-specific KDE automation binary without pinning the source
   commit and validating the installed server and `inputsynth` paths during the
   image build.
+- A KDE WebDriver prebake with only `qt6-qtbase-devel`: its CMake project uses
+  `Qt6GuiPrivate`, which Fedora supplies through `qt6-qtbase-private-devel`.
 - Templates annotated `DEPRECATED` that haven't been deleted from git
 - Two CronWorkflows with the same schedule covering overlapping namespaces
 - A `steps` template with the same `when` condition on 3+ sequential steps (convert to `dag` + `depends` chain)

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -226,6 +226,7 @@ def test_aurora_containerdisk_builder_isolated_and_prebaked():
     assert "selenium-webdriver-at-spi.git" in builder
     assert "d45a21e8f1b3591dc921f0be85f1ecd834cbe413" in builder
     assert "selenium-webdriver-at-spi-inputsynth" in builder
+    assert "qt6-qtbase-private-devel" in builder
     assert "192.168.1.102:30500/{{inputs.parameters.containerdisk-repo}}:${TAG}" in builder
 
     aurora = (ROOT / "argo/workflow-templates/aurora-containerdisk-test.yaml").read_text(


### PR DESCRIPTION
## Root cause

A retained, redacted Aurora builder log reached the KDE WebDriver prebake and failed CMake configuration because `Qt6GuiPrivateConfig.cmake` was absent. This is a **prebake** failure, not a source pull/signature, bootc/filesystem/bootloader, disk-capacity, or registry-push failure.

## Repair and proof

- add Fedora `qt6-qtbase-private-devel`, which provides the required Qt6 private CMake package
- focused regression asserts the dependency is retained
- `pytest -q tests/unit/test_workflow_defaults.py` (27 passed)
- `just lint` (passed)

The preceding direct sabotage contract repair merged as #546.