### PR TITLE
fix(argo): pass poller digest defaults

### DIFF
--- a/manifests/image-poll-aurora-main.yaml
+++ b/manifests/image-poll-aurora-main.yaml
@@ -30,6 +30,8 @@ spec:
           value: "ghcr.io/ublue-os/aurora"
         - name: image-tag
           value: "latest"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-aurora-main"
         - name: suites

--- a/manifests/image-poll-aurora-stable.yaml
+++ b/manifests/image-poll-aurora-stable.yaml
@@ -31,6 +31,8 @@ spec:
           value: "ghcr.io/ublue-os/aurora"
         - name: image-tag
           value: "stable"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-aurora-stable"
         - name: suites

--- a/manifests/image-poll-aurora-testing.yaml
+++ b/manifests/image-poll-aurora-testing.yaml
@@ -32,6 +32,8 @@ spec:
           value: "ghcr.io/ublue-os/aurora"
         - name: image-tag
           value: "testing"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-aurora-testing"
         - name: suites

--- a/manifests/image-poll-bluefin-main.yaml
+++ b/manifests/image-poll-bluefin-main.yaml
@@ -30,6 +30,8 @@ spec:
           value: "ghcr.io/ublue-os/bluefin"
         - name: image-tag
           value: "latest"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-bluefin-main"
         - name: suites

--- a/manifests/image-poll-bluefin-stable.yaml
+++ b/manifests/image-poll-bluefin-stable.yaml
@@ -30,6 +30,8 @@ spec:
           value: "ghcr.io/projectbluefin/bluefin"
         - name: image-tag
           value: "stable"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-bluefin-stable"
         - name: suites

--- a/manifests/image-poll-bluefin-testing.yaml
+++ b/manifests/image-poll-bluefin-testing.yaml
@@ -30,6 +30,8 @@ spec:
           value: "ghcr.io/projectbluefin/bluefin"
         - name: image-tag
           value: "testing"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-bluefin-testing"
         - name: suites

--- a/manifests/image-poll-fedora-bootc-latest.yaml
+++ b/manifests/image-poll-fedora-bootc-latest.yaml
@@ -30,6 +30,8 @@ spec:
           value: "quay.io/fedora/fedora-bootc"
         - name: image-tag
           value: "latest"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-fedora-bootc-latest"
         - name: suites

--- a/manifests/image-poll-fedora-bootc-rawhide.yaml
+++ b/manifests/image-poll-fedora-bootc-rawhide.yaml
@@ -30,6 +30,8 @@ spec:
           value: "quay.io/fedora/fedora-bootc"
         - name: image-tag
           value: "rawhide"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-fedora-bootc-rawhide"
         - name: suites

--- a/manifests/image-poll-lts-stable.yaml
+++ b/manifests/image-poll-lts-stable.yaml
@@ -30,6 +30,8 @@ spec:
           value: "ghcr.io/projectbluefin/bluefin-lts"
         - name: image-tag
           value: "stable"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-lts-stable"
         - name: suites

--- a/manifests/image-poll-lts-testing.yaml
+++ b/manifests/image-poll-lts-testing.yaml
@@ -30,6 +30,8 @@ spec:
           value: "ghcr.io/projectbluefin/bluefin-lts"
         - name: image-tag
           value: "testing"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-lts-testing"
         - name: suites

--- a/manifests/image-poll-snosi-latest.yaml
+++ b/manifests/image-poll-snosi-latest.yaml
@@ -31,6 +31,8 @@ spec:
           value: "ghcr.io/frostyard/snow"
         - name: image-tag
           value: "latest"
+        - name: image-digest
+          value: ""
         - name: state-key
           value: "digest-snosi-latest"
         - name: suites

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -54,6 +54,23 @@ def test_image_poller_declares_the_digest_parameter_used_by_its_qa_reference():
     assert parameters["image-digest"] == ""
 
 
+def test_image_poller_cron_workflows_supply_the_digest_parameter():
+    offenders = []
+
+    for manifest in sorted((ROOT / "manifests").glob("image-poll-*.yaml")):
+        document = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+        if document["spec"]["workflowSpec"].get("workflowTemplateRef", {}).get("name") != "image-poller":
+            continue
+        parameters = {
+            parameter["name"]: parameter.get("value")
+            for parameter in document["spec"]["workflowSpec"]["arguments"]["parameters"]
+        }
+        if parameters.get("image-digest") != "":
+            offenders.append(manifest.name)
+
+    assert not offenders, f"missing image-digest default in: {', '.join(offenders)}"
+
+
 def test_dakota_requires_distributed_capacity_matched_execution():
     config = (ROOT / "manifests/buildstream-remote-cache-config.yaml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Summary: declare the empty digest parameter in every image-poller CronWorkflow so Argo can resolve the referenced QA pipeline and GitOps health recovers. Validation: python3 -m pytest tests/unit/test_workflow_defaults.py tests/unit/test_container_only_qa_workflows.py -q; just lint.