### PR TITLE
fix(kde): pin durable result runner to ghost

### DIFF
--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -51,6 +51,9 @@ spec:
           path: /tmp/results/failed-scenarios.json
           default: "[]"
     activeDeadlineSeconds: 3600
+    # The durable result store is local to ghost.
+    nodeSelector:
+      kubernetes.io/hostname: ghost
     initContainers:
     - name: git-sync
       image: ghcr.io/projectbluefin/lab-runner@sha256:fe097bb3b85a126b9a16093fbc498b4b6fb7b24e0f74162ad3d91a402dcfa940

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -411,6 +411,8 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "/status" in kde
     assert "publish_test_results.py" in kde
     assert "/var/mnt/ghost-data/test-results" in kde
+    template = yaml.safe_load(kde)["spec"]["templates"][0]
+    assert template["nodeSelector"] == {"kubernetes.io/hostname": "ghost"}
     assert "- name: failure-class" in kde
     assert "- name: failure-issue-url" in kde
     assert "- name: behave-retries" in kde


### PR DESCRIPTION
Summary: pin the KDE runner to the node that owns its durable result hostPath, and regression-test that placement. Validation: pytest -q tests/unit/test_workflow_defaults.py; just lint. Fixes #470.