### PR TITLE
fix(recc): preserve full metric log lines

### DIFF
--- a/argo/workflow-templates/recc-baseline-pipeline.yaml
+++ b/argo/workflow-templates/recc-baseline-pipeline.yaml
@@ -486,8 +486,7 @@ spec:
               printf '%s phase: failed (exit %s)\n' "${phase}" "${rc}" >> "${phase_log}"
               printf -v "${status_var}" '%s' failed
             fi
-            grep -Eio '(^|[[:space:]\[\(])RECC(_VERBOSE|_METRICS)?([[:space:]:\]\)]|$).*' \
-              "${phase_log}" > "${phase_raw_recc}" || true
+            grep -Ei "${RECC_LOG_PATTERN}" "${phase_log}" > "${phase_raw_recc}" || true
             {
               printf '=== BEGIN RECC_VERBOSE LOG ===\n'
               cat "${phase_raw_recc}"

--- a/docs/reference/recc-baseline.md
+++ b/docs/reference/recc-baseline.md
@@ -92,8 +92,8 @@ are never treated as compiler durations.
 RECC's metrics file is written under BuildStream's ephemeral `%{build-root}`,
 then printed into the element build log and removed before artifact creation.
 The workflow sets BuildStream's supported `logdir` to `/work/buildstream-logs`
-and extracts RECC-marked lines from those per-element logs into the workflow
-evidence. This keeps the StatsD/log handoff outside the deterministic artifact;
+and extracts complete RECC-marked lines from those per-element logs into the
+workflow evidence. This keeps the StatsD/log handoff outside the deterministic artifact;
 cache-only and upload-local-build phases fail closed when that handoff produces
 no valid RECC StatsD metric evidence.
 

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -240,7 +240,7 @@ The operator-only `recc-baseline-pipeline` must use BuildStream's configured
 StatsD output under `%{build-root}`, prints each record with a
 `[RECC_METRICS]` marker into the element build log, and removes the file before
 installing the deterministic artifact. The workflow points `logdir` at its
-`/work` volume and extracts only RECC-marked lines; do not put metrics in
+`/work` volume and preserves complete RECC-marked lines; do not put metrics in
 `%{install-root}`, a checked-out artifact, or a host mount.
 
 This preserves artifact determinism while making action-cache hits/misses,

--- a/tests/unit/test_recc_baseline_workflow.py
+++ b/tests/unit/test_recc_baseline_workflow.py
@@ -161,6 +161,7 @@ def test_metadata_outputs_preserve_remote_cache_and_unavailable_fields():
     assert "RECC_STATSD_PATTERN=" in text
     assert "RECC StatsD metric evidence missing from BuildStream logdir" in text
     assert 'grep -Eiq "${RECC_STATSD_PATTERN}" "${phase_log}"' in text
+    assert 'grep -Ei "${RECC_LOG_PATTERN}" "${phase_log}" > "${phase_raw_recc}"' in text
     assert "--prometheus-before" in text
     assert "--prometheus-after" in text
     assert "/work/recc.log" in text


### PR DESCRIPTION
Follow-up for #532: preserve the complete RECC metric line when turning the BuildStream logdir handoff into collector input. The prior extraction dropped the opening bracket from [RECC_METRICS], so the collector could not recognize otherwise valid StatsD evidence.

Validation: targeted RECC pytest; just lint.