### PR TITLE
fix(argo): declare poller digest parameter

### DIFF
--- a/argo/workflow-templates/image-poller.yaml
+++ b/argo/workflow-templates/image-poller.yaml
@@ -19,6 +19,10 @@ spec:
     parameters:
       - name: image
       - name: image-tag
+      # This caller resolves a digest at runtime for the referenced QA
+      # template; declare the parameter so Argo can validate that reference.
+      - name: image-digest
+        value: ""
       - name: state-key
       - name: namespace
         value: "bluefin-test"

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -40,6 +40,20 @@ def test_image_poller_cron_manifests_do_not_pass_containerdisk_tag():
     assert not offenders, f"obsolete containerdisk-tag in: {', '.join(offenders)}"
 
 
+def test_image_poller_declares_the_digest_parameter_used_by_its_qa_reference():
+    poller = yaml.safe_load(
+        (ROOT / "argo/workflow-templates/image-poller.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    parameters = {
+        parameter["name"]: parameter.get("value")
+        for parameter in poller["spec"]["arguments"]["parameters"]
+    }
+
+    assert parameters["image-digest"] == ""
+
+
 def test_dakota_requires_distributed_capacity_matched_execution():
     config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Summary: declare the image-poller digest parameter required to validate its referenced QA pipeline, restoring healthy image-poll CronWorkflows and GitOps reconciliation. Validation: python3 -m pytest tests/unit/test_workflow_defaults.py tests/unit/test_container_only_qa_workflows.py -q; just lint.