### PR TITLE
fix(kubevirt): unconfine virtio console loader

### DIFF
--- a/manifests/virtio-console-module.yaml
+++ b/manifests/virtio-console-module.yaml
@@ -25,6 +25,9 @@ spec:
         app.kubernetes.io/component: node-tuning
         app.kubernetes.io/part-of: bluefin-test-suite
     spec:
+      securityContext:
+        seccompProfile:
+          type: Unconfined
       tolerations:
         - operator: Exists
       hostPID: true

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -246,6 +246,16 @@ def test_buildbarn_runner_uses_stable_tmpdir_after_chroot():
     assert "filePool:" not in config
 
 
+def test_virtio_console_module_can_enter_host_mount_namespace():
+    daemonset = yaml.safe_load(
+        (ROOT / "manifests/virtio-console-module.yaml").read_text(encoding="utf-8")
+    )
+
+    assert daemonset["spec"]["template"]["spec"]["securityContext"] == {
+        "seccompProfile": {"type": "Unconfined"}
+    }
+
+
 def test_aurora_containerdisk_builder_isolated_and_prebaked():
     builder = (
         ROOT / "argo/workflow-templates/build-bluefin-migration-containerdisk.yaml"


### PR DESCRIPTION
## Root cause

The live `virtio-console-module` init container logged `nsenter: can’t open /proc/1/ns/mnt: Permission denied`. Its pod has no seccomp profile, so the module loader cannot enter the host mount namespace. Aurora VMs consequently report `AccessCredentialsSyncFailed: Guest agent is offline`.

## Repair

Set pod seccomp to `Unconfined`, as required for the privileged host namespace operation. A focused manifest regression verifies the contract; `pytest -q tests/unit/test_workflow_defaults.py` (30 passed) and `just lint` pass.