### PR TITLE
feat: enable AMD GPU on both lab nodes

### DIFF
--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -53,16 +53,53 @@ distributed.
 
 ## AMD ROCm GPU readiness — quick checks
 
-If the AMD GPU exists on the host but Kubernetes still refuses to schedule `amd.com/gpu` workloads, confirm the ROCm device plugin is installed and the node is labeled for it:
+Both lab nodes are 64 GB Framework Desktop (Strix Halo) machines with an AMD
+iGPU. The device plugin selects nodes via the Node Feature Discovery label
+`feature.node.kubernetes.io/pci-0380_1002.present`, so no hand-applied label is
+needed — a node with an AMD display controller is picked up automatically.
+ArgoCD owns `manifests/`; do not `kubectl apply` these files.
 
 ```bash
-kubectl label node exo-0 lab.projectbluefin.io/amd-gpu=true --overwrite
-kubectl apply -f manifests/amdgpu-device-plugin.yaml
+# Which nodes advertise a GPU?
+kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.amd\\.com/gpu
+
 kubectl rollout status daemonset/amdgpu-device-plugin -n kube-system --timeout=300s
-kubectl get node exo-0 -o jsonpath='{.status.allocatable.amd\.com/gpu}{"\n"}'
 ```
 
-Expected outcome: the node advertises `1` or more `amd.com/gpu` allocatable units, and the `amdgpu-device-plugin` DaemonSet pod is `Running` on the GPU node.
+Expected outcome: every node with an AMD iGPU advertises `1` or more
+`amd.com/gpu` allocatable units, and an `amdgpu-device-plugin` pod is `Running`
+on each.
+
+### GPU-addressable memory
+
+Two independent ceilings apply, and both have bitten this lab:
+
+```bash
+# Per-node GPU memory ceilings (VRAM is BIOS-set, GTT is kernel-set)
+for n in ghost exo-0; do
+  pod=$(kubectl -n kube-system get pod -l app=usb4-link-monitor \
+    -o jsonpath="{.items[?(@.spec.nodeName=='$n')].metadata.name}")
+  echo "== $n"
+  kubectl -n kube-system exec "$pod" -- nsenter -t 1 -m -- sh -c \
+    'cat /sys/class/drm/card1/device/mem_info_vram_total /sys/class/drm/card1/device/mem_info_gtt_total'
+done
+```
+
+- **VRAM** (`mem_info_vram_total`) is the BIOS UMA setting and can only be
+  changed in the Framework Desktop firmware. A node reporting 512 MiB is
+  misconfigured; a correctly configured node reports the full 64 GiB. ROCm
+  allocates device memory from VRAM, so 512 MiB cannot host a large model
+  regardless of quantization.
+- **GTT** (`mem_info_gtt_total`) is capped by `ttm.pages_limit`, which defaults
+  to half of system RAM. `manifests/amdgpu-kargs.yaml` raises it via
+  `rpm-ostree kargs`. Kargs take effect on next boot; check progress with:
+
+```bash
+kubectl get nodes -o custom-columns=NAME:.metadata.name,KARGS:.metadata.annotations.lab\\.projectbluefin\\.io/amdgpu-kargs
+```
+
+`pending-reboot` means the kargs are staged but the node is still running the
+old kernel command line.
 
 ## Local LLM deployment — quick checks
 

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -579,3 +579,17 @@ sudo /var/usrlocal/bin/k3s-agent-uninstall.sh
 - **Flannel backend:** `host-gw` (pure L2 routes, all nodes on `<lab-subnet>/24`)
 - **Upgrades:** managed by system-upgrade-controller via `manifests/k3s-upgrade-plans.yaml`
 - **Version skew:** agents must not be newer than the server (ghost)
+
+### BIOS UMA carve-out — leave at minimum
+
+Measured on exo-0 (2026-08-06). The Framework Desktop UMA setting is a hard
+carve-out from system RAM, not a reallocation, and GTT is sized from what is
+left over:
+
+| BIOS UMA | `mem_info_vram_total` | `MemTotal` | `mem_info_gtt_total` |
+|---|---|---|---|
+| 512 MiB (correct) | 512 MiB | 62.1 GiB | 31.0 GiB |
+| 48 GiB (tested, reverted) | 48.0 GiB | 15.4 GiB | 7.9 GiB |
+
+Raising it cost 47 GiB of system RAM and cut GTT by 4×. Keep the carve-out at
+the minimum and get GPU capacity from `ttm.pages_limit` instead.

