### PR TITLE
fix(aurora): restore static GRUB boot UUID

### DIFF
--- a/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
+++ b/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
@@ -549,6 +549,31 @@ spec:
               fi
               SSHD_ENABLED=true
 
+              # --with-static-configs avoids the btrfs findmnt bug above, but
+              # does not write the boot filesystem UUID.  A generic disk's
+              # root filesystem is labelled "root", not "boot", so GRUB needs
+              # this bootupd-format file in its EFI vendor directory to find
+              # the real grub.cfg.
+              ROOT_UUID="$(blkid -s UUID -o value "${PART}")"
+              test -n "${ROOT_UUID}"
+              ESP_ROOT="${STAGING}/esp-root"
+              mkdir -p "${ESP_ROOT}"
+              mount "${LOOP_DEV}p2" "${ESP_ROOT}"
+              BOOTUUID_WRITTEN=false
+              for GRUB_CFG in "${ESP_ROOT}"/EFI/*/grub.cfg; do
+                [ -f "${GRUB_CFG}" ] || continue
+                printf 'set BOOT_UUID="%s"\n' "${ROOT_UUID}" \
+                  > "$(dirname "${GRUB_CFG}")/bootuuid.cfg"
+                BOOTUUID_WRITTEN=true
+              done
+              sync
+              umount "${ESP_ROOT}"
+              rmdir "${ESP_ROOT}"
+              if [ "${BOOTUUID_WRITTEN}" != true ]; then
+                echo "[POST-INSTALL] bootupd EFI vendor grub.cfg was not found" >&2
+                exit 1
+              fi
+
               # Restore original findmnt binaries by finding all findmnt.orig in the deployed system root
               echo "[POST-INSTALL] Restoring original findmnt binaries..."
               find "${DEPLOY_DIR}" -name "findmnt.orig" | while read -r orig_file; do

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -276,6 +276,10 @@ def test_aurora_containerdisk_builder_isolated_and_prebaked():
     assert "libxkbcommon-devel wayland-devel \\\n              qemu-guest-agent \\" in builder
     assert "systemctl enable qemu-guest-agent.service" in builder
     assert 'test -f "${QGA_UNIT}"' in builder
+    assert 'ROOT_UUID="$(blkid -s UUID -o value "${PART}")"' in builder
+    assert '"${ESP_ROOT}"/EFI/*/grub.cfg' in builder
+    assert 'bootuuid.cfg' in builder
+    assert 'set BOOT_UUID="%s"\\n' in builder
     assert "192.168.1.102:30500/{{inputs.parameters.containerdisk-repo}}:${TAG}" in builder
 
     aurora = (ROOT / "argo/workflow-templates/aurora-containerdisk-test.yaml").read_text(


### PR DESCRIPTION
## Root cause

The guest-agent symptom was downstream of a failed guest boot, not the host virtio channel. The authorized serial console reached a GRUB prompt. The EFI stub fell back to `search --label boot`, but the generic btrfs root filesystem is labelled `root`; `skip-boot-uuid=true` had deliberately omitted `bootuuid.cfg`.

## Repair

After `bootc install`, derive the root filesystem UUID and write bootupd-format `bootuuid.cfg` alongside every EFI vendor `grub.cfg`. This preserves the btrfs workaround and restores normal EFI GRUB discovery.

## Verification

- Manual serial commands selecting the root `grub.cfg` displayed the Aurora boot menu and booted its BLS entry.
- Regression first failed, then `pytest -q tests/unit/test_workflow_defaults.py` passed (30 tests).
- `just lint` passed.