### PR TITLE
fix(kde): download virtctl to writable path

### DIFF
--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -176,7 +176,7 @@ spec:
         [[ -n "${GITHUB_TOKEN:-}" ]] ||
           { echo "Required credential is missing: GITHUB_TOKEN" >&2; exit 2; }
         mkdir -p /tmp/results
-        VIRTCTL=/usr/local/bin/virtctl
+        VIRTCTL=/tmp/virtctl
         if [[ ! -x "${VIRTCTL}" ]]; then
           curl --fail --location --retry 3 --output "${VIRTCTL}" \
             https://github.com/kubevirt/kubevirt/releases/download/v1.8.2/virtctl-v1.8.2-linux-amd64

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -446,6 +446,8 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert 'find "${XDG_RUNTIME_DIR}"' not in kde
     assert "find /tmp/results" not in kde
     assert "shopt -s nullglob globstar" in kde
+    assert "VIRTCTL=/tmp/virtctl" in kde
+    assert "VIRTCTL=/usr/local/bin/virtctl" not in kde
     assert "publish_test_results.py" in kde
     assert "/var/mnt/ghost-data/test-results" in kde
     template = yaml.safe_load(kde)["spec"]["templates"][0]


### PR DESCRIPTION
Summary: download virtctl to the runner writable temporary directory and lock that contract with a test. Validation: pytest -q tests/unit/test_workflow_defaults.py; just lint. Fixes #470.