### PR TITLE
fix: restore merged KDE workflow contracts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -317,11 +317,6 @@ run-dakota-container-qa image-tag="testing" variant="dakota":
       -p variant={{ variant }} \
       -n {{ argo_ns }} --watch
 
-# Publish dakota:testing and dakota-nvidia:testing from Zot to GHCR.
-run-dakota-publish:
-    argo submit --from workflowtemplate/dakota-publish-pipeline \
-      -n {{ argo_ns }} --watch
-
 # Validate canonical Dakota build/publish history records.
 validate-dakota-history:
     python3 scripts/publish_dakota_run.py validate-history
@@ -347,6 +342,34 @@ run-bluefin-server-build ref="main" repo="https://github.com/projectbluefin/serv
     argo submit --from workflowtemplate/bluefin-server-build-pipeline \
       -p ref={{ ref }} \
       -p repo={{ repo }} \
+      -n {{ argo_ns }} --watch
+
+# Run the isolated operator-only RECC baseline.
+# Usage: just run-recc-baseline mode=cache-only cache-policy=both recc-provider=components/buildbox.bst
+run-recc-baseline *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    MODE="buildstream-only"
+    RUN_ID=""
+    CACHE_POLICY="cold"
+    RECC_PROVIDER="freedesktop-sdk.bst:components/buildbox.bst"
+    for arg in {{ args }}; do
+      case "${arg}" in
+        mode=*) MODE="${arg#mode=}" ;;
+        run-id=*) RUN_ID="${arg#run-id=}" ;;
+        cache-policy=*) CACHE_POLICY="${arg#cache-policy=}" ;;
+        recc-provider=*) RECC_PROVIDER="${arg#recc-provider=}" ;;
+        *)
+          echo "Unsupported run-recc-baseline argument: ${arg}" >&2
+          exit 2
+          ;;
+      esac
+    done
+    exec argo submit --from workflowtemplate/recc-baseline-pipeline \
+      -p mode="${MODE}" \
+      -p run-id="${RUN_ID}" \
+      -p cache-policy="${CACHE_POLICY}" \
+      -p recc-provider="${RECC_PROVIDER}" \
       -n {{ argo_ns }} --watch
 
 # ── Validation ───────────────────────────────────────────────────────────────

--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -41,6 +41,15 @@ spec:
         value: ""
       - name: behave-retries
         value: "2"
+    outputs:
+      parameters:
+      - name: result
+        valueFrom:
+          path: /tmp/results/result-summary.txt
+      - name: failed-scenarios
+        valueFrom:
+          path: /tmp/results/failed-scenarios.json
+          default: "[]"
     activeDeadlineSeconds: 3600
     initContainers:
     - name: git-sync
@@ -283,47 +292,15 @@ spec:
         fi
         echo "Results and KDE artifacts saved to ${RESULT_DIR}" >&2
 
-        IMG_SLUG="${VARIANT}"
-        if [[ "${VARIANT}" == "aurora" && -n "{{inputs.parameters.containerdisk-tag}}" ]]; then
-          IMG_SLUG="aurora-${{inputs.parameters.containerdisk-tag}}"
-        fi
-
-        # Push the first in-guest screenshot as the stable OCI artifact used by
-        # the dashboard. KubeVirt's virt-launcher exposes no QEMU monitor, so
-        # QEMU-level screendumps are intentionally not part of this workflow.
+        # KubeVirt's virt-launcher exposes no QEMU monitor, and GHCR
+        # publication is disabled repo-wide. Retain screenshots in the
+        # hostPath results bundle only.
         SHOT=$(find /tmp/results -type f -name '*.png' -print -quit)
         if [[ -z "${SHOT}" || ! -f "${SHOT}" ]]; then
           echo "ERROR: KDE test did not produce a screenshot artifact" >&2
           ARTIFACT_RC=1
         else
-          ORAS_BIN=/workspace/oras-bin/oras
-          if [[ ! -x "${ORAS_BIN}" ]]; then
-            mkdir -p "$(dirname "${ORAS_BIN}")"
-            ORAS_ARCHIVE=/workspace/oras-bin/oras.tar.gz
-            curl --fail --silent --show-error --location \
-              --output "${ORAS_ARCHIVE}" \
-              "https://github.com/oras-project/oras/releases/download/v1.2.3/oras_1.2.3_linux_amd64.tar.gz"
-            python3 -m tarfile -e "${ORAS_ARCHIVE}" "$(dirname "${ORAS_BIN}")"
-            rm -f "${ORAS_ARCHIVE}"
-          fi
-          if ! {
-            if [[ ! -x "${ORAS_BIN}" ]]; then
-              echo "Required tool is unavailable: ${ORAS_BIN}" >&2
-              false
-            fi
-            export PATH="$(dirname "${ORAS_BIN}"):${PATH}"
-            SCREENSHOT_IMAGE="ghcr.io/projectbluefin/testsuite/desktop-screenshot"
-            PUSH_TAG="${IMG_SLUG}-${SUITE}-latest"
-            echo "${GITHUB_TOKEN}" | oras login ghcr.io \
-              -u github-actions --password-stdin
-            oras push "${SCREENSHOT_IMAGE}:${PUSH_TAG}" \
-              --annotation "org.opencontainers.image.description=Bluefin KDE desktop screenshot from lab e2e suite: ${SUITE}" \
-              --annotation "io.github.projectbluefin.caller_repo=projectbluefin/lab" \
-              "${SHOT}:image/png"
-          }; then
-            echo "ERROR: failed to publish KDE screenshot artifact" >&2
-            ARTIFACT_RC=1
-          fi
+          echo "GHCR screenshot publication disabled; retaining screenshot locally only." >&2
         fi
 
         PUBLISH_RC=0

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -352,7 +352,7 @@ def test_kde_runner_adapts_gnome_runner_contract_for_webdriver():
     assert "gnome-ponytail-daemon" not in kde
 
 
-def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
+def test_kde_runner_persists_failure_artifacts_without_publishing_screenshots():
     kde = (ROOT / "argo/workflow-templates/run-kde-tests.yaml").read_text(
         encoding="utf-8"
     )
@@ -364,9 +364,9 @@ def test_kde_runner_persists_failure_artifacts_and_pushes_guest_screenshots():
     assert "evidence artifacts were not fully retained" in kde
     assert "scp" in kde
     assert "BEHAVE_RC=0" in kde
-    assert "SCREENSHOT_IMAGE=" in kde
-    assert "oras push" in kde
-    assert "ERROR: failed to publish KDE screenshot artifact" in kde
+    assert "GHCR screenshot publication disabled" in kde
+    assert "oras push" not in kde
+    assert "SCREENSHOT_IMAGE=" not in kde
     assert "Warning: failed" not in kde
     assert "TESTSUITE_RESULTS_DIR" in kde
     assert "qemu_screendump" not in kde


### PR DESCRIPTION
Restore current main contracts after merging the legacy KDE soak PR: structured runner outputs, no-GHCR screenshot publication, and the RECC baseline Justfile operator entrypoint.

Validation: 58 targeted tests passed; just lint.