### PR TITLE
fix(argo): bound container QA pull attempts to stop registry stalls from starving the semaphore

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -171,7 +171,10 @@ spec:
             if [[ -n "${GITHUB_TOKEN:-}" ]]; then
               SKOPEO_ARGS+=(--creds "_token:${GITHUB_TOKEN}")
             fi
-            DIGEST=$(skopeo inspect "${SKOPEO_TLS_ARGS[@]}" "${SKOPEO_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE}" 2>/dev/null || true)
+            # Bounded so a stalled registry mirror connection cannot hang
+            # digest resolution; a timeout falls through to the existing
+            # tag-based fallback below, same as any other inspect failure.
+            DIGEST=$(timeout 120 skopeo inspect "${SKOPEO_TLS_ARGS[@]}" "${SKOPEO_ARGS[@]}" --no-tags --format '{{.Digest}}' "docker://${IMAGE}" 2>/dev/null || true)
           fi
           if [[ -z "${DIGEST:-}" ]]; then
             echo "Warning: could not resolve digest for ${IMAGE}; result will still be published but may fall back to tag-based matching." >&2
@@ -195,14 +198,36 @@ spec:
           exit 1
         }
         mkdir -p /tmp/results
-        if [[ "${#PODMAN_PULL_TLS_ARGS[@]}" -gt 0 ]]; then
-          podman pull "${PODMAN_PULL_TLS_ARGS[@]}" "${TARGET_IMAGE}" >/dev/null
+
+        # Bound every pull attempt. The shared Zot pull-through cache
+        # occasionally hits "unexpected EOF" reconnecting mid-blob against
+        # ghcr.io; without a client-side timeout that hang blocks this pod
+        # (and its ghost-container-qa semaphore slot) for up to
+        # activeDeadlineSeconds instead of minutes. Retry a bounded number of
+        # times first, since a stall is often resolved by Zot's own
+        # reconnect-and-resume on the next attempt.
+        PULL_ATTEMPTS=3
+        PULL_TIMEOUT_SECONDS=480
+        pull_ok=false
+        for attempt in $(seq 1 "${PULL_ATTEMPTS}"); do
+          echo "Pulling ${TARGET_IMAGE} (attempt ${attempt}/${PULL_ATTEMPTS}, ${PULL_TIMEOUT_SECONDS}s timeout)..." >&2
+          if timeout "${PULL_TIMEOUT_SECONDS}" podman pull "${PODMAN_PULL_TLS_ARGS[@]}" "${TARGET_IMAGE}" >/dev/null; then
+            pull_ok=true
+            break
+          fi
+          echo "Pull attempt ${attempt} for ${TARGET_IMAGE} failed or timed out after ${PULL_TIMEOUT_SECONDS}s" >&2
+          sleep 30
+        done
+        if [[ "${pull_ok}" != true ]]; then
+          echo "Giving up on ${TARGET_IMAGE} after ${PULL_ATTEMPTS} pull attempts; registry appears stalled or unreachable" >&2
+          exit 1
         fi
         podman run --detach --systemd=always --network host --privileged \
           --cgroupns=host \
           --security-opt seccomp=unconfined \
           --tmpfs /run:rw,nosuid,nodev,mode=755,size=256m \
           --name "${TARGET_NAME}" \
+          --pull=never \
           --mount type=bind,source=/sys,destination=/sys,ro,bind-propagation=rprivate \
           --mount type=bind,source=/run/udev,destination=/run/udev,ro,bind-propagation=rprivate \
           --volume /workspace:/workspace:ro \


### PR DESCRIPTION
## Problem (live, confirmed)

The shared `triage-lab-blockages` diagnosis found a real active blockage:
stalled `podman pull`/`skopeo` requests to `ghcr.io` (via the Zot pull-through
cache) were monopolizing all 6 `ghost-container-qa` semaphore slots, queuing
~19 PR/nightly QA workflows for hours.

## Diagnosis (rigorous, live feedback loop)

- `argo-mcp-get_workflow_node` on multiple queued workflows showed the live
  message `"Waiting for argo/ConfigMap/workflow-semaphores/ghost-container-qa
  lock. Lock status: 0/6"` at two different timestamps — semaphore fully
  exhausted, actively ongoing.
