### PR TITLE
fix(argo): give Aurora conversion time to finish

### DIFF
--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -18,7 +18,7 @@ spec:
       bluefin.io/evidence-contract: qa-run-v1
   entrypoint: aurora-qa
   onExit: teardown
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 14400
   volumeClaimGC:
     strategy: OnWorkflowCompletion
   volumeClaimTemplates:

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -287,7 +287,7 @@ def test_aurora_qa_pipeline_is_vm_based_and_serialized():
     assert pipeline["metadata"]["name"] == "aurora-qa-pipeline"
     assert spec["entrypoint"] == "aurora-qa"
     assert spec["onExit"] == "teardown"
-    assert spec["activeDeadlineSeconds"] == 3600
+    assert spec["activeDeadlineSeconds"] == 14400
     assert spec["templates"][0]["name"] == "aurora-qa"
     assert spec["templates"][0]["synchronization"]["semaphores"][0]["configMapKeyRef"] == {
         "name": "workflow-semaphores",


### PR DESCRIPTION
## Evidence

`aurora-qa-pipeline-wjs5x` reached `convert-and-push` successfully, but spent over 50 minutes in the Fedora package transaction while still making measurable forward progress (42/85 packages). Its 3600-second workflow deadline leaves insufficient time for conversion and registry push.

## Repair

Raise the Aurora pipeline deadline to 14400 seconds, matching the shared builder. The focused workflow contract regression and `just lint` pass.