### PR TITLE
fix(aurora): let the SSH socket own port 22

### DIFF
--- a/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
+++ b/argo/workflow-templates/build-bluefin-migration-containerdisk.yaml
@@ -509,13 +509,12 @@ spec:
           --via-loopback \
           "${DISK}"
 
-        # Some images disable the runtime services the lab depends on.
-        # Bluefin needs qemu-guest-agent for KubeVirt accessCredentials, and
-        # the lab also needs sshd.service to be enabled in the ostree deployment.
-        echo "[POST-INSTALL] Enabling qemu-guest-agent.service and sshd.service for lab access..."
+        # Bluefin needs qemu-guest-agent for KubeVirt accessCredentials.
+        # The provision workflow starts sshd.socket after the agent is ready;
+        # enabling sshd.service here would make the socket fail to bind port 22.
+        echo "[POST-INSTALL] Enabling qemu-guest-agent.service for lab access..."
         LOOP_DEV=$(losetup -f --show -P "${DISK}")
         SYSROOT=$(mktemp -d)
-        SSHD_ENABLED=false
         QGA_ENABLED=false
         for PARTNUM in 4 3 2; do
           PART="${LOOP_DEV}p${PARTNUM}"
@@ -538,16 +537,6 @@ spec:
                 echo "[POST-INSTALL] qemu-guest-agent.service already enabled"
               fi
               QGA_ENABLED=true
-
-              WANTS="${DEPLOY_DIR}/etc/systemd/system/multi-user.target.wants/sshd.service"
-              if [ ! -e "${WANTS}" ]; then
-                mkdir -p "$(dirname "${WANTS}")"
-                ln -sf /usr/lib/systemd/system/sshd.service "${WANTS}"
-                echo "[POST-INSTALL] sshd.service enabled in ${DEPLOY_DIR}"
-              else
-                echo "[POST-INSTALL] sshd.service already enabled"
-              fi
-              SSHD_ENABLED=true
 
               # --with-static-configs avoids the btrfs findmnt bug above, but
               # does not write the boot filesystem UUID.  A generic disk's
@@ -592,9 +581,6 @@ spec:
         losetup -d "${LOOP_DEV}" 2>/dev/null || true
         if [ "${QGA_ENABLED}" = false ]; then
           echo "[POST-INSTALL] WARNING: could not find ostree deploy dir to enable qemu-guest-agent"
-        fi
-        if [ "${SSHD_ENABLED}" = false ]; then
-          echo "[POST-INSTALL] WARNING: could not find ostree deploy dir to enable sshd"
         fi
 
   - name: convert-and-push

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -276,6 +276,8 @@ def test_aurora_containerdisk_builder_isolated_and_prebaked():
     assert "libxkbcommon-devel wayland-devel \\\n              qemu-guest-agent \\" in builder
     assert "systemctl enable qemu-guest-agent.service" in builder
     assert 'test -f "${QGA_UNIT}"' in builder
+    assert "sshd.service enabled" not in builder
+    assert 'multi-user.target.wants/sshd.service' not in builder
     assert 'ROOT_UUID="$(blkid -s UUID -o value "${PART}")"' in builder
     assert '"${ESP_ROOT}"/EFI/*/grub.cfg' in builder
     assert 'bootuuid.cfg' in builder


### PR DESCRIPTION
## Root cause

Guest-agent diagnostics on the freshly built disk showed `sshd.service` had already bound port 22. The provision workflow subsequently started `sshd.socket`; systemd rejected that socket with `Address already in use` and terminated the running SSH service, so the TCP readiness probe always timed out.

## Repair

Do not enable `sshd.service` during the disk build. The existing guest-agent readiness step owns socket activation after the agent is connected.

## Evidence

After stopping the service and resetting the failed socket, `systemctl start sshd.socket` became active and listened on port 22. The regression failed before this change, then `pytest -q tests/unit/test_workflow_defaults.py` (30 passed) and `just lint` passed.