- `kubernetes-mcp-pods_list_in_namespace` found the `run-container-tests` pods
  holding the slots; `argo-mcp-logs_workflow` polled seconds apart on two of
  them showed **zero log progress** (stuck at the same "Copying blob
  sha256:..." line) — a genuine hang, not a slow-but-progressing pull.
- Zot's own pod logs (`zot-cache-8qjm6`, `local-registry` ns) showed direct
  corroborating evidence: `"Reading blob body from https://ghcr.io/v2/...
  failed (unexpected EOF), reconnecting after N bytes…"` — 7 such events in a
  92-minute window.
- `manifests/zot-cache.yaml` shows Zot's own `maxRetries: 3, retryDelay: 2m`
  applies to sync-level failures, not the internal streaming reconnect seen
  above — a client (`podman`/`skopeo`) request can stay blocked through
  multiple silent Zot-side reconnects with **no client-side timeout**.
- Confirmed via pod `creationTimestamp` that the stuck pod's age was still
  under `activeDeadlineSeconds` (3600s), i.e. Kubernetes would eventually kill
  it, but only after up to a full hour per attempt — and since the underlying
  registry hiccup recurs, a freshly-freed slot has a good chance of
  re-stalling on the very next attempt, capping effective slot throughput at
  ~6 attempts/hour regardless of demand.
- Live re-validation during this fix: watched all 6 slots drain and refill in
  real time (previous stuck pods hit `activeDeadlineSeconds` and died; new
  pods immediately grabbed the freed slots and started fresh pulls with new
  digests), then confirmed one of the new pulls progressed normally on
  re-poll — consistent with an intermittent (not constant) upstream/mirror
  issue.

### Ranked hypotheses
1. **H1 (confirmed):** unbounded pull/digest-resolution calls have no
   client-side timeout, so a Zot-side stall blocks the pod for up to
   `activeDeadlineSeconds`; because the registry issue recurs, slot
   throughput collapses to ~6 attempts/hour instead of ~6 attempts per
   test-suite-runtime.
2. **H2 (falsified as primary):** `activeDeadlineSeconds` itself broken/not
   enforced — ruled out, it just hadn't fired yet because pod age was still
   under 1h.
3. **H3 (falsified):** normal legitimate contention — ruled out by zero log
   progress between polls.
4. **H4 (secondary, unconfirmed, out of scope):** a possible stale/leaked
   semaphore holder (5 live pods observed vs. reported 6 held) — not
   root-caused; not pursued further to stay within "smallest safe
   mitigation" scope. Flagged for follow-up if queue depth doesn't improve
   post-deploy.

## Fix

- Wrap `skopeo inspect` digest resolution in `timeout 120` (falls through to
  the existing tag-based fallback on timeout, same as any other inspect
  failure).
- Replace the previously conditional-only `podman pull` (it only ran for
  local/insecure registries, leaving GHCR pulls to the unbounded implicit
  pull inside `podman run`) with an **always-run, bounded, retried** explicit
  pull: 3 attempts, each wrapped in `timeout 480` (8 min), 30s backoff between
  attempts, failing the pod cleanly (`exit 1`, descriptive message) if all
  attempts are exhausted.
- Add `--pull=never` to the subsequent `podman run` since the image is now
  always explicitly pre-pulled, avoiding a redundant second implicit pull.

## Why this is the smallest safe fix

- Does **not** weaken digest/image validation (digest resolution logic and
  fallback are unchanged, just bounded).
- Does **not** bypass the registry allowlist.
- Does **not** eliminate existing retries — Zot's own sync
  `maxRetries`/`retryDelay` is untouched; this adds a bounded client-side
  retry layer on top, it doesn't replace anything.
- Does **not** touch `manifests/workflow-semaphores.yaml` (capacity) or any
  scheduling/partitioning — the root cause is stall duration, not capacity,
  so a capacity change wouldn't fix the underlying throughput collapse.
- **Quantified improvement:** worst-case slot-hold time for a stalled pull
  drops from ~3600s (`activeDeadlineSeconds`) to ~1500s (3×480s + 2×30s) —
  a **58% reduction**, and leaves ~35 minutes of the original 1h deadline
  budget for GDM boot + the behave suite instead of potentially zero.

## Validation

- `python3 -m pytest tests/unit/test_container_only_qa_workflows.py
  tests/unit/test_workflow_defaults.py -q` — 57 passed.
- `just lint` — clean (workflow-templates, bootstrap, standalone workflows).
- Live cluster: re-confirmed the incident was ongoing (semaphore `0/6`,
  stuck pods) before this change; will re-verify semaphore/queue drain after
  merge + ArgoCD reconciliation.

## Scope / coordination

No overlap with `repair-aurora-gate` or `verify-kde-linux` — this PR only
touches `argo/workflow-templates/run-container-tests.yaml`, which is not
touched by either of those in-flight branches. VM-based lanes (Aurora, KDE
OVMF) don't use `ghost-container-qa` and are unaffected.