--- a/manifests/amdgpu-device-plugin.yaml
+++ b/manifests/amdgpu-device-plugin.yaml
@@ -16,8 +16,13 @@ spec:
         app.kubernetes.io/name: amdgpu-device-plugin
         app.kubernetes.io/part-of: lab
     spec:
+      # Driven off Node Feature Discovery rather than a hand-applied label so
+      # every node with an AMD display controller (PCI class 0380, vendor 1002)
+      # advertises amd.com/gpu automatically. The previous hand-applied
+      # lab.projectbluefin.io/amd-gpu label was only ever set on exo-0, which
+      # left ghost's iGPU invisible to the scheduler.
       nodeSelector:
-        lab.projectbluefin.io/amd-gpu: "true"
+        feature.node.kubernetes.io/pci-0380_1002.present: "true"
       priorityClassName: system-node-critical
       containers:
         - name: amdgpu-device-plugin

--- a/manifests/amdgpu-kargs.yaml
+++ b/manifests/amdgpu-kargs.yaml
@@ -1,0 +1,158 @@
+# manifests/amdgpu-kargs.yaml
+# Raises the GPU-addressable memory ceiling on AMD "Strix Halo" nodes.
+#
+# Why this exists:
+#   amdgpu sizes GTT from TTM's global page limit, which defaults to half of
+#   system RAM. On the 64 GB Framework Desktop nodes that lands at ~31 GiB
+#   (ttm.pages_limit = 8,200,809 pages on ghost, 8,136,299 on exo-0), which is
+#   the real cap on how much memory the iGPU can address. Neither node had any
+#   amdgpu or ttm kernel argument set — the ceiling was a driver default, not a
+#   deliberate choice.
+#
+#   amdgpu.gttsize is expressed in MiB; ttm.pages_limit in 4 KiB pages. Both
+#   must be raised together: gttsize alone is still clamped by TTM.
+#
+#   These are ceilings, not reservations. Memory is allocated on demand, so a
+#   higher limit costs nothing until a workload actually uses it. The value is
+#   deliberately held below total RAM so GPU allocations cannot starve k3s and
+#   the BuildStream workers that share these nodes.
+#
+# Scope note: this does NOT fix the BIOS UMA carve-out. exo-0 reports
+#   mem_info_vram_total = 512 MiB against ghost's 64 GiB on identical hardware;
+#   that is a firmware setting and must be changed in the Framework Desktop
+#   BIOS by hand. This DaemonSet only removes the GTT ceiling.
+#
+# Applying kargs stages a new ostree deployment; it takes effect on next boot.
+# This manifest never reboots a node on its own. It annotates the node instead:
+#   lab.projectbluefin.io/amdgpu-kargs = applied | pending-reboot
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: amdgpu-kargs
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: lab
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: amdgpu-kargs
+  labels:
+    app.kubernetes.io/part-of: lab
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: amdgpu-kargs
+  labels:
+    app.kubernetes.io/part-of: lab
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: amdgpu-kargs
+subjects:
+  - kind: ServiceAccount
+    name: amdgpu-kargs
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: amdgpu-kargs
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: amdgpu-kargs
+    app.kubernetes.io/component: node-tuning
+    app.kubernetes.io/part-of: lab
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: amdgpu-kargs
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: amdgpu-kargs
+        app.kubernetes.io/component: node-tuning
+        app.kubernetes.io/part-of: lab
+    spec:
+      serviceAccountName: amdgpu-kargs
+      nodeSelector:
+        feature.node.kubernetes.io/pci-0380_1002.present: "true"
+      tolerations:
+        - operator: Exists
+      hostPID: true
+      initContainers:
+        - name: set-kargs
+          image: cgr.dev/chainguard/kubectl:latest-dev
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # 48 GiB ceiling on a 64 GiB node, leaving ~14 GiB for the OS,
+            # k3s and build workloads. gttsize is MiB; pages_limit is 4 KiB
+            # pages. Keep the two in sync if you change either.
+            - name: GTT_SIZE_MIB
+              value: "49152"
+            - name: TTM_PAGES_LIMIT
+              value: "12582912"
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+
+              ostree_kargs() { nsenter -t 1 -m -- rpm-ostree kargs "$@"; }
+
+              DESIRED="amdgpu.gttsize=${GTT_SIZE_MIB} ttm.pages_limit=${TTM_PAGES_LIMIT}"
+              CURRENT="$(ostree_kargs)"
+
+              CHANGES=()
+              for want in ${DESIRED}; do
+                key="${want%%=*}"
+                if grep -qE "(^| )${key}=${want#*=}( |$)" <<<"${CURRENT}"; then
+                  echo "ok: ${want} already staged"
+                  continue
+                fi
+                # Same key present with a different value: drop the stale token
+                # so rpm-ostree does not end up with two copies of the key.
+                stale="$(grep -oE "(^| )${key}=[^ ]*" <<<"${CURRENT}" | tr -d ' ' || true)"
+                if [[ -n "${stale}" ]]; then
+                  echo "replacing ${stale} -> ${want}"
+                  CHANGES+=("--delete-if-present=${stale}")
+                fi
+                CHANGES+=("--append-if-missing=${want}")
+              done
+
+              if [[ ${#CHANGES[@]} -gt 0 ]]; then
+                echo "applying: ${CHANGES[*]}"
+                ostree_kargs "${CHANGES[@]}"
+              fi
+
+              # Compare the staged kargs against what the running kernel booted
+              # with, so the annotation reflects reality rather than intent.
+              RUNNING="$(nsenter -t 1 -m -- cat /proc/cmdline)"
+              STATE=applied
+              for want in ${DESIRED}; do
+                grep -qE "(^| )${want}( |$)" <<<"${RUNNING}" || STATE=pending-reboot
+              done
+              echo "node ${NODE_NAME}: ${STATE}"
+
+              kubectl annotate node "${NODE_NAME}" \
+                "lab.projectbluefin.io/amdgpu-kargs=${STATE}" --overwrite
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 1m
+              memory: 4Mi
+            limits:
+              cpu: 10m
+              memory: 32Mi

--- a/manifests/amdgpu-kargs.yaml
+++ b/manifests/amdgpu-kargs.yaml
@@ -28,12 +28,21 @@
 #   deliberately held below total RAM so GPU allocations cannot starve k3s and
 #   the BuildStream workers that share these nodes.
 #
-# Scope note: this does NOT touch the BIOS UMA carve-out. exo-0 reports
-#   mem_info_vram_total = 512 MiB against ghost's 64 GiB on identical hardware.
-#   Prevailing Strix Halo guidance is that a *minimum* carve-out is correct on
-#   Linux and that real capacity should come from GTT, which would make exo-0
-#   the correctly configured node. That discrepancy is unresolved and must be
-#   settled by measuring what each node can actually allocate under ROCm.
+# BIOS note (measured 2026-08-06, do not undo): the UMA carve-out on these
+#   boards must stay at the MINIMUM (512 MiB). It was tested at 48 GiB on exo-0
+#   and the carve-out is a hard steal from system RAM, not a reallocation:
+#
+#     setting     mem_info_vram_total   MemTotal        mem_info_gtt_total
+#     512 MiB          512 MiB          62.1 GiB          31.0 GiB
+#     48 GiB            48.0 GiB        15.4 GiB           7.9 GiB
+#
+#   Raising it cost 47 GiB of system RAM and, because GTT is derived from what
+#   remains, collapsed GTT from 31 GiB to 7.9 GiB — the opposite of the goal.
+#   Kubernetes saw the node as a 15 GiB machine, too small for the buildbarn
+#   workers, KubeVirt VMs and KubeStellar control-plane pods it carries.
+#
+#   Minimum carve-out plus a raised ttm.pages_limit is therefore the correct
+#   configuration, and is what this manifest implements.
 #
 # Applying kargs stages a new ostree deployment; it takes effect on next boot.
 # This manifest never reboots a node on its own. It annotates the node instead:

--- a/manifests/amdgpu-kargs.yaml
+++ b/manifests/amdgpu-kargs.yaml
@@ -9,18 +9,31 @@
 #   amdgpu or ttm kernel argument set — the ceiling was a driver default, not a
 #   deliberate choice.
 #
-#   amdgpu.gttsize is expressed in MiB; ttm.pages_limit in 4 KiB pages. Both
-#   must be raised together: gttsize alone is still clamped by TTM.
+#   ttm.pages_limit (4 KiB pages) is the authoritative control. amdgpu.gttsize
+#   (MiB) is deprecated upstream — the driver logs "Configuring gttsize via
+#   module parameter is deprecated, please use ttm.pages_limit" — but is still
+#   honoured, and the Strix Halo community sets both. We do the same, so the
+#   ceiling holds regardless of which knob a given kernel respects. Keep the two
+#   values in agreement if you change either.
+#
+#   Deliberately NOT set: ttm.page_pool_size. That option pre-allocates memory
+#   and permanently removes it from the OS. On a 64 GB node shared with k3s and
+#   BuildStream workers, setting it near pages_limit would be actively harmful.
+#
+#   Note the exact spelling: "gtt_size" (with underscore) is not a valid
+#   parameter and is silently ignored.
 #
 #   These are ceilings, not reservations. Memory is allocated on demand, so a
 #   higher limit costs nothing until a workload actually uses it. The value is
 #   deliberately held below total RAM so GPU allocations cannot starve k3s and
 #   the BuildStream workers that share these nodes.
 #
-# Scope note: this does NOT fix the BIOS UMA carve-out. exo-0 reports
-#   mem_info_vram_total = 512 MiB against ghost's 64 GiB on identical hardware;
-#   that is a firmware setting and must be changed in the Framework Desktop
-#   BIOS by hand. This DaemonSet only removes the GTT ceiling.
+# Scope note: this does NOT touch the BIOS UMA carve-out. exo-0 reports
+#   mem_info_vram_total = 512 MiB against ghost's 64 GiB on identical hardware.
+#   Prevailing Strix Halo guidance is that a *minimum* carve-out is correct on
+#   Linux and that real capacity should come from GTT, which would make exo-0
+#   the correctly configured node. That discrepancy is unresolved and must be
+#   settled by measuring what each node can actually allocate under ROCm.
 #
 # Applying kargs stages a new ostree deployment; it takes effect on next boot.
 # This manifest never reboots a node on its own. It annotates the node instead:


### PR DESCRIPTION
Supersedes #594, which accidentally carried two unrelated commits from a local `main`.

## Problem

Both lab nodes are identical 64 GB Framework Desktop (Strix Halo) machines, yet only `exo-0` advertised `amd.com/gpu`, and both had GPU memory capped well below the hardware's capability.

| | ghost | exo-0 |
|---|---|---|
| `amd.com/gpu` allocatable | **0** | 1 |
| `mem_info_gtt_total` | 31.3 GiB | 31.0 GiB |
| `ttm.pages_limit` | 8,200,809 | 8,136,299 |

## Changes

**1. Device plugin node selection → NFD.** The plugin required a hand-applied `lab.projectbluefin.io/amd-gpu` label only ever set on `exo-0`, leaving ghost's iGPU invisible to the scheduler. It now selects on `feature.node.kubernetes.io/pci-0380_1002.present`, which both nodes already carry.

**2. New `manifests/amdgpu-kargs.yaml`.** GTT is capped by TTM's global page limit, which defaults to half of RAM — neither node had *any* `amdgpu`/`ttm` karg set, so ~31 GiB was a driver default rather than a choice. Stages `ttm.pages_limit=12582912` and `amdgpu.gttsize=49152` (48 GiB) via `rpm-ostree kargs`.

`ttm.pages_limit` is the authoritative knob; `amdgpu.gttsize` is deprecated upstream but still honoured, and the Strix Halo community sets both. `ttm.page_pool_size` is deliberately **not** set — it pre-allocates and permanently removes memory from the OS.

## Measured: leave the BIOS UMA carve-out at minimum

A 48 GiB carve-out was tested on exo-0 and reverted. It is a hard steal from system RAM, not a reallocation:

| BIOS UMA | `mem_info_vram_total` | `MemTotal` | `mem_info_gtt_total` |
|---|---|---|---|
| 512 MiB (correct) | 512 MiB | 62.1 GiB | 31.0 GiB |
| 48 GiB (reverted) | 48.0 GiB | **15.4 GiB** | **7.9 GiB** |

It cost 47 GiB of system RAM and cut GTT 4×, because GTT is sized from what remains. Kubernetes saw the node as a 15 GiB machine — too small for the buildbarn workers, KubeVirt VMs and KubeStellar control-plane pods it carries. Minimum carve-out + raised `ttm.pages_limit` is correct, and is documented in the cheatsheet so it isn't retried.

## Safety

- **Never reboots a node.** Kargs stage a new ostree deployment effective next boot; the node is annotated `lab.projectbluefin.io/amdgpu-kargs=applied|pending-reboot`.
- Idempotent; replaces stale values rather than appending duplicate keys. Parsing dry-tested against both nodes' real karg strings plus a stale-value case.
- 48 GiB ceiling leaves ~14 GiB for k3s and builds. These are ceilings, not reservations.

## Verification

`just lint` passes; manifests pass `kubectl apply --dry-run=server`. exo-0 was power-cycled during this work and is back `Ready`, uncordoned, with `usb4-link=up` on both nodes.

After merge, reboot nodes one at a time, then:

```bash
kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.amd\\.com/gpu,KARGS:.metadata.annotations.lab\\.projectbluefin\\.io/amdgpu-kargs
```