### PR TITLE
fix(kubevirt): run virtio console loader as root

### DIFF
--- a/manifests/virtio-console-module.yaml
+++ b/manifests/virtio-console-module.yaml
@@ -36,6 +36,7 @@ spec:
           image: cgr.dev/chainguard/kubectl:latest-dev
           securityContext:
             privileged: true
+            runAsUser: 0
           command: [sh, -c]
           args:
             - |

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -254,6 +254,11 @@ def test_virtio_console_module_can_enter_host_mount_namespace():
     assert daemonset["spec"]["template"]["spec"]["securityContext"] == {
         "seccompProfile": {"type": "Unconfined"}
     }
+    modprobe = daemonset["spec"]["template"]["spec"]["initContainers"][0]
+    assert modprobe["securityContext"] == {
+        "privileged": True,
+        "runAsUser": 0,
+    }
 
 
 def test_aurora_containerdisk_builder_isolated_and_prebaked():


### PR DESCRIPTION
## Root cause

The previous seccomp repair rolled out, but the loader still failed. The actual pod status and a direct redacted reproduction show the image starts as UID 65532. `nsenter -t 1 -m` cannot open root-owned `/proc/1/ns/mnt` as that user.

## Repair

Run only the privileged `modprobe` init container as UID 0. The existing manifest regression now locks both the unconfined pod profile and root loader identity.

## Evidence

- Post-rollout logs reproduced the failure under UID 65532.
- Target test: `pytest -q tests/unit/test_workflow_defaults.py` → 30 passed.
- `just lint` → passed.