### PR TITLE
fix(kde): bound artifact download stalls

### DIFF
--- a/argo/workflow-templates/provision-kde-linux-vm.yaml
+++ b/argo/workflow-templates/provision-kde-linux-vm.yaml
@@ -96,6 +96,7 @@ spec:
           exit 1
         }
         curl --fail --location --retry 3 --retry-all-errors \
+          --connect-timeout 30 --speed-limit 1024 --speed-time 120 --remove-on-error \
           --output "${IMAGE}" "${URL}"
         printf '%s  %s\n' "${SHA}" "${IMAGE}" | sha256sum -c -
 

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -496,6 +496,10 @@ def test_kde_linux_workflow_calls_native_runner_with_current_contract():
     assert "testsuite-branch" not in workflow
     assert 'value: "aurora-test"' in provision
     assert "kde-test-namespace" not in workflow
+    assert "--connect-timeout 30" in provision
+    assert "--speed-limit 1024" in provision
+    assert "--speed-time 120" in provision
+    assert "--remove-on-error" in provision
 
 
 def test_kde_workflow_images_are_digest_pinned():


### PR DESCRIPTION
Summary: bound KDE artifact connection and no-progress failures while retaining checksum verification and three retries. Validation: pytest -q tests/unit/test_workflow_defaults.py; just lint. Fixes #470.