### PR TITLE
fix(kde): preserve SSH command arguments

### DIFF
--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -186,9 +186,7 @@ spec:
         PF_PID=$!
         trap 'kill "${PF_PID}" 2>/dev/null || true' EXIT
         timeout 600 bash -c '
-          until ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no
-              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10
-              "${VM_USER}@127.0.0.1" true 2>/dev/null; do sleep 5; done'
+          until ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 "${VM_USER}@127.0.0.1" true 2>/dev/null; do sleep 5; done'
         ssh -i "${SSH_KEY}" -p 2222 -o StrictHostKeyChecking=no \
           -o UserKnownHostsFile=/dev/null "${VM_USER}@127.0.0.1" \
           '

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -464,6 +464,10 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "shopt -s nullglob globstar" in kde
     assert "VIRTCTL=/tmp/virtctl" in kde
     assert "VIRTCTL=/usr/local/bin/virtctl" not in kde
+    assert (
+        '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
+        '-o ConnectTimeout=10 "${VM_USER}@127.0.0.1" true'
+    ) in kde
     assert "publish_test_results.py" in kde
     assert "/var/mnt/ghost-data/test-results" in kde
     template = yaml.safe_load(kde)["spec"]["templates"][0]


### PR DESCRIPTION
Summary: prevent SSH options from becoming separate shell commands during KDE runner readiness checks. Validation: pytest -q tests/unit/test_workflow_defaults.py; just lint. Fixes #470.