### PR TITLE
fix(argo): install Aurora guest agent

### DIFF
--- a/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
+++ b/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
@@ -389,6 +389,7 @@ spec:
               kf6-kwayland-devel kf6-kwindowsystem-devel kf6-kcoreaddons-devel \
               kpipewire-devel plasma-wayland-protocols-devel \
               libxkbcommon-devel wayland-devel \
+              qemu-guest-agent \
               python3-devel python3-flask python3-pyatspi python3-lxml \
               python3-gobject ruby ruby-devel \
             && dnf clean all \
@@ -524,6 +525,9 @@ spec:
             DEPLOY_DIR=$(find "${SYSROOT}/ostree/deploy" -maxdepth 5 -name "*.0" -type d \
               -not -path "*/backing/*" 2>/dev/null | head -1)
             if [ -n "${DEPLOY_DIR}" ]; then
+              QGA_UNIT="${DEPLOY_DIR}/usr/lib/systemd/system/qemu-guest-agent.service"
+              test -f "${QGA_UNIT}" ||
+                { echo "[POST-INSTALL] qemu-guest-agent.service is absent" >&2; exit 1; }
               QGA_WANTS="${DEPLOY_DIR}/etc/systemd/system/multi-user.target.wants/qemu-guest-agent.service"
               if [ ! -e "${QGA_WANTS}" ]; then
                 mkdir -p "$(dirname "${QGA_WANTS}")"

--- a/docs/skills/kubevirt-vms/SKILL.md
+++ b/docs/skills/kubevirt-vms/SKILL.md
@@ -87,6 +87,11 @@ with no pinning.
 - `fsetxattr(security.selinux): Operation not supported` during LTS build — wrapper loaded but returning ENOTSUP; change wrapper to return 0 (noop) instead so ostree version mismatch doesn't matter.
 - SSH `Permission denied (publickey)` after configure-disk — **do not debug disk injection further**; switch to KubeVirt accessCredentials with qemuGuestAgent (section 2b).
 - Using disk injection for SSH keys when accessCredentials is available — disk injection is fragile; accessCredentials is the canonical KubeVirt pattern.
+- Enabling `qemu-guest-agent.service` in a generated containerDisk without first
+  ensuring the guest contains `qemu-guest-agent`. KubeVirt's
+  `qemuGuestAgent` access-credential propagation requires the installed guest
+  agent; make the shared builder install and verify its unit before creating
+  the service symlink.
 - `pip install --user` failing with EACCES inside VM — home directory owned by root; always chown after `install -d .ssh` (section 2c).
 - LTS VM goes `Stopped` immediately after creation — `bluefin-test-ssh-pubkey` secret missing from `bluefin-lts-test` namespace. The manifest must create the secret in **both** `bluefin-test` and `bluefin-lts-test`. Check with `kubectl get secret -n bluefin-lts-test bluefin-test-ssh-pubkey`.
 - VM goes `Stopped` with `FailedCreate` and `metadata.labels: must be no more than 63 characters` — VM name exceeds Kubernetes label-value limit. `bluefin-lts-testing-developer-<36-char-uuid>` = 67 chars, fails. `smoke` (5 chars) just passes; `developer` (9 chars) overflows. Fix: use `{{workflow.name}}-{{item}}` instead of `{{workflow.parameters.variant}}-{{item}}-{{workflow.uid}}` — workflow names are short and unique. Fixed in `bluefin-qa-pipeline` commit `7fca070`.

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -258,6 +258,8 @@ def test_aurora_containerdisk_builder_isolated_and_prebaked():
     assert "d45a21e8f1b3591dc921f0be85f1ecd834cbe413" in builder
     assert "selenium-webdriver-at-spi-inputsynth" in builder
     assert "qt6-qtbase-private-devel" in builder
+    assert "libxkbcommon-devel wayland-devel \\\n              qemu-guest-agent \\" in builder
+    assert 'test -f "${QGA_UNIT}"' in builder
     assert "192.168.1.102:30500/{{inputs.parameters.containerdisk-repo}}:${TAG}" in builder
 
     aurora = (ROOT / "argo/workflow-templates/aurora-containerdisk-test.yaml").read_text(


### PR DESCRIPTION
## Root cause

The normal Aurora run passed source pull, KDE WebDriver prebake, bootc install, conversion, registry push, and VM creation. It then failed before scenarios because the guest agent never connected: `AccessCredentialsSynchronized=False`, followed by the SSH readiness timeout.

## Repair and proof

- add `qemu-guest-agent` to the Aurora KDE prebake
- fail the builder if the deployed guest-agent unit is absent
- focused regression verifies both guards
- `pytest -q tests/unit/test_workflow_defaults.py` (27 passed)
- `just lint` (passed)

This is public-safe summary evidence; no credentials or raw sensitive logs are included.