### PR TITLE
fix(argo): give bounded GHCR pulls one more retry attempt

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -206,7 +206,19 @@ spec:
         # activeDeadlineSeconds instead of minutes. Retry a bounded number of
         # times first, since a stall is often resolved by Zot's own
         # reconnect-and-resume on the next attempt.
-        PULL_ATTEMPTS=3
+        #
+        # Podman's local blob storage persists across attempts within this
+        # pod, so a retry never restarts from zero: it skips every
+        # already-completed blob and only re-fetches what didn't finish.
+        # Under real ghost-container-qa concurrency (up to 6 simultaneous
+        # pulls sharing one node's egress), this makes attempts
+        # monotonically faster -- observed live in bluefin-qa-pipeline-42jhj,
+        # where attempt 3/3 reached the image's final blob and missed the
+        # 480s deadline by only ~47s. 3 attempts (1500s) was sized for the
+        # original instant-hang case; one extra bounded attempt (4 total,
+        # 2010s worst case) covers the demonstrated near-miss for slow-but-
+        # progressing pulls without unbounding any single attempt.
+        PULL_ATTEMPTS=4
         PULL_TIMEOUT_SECONDS=480
         pull_ok=false
         for attempt in $(seq 1 "${PULL_ATTEMPTS}"); do

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -140,6 +140,31 @@ def test_container_runner_skips_remote_digest_resolution_when_digest_provided():
     assert "skopeo inspect" in block
 
 
+def test_container_runner_pull_retry_budget_survives_slow_contended_pulls():
+    # Live incident bluefin-qa-pipeline-42jhj: under real concurrent
+    # ghost-container-qa demand (up to 6 simultaneous podman pulls sharing one
+    # node's egress), podman's local blob cache carries completed blobs
+    # forward across attempts (each retry starts faster than the last), so
+    # attempt 3/3 reached the final blob of the image and missed the 480s
+    # deadline by only ~47s. PULL_ATTEMPTS=3 was calibrated for the original
+    # instant "unexpected EOF" hang, not for this slow-but-progressing
+    # pattern. Bumping to 4 attempts (worst case 2010s) gives one more full
+    # bounded window -- comfortably more than the ~47s that was missing --
+    # while every attempt remains individually timeout-bounded (no unbounded
+    # retries) and activeDeadlineSeconds (3600s) is untouched.
+    content = (ROOT / "argo/workflow-templates/run-container-tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "PULL_ATTEMPTS=4" in content
+    assert "PULL_TIMEOUT_SECONDS=480" in content
+    assert (
+        'timeout "${PULL_TIMEOUT_SECONDS}" podman pull "${PODMAN_PULL_TLS_ARGS[@]}" "${TARGET_IMAGE}"'
+        in content
+    )
+    assert "activeDeadlineSeconds: 3600" in content
+
+
 def test_container_runner_readiness_probe_is_informative():
     content = (ROOT / "argo/workflow-templates/run-container-tests.yaml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Problem

Live incident `bluefin-qa-pipeline-42jhj` (smoke lane) failed with
`result: No results generated` / `failed-scenarios: []`, blocking #543.
The bounded pull-retry loop introduced in #556 was live and behaved
exactly as designed, but the pull still gave up after 3 attempts.

## Diagnosis (ranked hypotheses, tested one variable at a time)

1. **Retry budget too small relative to demonstrated per-attempt
   progress (confirmed).** Podman's local blob storage persists across
   `podman pull` invocations within the same pod, so each retry is
   faster than the last (already-downloaded blobs are skipped near-
   instantly). Timestamped pod logs show attempt 1/3 reached blob 9/16,
   attempt 2/3 reached blob 12/16, and attempt 3/3 reached the 16th and
   *final* blob — then missed the 480s deadline by only ~47s. This is
   monotonic progress, not a stall.
2. **Zot cache issue (falsified).** The nested `podman pull` for the
   test-target image never touches Zot — no `registries.conf` mirror
   is mounted into this pod. Zot's own logs show zero blob-fetch
   activity for `projectbluefin/bluefin` during the entire failure
   window.
3. **External GHCR outage (falsified).** Bytes transferred
   successfully and continuously on every attempt; GHCR was responsive
   throughout.
4. **Image reference/digest problem (falsified).** The supplied digest
   resolved correctly and every blob copied in sequence with no
   checksum/format errors.

**Live corroboration:** at the time of the failure, and again
independently confirmed live during this diagnosis, all 6
`ghost-container-qa` semaphore slots were simultaneously running
`podman pull` for large images, sharing one node's real network
egress. The queue is chronically saturated (workflows waiting 2h+ for
a slot), so this concurrency is the steady state for this cluster, not
a rare edge case.

## Fix

`PULL_ATTEMPTS` 3 → 4. Every attempt remains individually bounded by
the **unchanged** 480s timeout — no attempt is ever unbounded, and the
timeout wrapper itself is untouched. Worst-case total pull time goes
from 1500s to 2010s, comfortably covering the demonstrated ~47s
shortfall. `activeDeadlineSeconds` (3600s) is unchanged, preserving
ample headroom for the rest of the script (nested systemd boot, GDM,
qecore, behave). Digest/image validation and the registry allowlist
are untouched.

## Testing

- New regression test
  `test_container_runner_pull_retry_budget_survives_slow_contended_pulls`
  — watched fail against the pre-fix template, passes after the fix.
- `python3 -m pytest tests/unit/` — 341 passed.
- `just lint` — clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>