### PR TITLE
fix(argo): scope poller QA parameters

### DIFF
--- a/argo/workflow-templates/bluefin-qa-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-qa-pipeline.yaml
@@ -22,7 +22,7 @@ spec:
   # cross-workflow semaphore; the workflow-level deadline must outlive queue wait
   # plus the 1h per-suite test pod deadline.
   activeDeadlineSeconds: 14400
-  entrypoint: pipeline
+  entrypoint: dispatch-pipeline
   arguments:
     parameters:
     - name: image
@@ -48,22 +48,11 @@ spec:
     - name: testsuite-repo
       value: "https://github.com/projectbluefin/testsuite"
   templates:
-  - name: pipeline
+  - name: dispatch-pipeline
     dag:
       tasks:
-      - name: validate-suites
-        template: validate-suites
-        arguments:
-          parameters:
-          - name: suites
-            value: "{{workflow.parameters.suites}}"
-      - name: test-lane
-        depends: "validate-suites.Succeeded"
-        withItems: [smoke, common, developer, software, system]
-        when: "'{{workflow.parameters.suites}}' =~ '{{item}}'"
-        templateRef:
-          name: run-container-tests
-          template: run-container-tests
+      - name: pipeline
+        template: pipeline
         arguments:
           parameters:
           - name: image
@@ -72,8 +61,8 @@ spec:
             value: "{{workflow.parameters.image-tag}}"
           - name: image-digest
             value: "{{workflow.parameters.image-digest}}"
-          - name: suite
-            value: "{{item}}"
+          - name: suites
+            value: "{{workflow.parameters.suites}}"
           - name: variant
             value: "{{workflow.parameters.variant}}"
           - name: branch
@@ -82,6 +71,50 @@ spec:
             value: "{{workflow.parameters.testsuite-branch}}"
           - name: testsuite-repo
             value: "{{workflow.parameters.testsuite-repo}}"
+  - name: pipeline
+    inputs:
+      parameters:
+      - name: image
+      - name: image-tag
+      - name: image-digest
+      - name: suites
+      - name: variant
+      - name: branch
+      - name: testsuite-branch
+      - name: testsuite-repo
+    dag:
+      tasks:
+      - name: validate-suites
+        template: validate-suites
+        arguments:
+          parameters:
+          - name: suites
+            value: "{{inputs.parameters.suites}}"
+      - name: test-lane
+        depends: "validate-suites.Succeeded"
+        withItems: [smoke, common, developer, software, system]
+        when: "'{{inputs.parameters.suites}}' =~ '{{item}}'"
+        templateRef:
+          name: run-container-tests
+          template: run-container-tests
+        arguments:
+          parameters:
+          - name: image
+            value: "{{inputs.parameters.image}}"
+          - name: image-tag
+            value: "{{inputs.parameters.image-tag}}"
+          - name: image-digest
+            value: "{{inputs.parameters.image-digest}}"
+          - name: suite
+            value: "{{item}}"
+          - name: variant
+            value: "{{inputs.parameters.variant}}"
+          - name: branch
+            value: "{{inputs.parameters.branch}}"
+          - name: testsuite-branch
+            value: "{{inputs.parameters.testsuite-branch}}"
+          - name: testsuite-repo
+            value: "{{inputs.parameters.testsuite-repo}}"
           - name: behave-tags
             value: ""
   - name: validate-suites

--- a/argo/workflow-templates/image-poller.yaml
+++ b/argo/workflow-templates/image-poller.yaml
@@ -76,6 +76,8 @@ spec:
                   value: "{{workflow.parameters.branch}}"
                 - name: testsuite-branch
                   value: "{{workflow.parameters.testsuite-branch}}"
+                - name: testsuite-repo
+                  value: "{{workflow.parameters.testsuite-repo}}"
           - name: update-digest
             depends: "check-digest.Succeeded && run-pipeline.Succeeded"
             when: "{{tasks.check-digest.outputs.parameters.changed}} == true"

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -51,6 +51,28 @@ def test_bluefin_test_lane_depends_on_suite_validation():
     assert content.index("- name: validate-suites") < content.index("- name: test-lane")
 
 
+def test_bluefin_pipeline_accepts_explicit_template_ref_arguments():
+    import yaml
+
+    pipeline = yaml.safe_load(PIPELINE.read_text(encoding="utf-8"))
+    templates = {template["name"]: template for template in pipeline["spec"]["templates"]}
+    parameters = {
+        parameter["name"]
+        for parameter in templates["pipeline"]["inputs"]["parameters"]
+    }
+
+    assert parameters == {
+        "image",
+        "image-tag",
+        "image-digest",
+        "suites",
+        "variant",
+        "branch",
+        "testsuite-branch",
+        "testsuite-repo",
+    }
+
+
 def test_run_container_tests_explicitly_allows_system_suite():
     content = (ROOT / "argo/workflow-templates/run-container-tests.yaml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Summary: make the Bluefin QA pipeline accept explicit templateRef inputs, add a root dispatcher for direct submissions, and forward the image poller testsuite repository. This resolves the CronWorkflow validation stall without manual applies. Validation: python3 -m pytest tests/unit/test_container_only_qa_workflows.py tests/unit/test_workflow_defaults.py -q; just lint.