### PR TITLE
fix(argo): enable Aurora guest agent

### DIFF
--- a/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
+++ b/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
@@ -392,6 +392,7 @@ spec:
               qemu-guest-agent \
               python3-devel python3-flask python3-pyatspi python3-lxml \
               python3-gobject ruby ruby-devel \
+            && systemctl enable qemu-guest-agent.service \
             && dnf clean all \
             && git clone --quiet --depth 1 https://github.com/KDE/selenium-webdriver-at-spi.git /usr/src/selenium-webdriver-at-spi \
             && cd /usr/src/selenium-webdriver-at-spi \

--- a/docs/skills/kubevirt-vms/SKILL.md
+++ b/docs/skills/kubevirt-vms/SKILL.md
@@ -90,8 +90,8 @@ with no pinning.
 - Enabling `qemu-guest-agent.service` in a generated containerDisk without first
   ensuring the guest contains `qemu-guest-agent`. KubeVirt's
   `qemuGuestAgent` access-credential propagation requires the installed guest
-  agent; make the shared builder install and verify its unit before creating
-  the service symlink.
+  agent; make the shared builder install, enable, and verify its unit before
+  creating the service symlink.
 - `pip install --user` failing with EACCES inside VM — home directory owned by root; always chown after `install -d .ssh` (section 2c).
 - LTS VM goes `Stopped` immediately after creation — `bluefin-test-ssh-pubkey` secret missing from `bluefin-lts-test` namespace. The manifest must create the secret in **both** `bluefin-test` and `bluefin-lts-test`. Check with `kubectl get secret -n bluefin-lts-test bluefin-test-ssh-pubkey`.
 - VM goes `Stopped` with `FailedCreate` and `metadata.labels: must be no more than 63 characters` — VM name exceeds Kubernetes label-value limit. `bluefin-lts-testing-developer-<36-char-uuid>` = 67 chars, fails. `smoke` (5 chars) just passes; `developer` (9 chars) overflows. Fix: use `{{workflow.name}}-{{item}}` instead of `{{workflow.parameters.variant}}-{{item}}-{{workflow.uid}}` — workflow names are short and unique. Fixed in `bluefin-qa-pipeline` commit `7fca070`.

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -259,6 +259,7 @@ def test_aurora_containerdisk_builder_isolated_and_prebaked():
     assert "selenium-webdriver-at-spi-inputsynth" in builder
     assert "qt6-qtbase-private-devel" in builder
     assert "libxkbcommon-devel wayland-devel \\\n              qemu-guest-agent \\" in builder
+    assert "systemctl enable qemu-guest-agent.service" in builder
     assert 'test -f "${QGA_UNIT}"' in builder
     assert "192.168.1.102:30500/{{inputs.parameters.containerdisk-repo}}:${TAG}" in builder
 


### PR DESCRIPTION
## Root cause

The shared builder installed and linked the guest-agent unit, but the normal Aurora VM still reported a disconnected guest agent and never opened SSH. The image build had not enabled the service before `bootc install to-disk`.

## Repair and proof

- enable `qemu-guest-agent.service` in the prebaked Aurora source image
- focused regression asserts the enablement command
- `pytest -q tests/unit/test_workflow_defaults.py` (29 passed)
- `just lint` (passed)

This remains a public-safe technical summary.