### PR TITLE
fix(argocd): raise repo-server memory limit to survive a cold cache

### DIFF
--- a/manifests/argocd-tuning.yaml
+++ b/manifests/argocd-tuning.yaml
@@ -133,13 +133,19 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: argocd-repo-server
+          # 256Mi was too small to render the kubestellar-console Helm chart
+          # from a cold manifest cache: steady-state syncs are served from
+          # cache, but after an outage repo-server regenerates every app at
+          # once and is OOMKilled (exit 137), which deadlocks ArgoCD because
+          # it cannot sync the fix for its own outage. Nodes have 62 GiB;
+          # 1Gi is still conservative.
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 256Mi
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 1Gi
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Problem

After the 2026-08-06 cluster reboot, `argocd-repo-server` sat in `CrashLoopBackOff`:

```
"terminated":{"exitCode":137,"reason":"OOMKilled"}
```

Its logs show no errors — it starts, serves gRPC, and is killed mid-`GenerateManifest`.

## Root cause

The limit was **256Mi**. That holds in steady state because manifest generation is served from cache, but after an outage the cache is empty and repo-server regenerates every application at once — including the `kubestellar-console` Helm chart (`GenerateManifest` → `manifest cache miss` for both apps back-to-back in the logs).

This is a **deadlock**: ArgoCD cannot sync a fix for its own outage, so nothing in `manifests/` reconciles until a human intervenes.

`reposerver.parallelism.limit: "1"` was already set, so concurrency was already bounded — the remaining gap was per-render headroom, not parallelism.

## Fix

1Gi limit / 256Mi request. Nodes have 62 GiB, so this is still conservative. The original 256Mi dates from when the reference deployment was a single small VM.

## Verification

Patched live and rolled out clean:

```
deployment "argocd-repo-server" successfully rolled out
```

Stable since. This PR codifies the value ArgoCD is now running, so reconciliation is a no-op.