### PR TITLE
fix: configure HTTP Zot pulls in QA runner

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -149,7 +149,8 @@ spec:
           TARGET_IMAGE="${IMAGE}"
         fi
 
-        # Local Zot and other insecure registries need explicit TLS verification off.
+        # Local Zot is an HTTP registry, so configure containers/image to use
+        # its insecure transport before any digest resolution or image pull.
         SKOPEO_TLS_ARGS=()
         PODMAN_PULL_TLS_ARGS=()
         case "${IMAGE%%/*}" in
@@ -174,6 +175,18 @@ spec:
           esac
         }
         ZOT_IMAGE_REPO=$(zot_image "${IMAGE_REPO}")
+        case "${ZOT_IMAGE_REPO}" in
+          192.168.1.102:*|localhost:*|127.0.0.1:*)
+            mkdir -p /etc/containers/registries.conf.d
+            cat >/etc/containers/registries.conf.d/bluefin-local-zot.conf <<'EOF'
+        [[registry]]
+        location = "192.168.1.102:30501"
+        insecure = true
+        EOF
+            SKOPEO_TLS_ARGS=(--tls-verify=false)
+            PODMAN_PULL_TLS_ARGS=(--tls-verify=false)
+            ;;
+        esac
         if [[ -z "${IMAGE_DIGEST:-}" ]]; then
           if ! command -v skopeo >/dev/null 2>&1; then
             echo "skopeo not found; installing for digest resolution..." >&2

--- a/tests/unit/test_image_poll_bandwidth.py
+++ b/tests/unit/test_image_poll_bandwidth.py
@@ -37,6 +37,8 @@ def test_container_runner_preserves_digest_pinning_and_has_no_extra_closer():
     source = (ROOT / "argo/workflow-templates/run-container-tests.yaml").read_text()
     assert 'TARGET_IMAGE="${IMAGE_REPO}@${IMAGE_DIGEST}"' in source
     assert 'podman pull "${PODMAN_PULL_TLS_ARGS[@]}" "${TARGET_IMAGE}"' in source
+    assert 'location = "192.168.1.102:30501"' in source
+    assert "insecure = true" in source
     assert source.count("        fi\n        podman run") == 1
 
 


### PR DESCRIPTION
## Summary
Configure containers/image for the lab Zot HTTP endpoint before pinned QA image pulls. The bandwidth probe exposed that the runner was attempting HTTPS against the HTTP NodePort after the mirror was made fail-closed.

## Validation
- targeted pytest: 21 passed
- just lint
- git diff --check