### PR TITLE
test: align Aurora deadline contract

### DIFF
--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -338,7 +338,7 @@ def test_aurora_qa_pipeline_is_vm_based_and_serialized():
     assert pipeline["metadata"]["name"] == "aurora-qa-pipeline"
     assert spec["entrypoint"] == "aurora-qa"
     assert spec["onExit"] == "teardown"
-    assert spec["activeDeadlineSeconds"] == 3600
+    assert spec["activeDeadlineSeconds"] == 14400
     assert spec["templates"][0]["name"] == "aurora-qa"
     assert spec["templates"][0]["synchronization"]["semaphores"][0]["configMapKeyRef"] == {
         "name": "workflow-semaphores",


### PR DESCRIPTION
Update the workflow default contract to match the current Aurora QA deadline of 14400 seconds. This fixes the required unit-test failure on current main.