### PR TITLE
feat(llm-d): serve Qwen3-30B-A3B on llama.cpp/Vulkan with persistent cache

### DIFF
--- a/docs/adr/0007-local-inference-runtime.md
+++ b/docs/adr/0007-local-inference-runtime.md
@@ -1,0 +1,223 @@
+# ADR 0007 — Local inference runtime on Strix Halo
+
+Status: Accepted
+Date: 2026-08-06
+
+## Context
+
+The lab has a repo-managed local inference deployment (`manifests/llm-d.yaml`)
+pinned to `exo-0`, a Framework Desktop with an AMD Ryzen AI Max+ 395 "Strix Halo"
+APU (`gfx1151`, Radeon 8060S iGPU). Until now it was a placeholder: vLLM on ROCm
+serving `unsloth/Llama-3.2-3B-Instruct` at 4096 context, an `emptyDir` model
+cache, and `replicas: 0` — so it served nothing, while the agent cheatsheet
+claimed it was enabled with one replica.
+
+The requirement is a **single-user, quality-first assistant left running for
+hours**. Throughput is secondary to answer quality.
+
+### The hardware constraint that drives everything
+
+`exo-0` has **64 GB** of unified LPDDR5X, not the 128 GB that every published
+Strix Halo tuning guide assumes. Measured allocatable capacity is 65090060Ki
+(~62.1 GiB), and the node reports allocatable == capacity, i.e. no kubelet
+system-reserved headroom.
+
+`manifests/amdgpu-kargs.yaml` raises the GPU-addressable ceiling to **48 GiB**
+(`amdgpu.gttsize=49152` plus a matching `ttm.pages_limit`). That ceiling is
+~77% of system RAM and cannot meaningfully rise: the BIOS UMA carve-out must stay
+at its 512 MiB minimum, because raising it is a hard steal from system RAM
+(measured: a 48 GiB carve-out dropped `MemTotal` to 15.4 GiB *and* collapsed GTT
+to 7.9 GiB).
+
+Critically, **GTT is system RAM**, shared with k3s, BuildBarn workers, KubeVirt
+VMs and the KubeStellar control plane. The 48 GiB ceiling is a maximum mapping
+limit, not a spending budget.
+
+### Measured behaviour of this hardware
+
+Benchmarking on Strix Halo, corroborated by published measurements from
+`apellegr/Strix-Halo-Models` across 38 models:
+
+| Model | Kind | Quant | Size | Generation |
+|---|---|---|---|---|
+| Qwen3 Coder 30B-A3B | MoE, 3B active | Q4_K_M | 17 GB | **69.6 tok/s** |
+| Qwen 2.5 Coder 32B | dense | Q4_K_M | 19 GB | **11.0 tok/s** |
+| Llama 3.3 70B | dense | Q6_K | 54 GB | 3.8 tok/s |
+
+The machine is **memory-bandwidth bound**: host-to-device bandwidth is
+**~85 GB/s**, against 205–236 GB/s GPU-internal. Decode speed is therefore set by
+the parameters *activated per token*, not by total parameter count. A 30B MoE
+with 3B active runs roughly 6× faster than a dense 32B of comparable size, and
+the published summary states MoE achieves 3–14× higher generation throughput
+than similarly-sized dense models.
+
+## Decisions
+
+### 1. llama.cpp, not vLLM
+
+vLLM's advantage is continuous batching across concurrent tenants. For a single
+user that buys nothing and costs KV-cache memory that could be spent on context
+or quality. llama.cpp gives the full GGUF quantization ladder, KV-cache
+quantization, and is the far better-trodden path on `gfx1151`.
+
+### 2. Vulkan, not ROCm/HIP
+
+Two independent sources conclude that on `gfx1151` the reliable, well-supported
+llama.cpp GPU path is the **Vulkan** backend (Mesa RADV), and that ROCm is not
+required for inference. The community ROCm toolboxes additionally have to carry a
+patch for llama.cpp issue #25992 (ROCm host-buffer selection on integrated GPUs
+causing inference failures).
+
+This also resolves a supply-chain constraint: `ghcr.io/ggml-org/llama.cpp`
+publishes **no ROCm tags at all** (only `vulkan`, `cuda`, `musa`, `intel`), while
+the patched ROCm toolboxes live on Docker Hub, which is not in the lab registry
+allowlist. Vulkan keeps us on an allowlisted registry with an upstream-maintained
+image.
+
+The image is **pinned by digest**, not `latest`, so rollback is reproducible.
+
+### 3. Qwen3-30B-A3B-Instruct-2507 at Q6_K, not Q8_0
+
+Published quantization guidance:
+
+| Quant | Quality loss | Recommended for |
+|---|---|---|
+| Q8_0 | Minimal | Small models, max quality |
+| **Q6_K** | **Very low** | **Models up to 32B** |
+| Q5_K_M | Low | up to 70B |
+| Q4_K_M | Acceptable | 70B |
+| Q3_K_M | **Noticeable** | 100B+ only |
+
+Q6_K (25.1 GB) sits in its recommended band for a 30B model at "very low" loss.
+Q8_0 (32.5 GB) costs 7.4 GB more to move from "very low" to "minimal" — a
+negligible quality gain that spends the KV-cache headroom a long-context
+assistant actually needs on a 64 GB node.
+
+### 4. Rejected: a larger MoE at lower precision
+
+Qwen3-Next-80B-A3B has the **same ~3B active parameters** as Qwen3-30B-A3B, so it
+would decode at the same speed, and at Q3 it fits the same envelope
+(UD-IQ3_XXS 33.1 GB, UD-Q3_K_XL 35.6 GB) with 2.7× the total parameters. The
+bandwidth argument above genuinely points this way.
+
+It is rejected for now because the same quantization table rates Q3_K_M as
+"noticeable" loss and reserves it for 100B+ models, and because Qwen3-Next's
+Gated-DeltaNet linear attention is only newly supported in llama.cpp — the CUDA
+optimisation PR is still open — making it a poor bet on the Vulkan path.
+
+**Re-evaluation trigger:** revisit if a ~30–40 GB MoE ships a native MXFP4 GGUF
+(rated "low" loss, and the format behind GPT-OSS 120B's 51 tok/s), or once
+Qwen3-Next's Vulkan path is proven. GPT-OSS 120B itself needs 59 GB and does not
+fit this node.
+
+### 5. Tensor parallelism across the USB4 link is rejected
+
+Splitting a model across `ghost` and `exo-0` over the point-to-point USB4 link
+requires ~128 collective operations per token. At 70–100 µs link latency that is
+**9–13 ms of stall per token**, worse than the single-node decode it would try to
+beat.
+
+This is confirmed by measurement, not just arithmetic: `Foxlight-Foundation/Skulk`
+measured llama.cpp RPC pooling across a Strix Halo pair as "a capacity feature,
+not a speedup" — decode runs **~15% slower** pooled than on a single node that
+fits the model, and a Thunderbolt link "helps load time, not decode".
+
+Multi-node pooling therefore remains justified only for models that do not fit
+one node. Since we deliberately choose a model that fits, it stays off.
+
+### 6. GPU lockup timeout is raised to 20s
+
+The amdgpu default (~10s) is tuned for interactive desktop use. Under sustained
+inference on `gfx1151` it trips a **spurious GPU reset** ("device lost", ring
+timeout) that kills the inference backend mid-run even though the GPU is merely
+busy. Since the stated workload is hours-long sessions, this is the most likely
+practical failure mode. `manifests/amdgpu-kargs.yaml` now sets
+`amdgpu.lockup_timeout=20000`, which avoids the false positive without masking a
+genuine hang.
+
+**Not adopted:** `amd_iommu=off`, despite being measured 5–12% faster. It
+disables IOMMU device isolation host-wide, and these nodes run KubeVirt VMs that
+depend on it. Inference here is throughput-tolerant, so the security property
+wins. Also not adopted: `ttm.page_pool_size`, which some guides recommend but
+which pre-allocates and permanently removes memory from the OS — unacceptable on
+a shared node.
+
+### 7. Unified memory is a node-level safety problem, not a pod-level one
+
+`amd.com/gpu: 1` grants device access but reserves **no** GTT capacity, and
+amdgpu GTT pins system RAM that the kernel OOM-killer cannot reclaim. On a UMA
+node this means memory pressure can *deadlock the node* rather than evict a pod.
+
+Consequences encoded in the deployment:
+
+- The memory **request** is sized to reserve scheduler space for the model, so
+  nothing else fills the node underneath it.
+- The memory **limit** is deliberately generous rather than snug, because a tight
+  limit risks an OOM kill during model load, and GPU-backed pages may not be
+  charged to the pod cgroup at all.
+- Node-level protection (kubelet system-reserved / eviction thresholds on
+  `exo-0`) is required and tracked separately; it is not something a pod spec can
+  express.
+
+### 8. Rollout is `Recreate` and phased
+
+The node exposes exactly one `amd.com/gpu` and the cache PVC is RWO. A default
+rolling update would create the replacement pod before deleting the old one, the
+replacement could never obtain the GPU, and `maxUnavailable: 0` would keep the
+old pod forever — a permanent deadlock. `strategy.type: Recreate` is mandatory,
+and the resulting downtime during updates is accepted.
+
+The model cache moves from `emptyDir` to a 100Gi `local-path` PVC, so a restart
+no longer re-downloads ~25 GB. `local-path` is RWO and `WaitForFirstConsumer`;
+placement is deterministic because the Deployment pins to `exo-0`.
+
+The Deployment ships at `replicas: 0` and is enabled in a **separate** GitOps
+change once the kargs reboot, the PVC bind and node headroom are confirmed.
+
+## Consequences
+
+- Local inference is a genuinely useful assistant rather than a 3B placeholder,
+  at roughly 8× the parameter count of what was configured before.
+- The pod drops from `privileged: true` with four hostPaths to unprivileged with
+  a single `/dev/dri` mount, because the Vulkan backend needs only the render
+  node (`/dev/dri/renderD128` is mode 0666 on these nodes).
+- `llm-d` still trips two `scripts/check_gitops_policy.py` rules — the `/dev/dri`
+  hostPath and the `kubernetes.io/hostname` nodeSelector. Both are inherent to
+  pinning a GPU workload to the one node with the GPU, and are accepted
+  exceptions rather than defects.
+- The lab gains a real OpenAI-compatible endpoint. It has no authentication and
+  permissive CORS, so it must stay on the trusted LAN.
+- Updating the model server incurs downtime by design.
+
+## Verification
+
+```bash
+# Kernel args live (after the reboot that the kargs DaemonSet stages)
+kubectl get node exo-0 -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/amdgpu-kargs}{"\n"}'   # applied
+
+# Storage and pod
+kubectl -n llm-d get pvc llm-d-model-cache      # Bound
+kubectl -n llm-d get pods -o wide               # Running on exo-0
+
+# GPU actually in use — expect Vulkan0, and all layers offloaded
+kubectl -n llm-d logs -l app.kubernetes.io/name=llm-d-modelserver --tail=200 \
+  | grep -Ei "vulkan|offload"
+
+# Serving, with measured decode speed
+curl -s http://<ghost-ip>:30800/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"Explain Kubernetes in one sentence."}],"max_tokens":128}' \
+  | jq '.timings.predicted_per_second'
+```
+
+A healthy result is a completion returned with all layers offloaded to Vulkan, a
+sustained multi-hour session with **zero** amdgpu resets, and no node memory
+pressure or evictions on `exo-0`.
+
+## References
+
+- [`kyuz0/amd-strix-halo-toolboxes`](https://github.com/kyuz0/amd-strix-halo-toolboxes) — Strix Halo llama.cpp images, tested `models.ini` presets, host tuning
+- [`defilantech/LLMKube`](https://github.com/defilantech/LLMKube) — Kubernetes + Strix Halo onboarding, kernel args, UMA OOM failure mode
+- [`Foxlight-Foundation/Skulk`](https://github.com/Foxlight-Foundation/Skulk) — Vulkan-over-ROCm rationale, measured multi-node pooling results
+- [`apellegr/Strix-Halo-Models`](https://github.com/apellegr/Strix-Halo-Models) — 38-model benchmark set, quantization guide, GPU stability runbook
+- ADR 0005 — storage and backup (`local-path` semantics)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,5 +8,6 @@ Authoritative decisions, append-only.
 - [`0004-network-stack.md`](0004-network-stack.md)
 - [`0005-storage-and-backup.md`](0005-storage-and-backup.md)
 - [`0006-elastic-bst-build-grid.md`](0006-elastic-bst-build-grid.md)
+- [`0007-local-inference-runtime.md`](0007-local-inference-runtime.md)
 
 Add a new ADR by copying this pattern and bumping the sequence number.

--- a/docs/data/policy-compliance.json
+++ b/docs/data/policy-compliance.json
@@ -3,12 +3,12 @@
   "_meta": {
     "page": "compliance",
     "description": "GitOps and running cluster compliance scorecard.",
-    "generated_at": "2026-08-07T00:59:01Z",
-    "live_snapshot_ok": false,
+    "generated_at": "2026-08-07T01:40:33Z",
+    "live_snapshot_ok": true,
     "git_manifests_scanned": 152,
-    "live_pods_scanned": 0
+    "live_pods_scanned": 116
   },
-  "score": 78.8,
+  "score": 88.4,
   "rules": [
     {
       "id": "registry_allowlist_git",
@@ -16,27 +16,23 @@
       "description": "All container images in git-tracked manifests must reside on allowed registries.",
       "status": "failed",
       "total_checked": 159,
-      "violations_count": 8,
+      "violations_count": 7,
       "violations": [
         {
-          "source": "git:manifests/llm-d.yaml",
-          "detail": "Banned registry for image 'vllm/vllm-openai-rocm:latest'"
+          "source": "git:manifests/k3s-upgrade-plans.yaml",
+          "detail": "Banned registry for image 'rancher/k3s-upgrade'"
+        },
+        {
+          "source": "git:manifests/k3s-upgrade-plans.yaml",
+          "detail": "Banned registry for image 'rancher/k3s-upgrade'"
+        },
+        {
+          "source": "git:manifests/k3s-upgrade-plans.yaml",
+          "detail": "Banned registry for image 'rancher/k3s-upgrade'"
         },
         {
           "source": "git:manifests/system-upgrade-controller.yaml",
           "detail": "Banned registry for image 'rancher/system-upgrade-controller:v0.19.2'"
-        },
-        {
-          "source": "git:manifests/k3s-upgrade-plans.yaml",
-          "detail": "Banned registry for image 'rancher/k3s-upgrade'"
-        },
-        {
-          "source": "git:manifests/k3s-upgrade-plans.yaml",
-          "detail": "Banned registry for image 'rancher/k3s-upgrade'"
-        },
-        {
-          "source": "git:manifests/k3s-upgrade-plans.yaml",
-          "detail": "Banned registry for image 'rancher/k3s-upgrade'"
         },
         {
           "source": "git:manifests/catalog-apps/jellyfin/manifest.yaml",
@@ -56,54 +52,63 @@
       "id": "registry_allowlist_cluster",
       "name": "Live Cluster Registry Allowlist",
       "description": "All running container images in the cluster must reside on allowed registries.",
-      "status": "passed",
-      "total_checked": 0,
-      "violations_count": 0,
-      "violations": []
+      "status": "failed",
+      "total_checked": 240,
+      "violations_count": 9,
+      "violations": [
+        {
+          "source": "cluster:argo/homelab-access-7ff9dddc95-hzz9c",
+          "detail": "Running image violates registry allowlist: 'python:3.12-slim'"
+        },
+        {
+          "source": "cluster:argocd/argocd-redis-5c6c67bb89-6l5hr",
+          "detail": "Running image violates registry allowlist: 'public.ecr.aws/docker/library/redis:8.2.3-alpine'"
+        },
+        {
+          "source": "cluster:catalog-jellyfin/jellyfin-68b47d76b5-49k56",
+          "detail": "Running image violates registry allowlist: 'lscr.io/linuxserver/jellyfin:latest'"
+        },
+        {
+          "source": "cluster:kube-system/amdgpu-device-plugin-n76tf",
+          "detail": "Running image violates registry allowlist: 'docker.io/rocm/k8s-device-plugin:latest'"
+        },
+        {
+          "source": "cluster:kube-system/amdgpu-device-plugin-trsqw",
+          "detail": "Running image violates registry allowlist: 'docker.io/rocm/k8s-device-plugin:latest'"
+        },
+        {
+          "source": "cluster:kube-system/coredns-578d7568df-f8n2p",
+          "detail": "Running image violates registry allowlist: 'rancher/mirrored-coredns-coredns:1.14.6'"
+        },
+        {
+          "source": "cluster:kube-system/local-path-provisioner-cfcd64b69-gtdsh",
+          "detail": "Running image violates registry allowlist: 'rancher/local-path-provisioner:v0.0.36'"
+        },
+        {
+          "source": "cluster:system-upgrade/system-upgrade-controller-79fc7f6f99-dxgfr",
+          "detail": "Running image violates registry allowlist: 'rancher/system-upgrade-controller:v0.19.2'"
+        },
+        {
+          "source": "cluster:wds1-system/kube-apiserver-6b67cfb95f-vsbv2",
+          "detail": "Running image violates registry allowlist: 'rancher/kine:v0.11.4'"
+        }
+      ]
     },
     {
       "id": "no_root_storage_git",
       "name": "No Root Disk Storage Allocations",
       "description": "No hard hostPath volume mounts on root disks (must use PVCs or approved storage).",
       "status": "failed",
-      "total_checked": 32,
-      "violations_count": 25,
+      "total_checked": 29,
+      "violations_count": 22,
       "violations": [
         {
-          "source": "git:manifests/amdgpu-device-plugin.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/lib/kubelet/device-plugins'"
-        },
-        {
-          "source": "git:manifests/amdgpu-device-plugin.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev'"
-        },
-        {
-          "source": "git:manifests/amdgpu-device-plugin.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/sys'"
-        },
-        {
-          "source": "git:manifests/buildbarn-worker.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/fuse'"
-        },
-        {
-          "source": "git:manifests/buildbarn-worker.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/lib/buildbarn/worker'"
-        },
-        {
-          "source": "git:manifests/llm-d.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/kfd'"
+          "source": "git:manifests/bst-cache-proxy.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/tmp/bst-http-cache'"
         },
         {
           "source": "git:manifests/llm-d.yaml",
           "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/dri'"
-        },
-        {
-          "source": "git:manifests/llm-d.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/sys'"
-        },
-        {
-          "source": "git:manifests/llm-d.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/lib/modules'"
         },
         {
           "source": "git:manifests/system-upgrade-controller.yaml",
@@ -118,36 +123,44 @@
           "detail": "Potentially unauthorized hostPath allocation on root disk: '/etc/ca-certificates'"
         },
         {
+          "source": "git:manifests/buildbarn-worker.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/fuse'"
+        },
+        {
+          "source": "git:manifests/buildbarn-worker.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/lib/buildbarn/worker'"
+        },
+        {
           "source": "git:manifests/registry-mirror-config.yaml",
           "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/lib/rancher/k3s/agent/etc/containerd/certs.d'"
         },
         {
-          "source": "git:manifests/bst-cache-proxy.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/tmp/bst-http-cache'"
+          "source": "git:manifests/amdgpu-device-plugin.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/lib/kubelet/device-plugins'"
         },
         {
-          "source": "git:argo/workflow-templates/build-bluefin-migration-containerdisk.yaml",
+          "source": "git:manifests/amdgpu-device-plugin.yaml",
           "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev'"
         },
         {
-          "source": "git:argo/workflow-templates/build-bluefin-migration-containerdisk.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/run/udev'"
-        },
-        {
-          "source": "git:argo/workflow-templates/ghost-cleanup.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/lib/containers/storage'"
-        },
-        {
-          "source": "git:argo/workflow-templates/iso-e2e-pipeline.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/kvm'"
+          "source": "git:manifests/amdgpu-device-plugin.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/sys'"
         },
         {
           "source": "git:argo/workflow-templates/cosmic-build-pipeline.yaml",
           "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/fuse'"
         },
         {
-          "source": "git:argo/workflow-templates/run-container-tests.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/run/udev'"
+          "source": "git:argo/workflow-templates/iso-e2e-pipeline.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/kvm'"
+        },
+        {
+          "source": "git:argo/workflow-templates/dakota-pr-batch-pipeline.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/fuse'"
+        },
+        {
+          "source": "git:argo/workflow-templates/ghost-cleanup.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/var/lib/containers/storage'"
         },
         {
           "source": "git:argo/workflow-templates/iso-build-e2e-pipeline.yaml",
@@ -158,8 +171,16 @@
           "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/fuse'"
         },
         {
-          "source": "git:argo/workflow-templates/dakota-pr-batch-pipeline.yaml",
-          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev/fuse'"
+          "source": "git:argo/workflow-templates/build-bluefin-migration-containerdisk.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/dev'"
+        },
+        {
+          "source": "git:argo/workflow-templates/build-bluefin-migration-containerdisk.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/run/udev'"
+        },
+        {
+          "source": "git:argo/workflow-templates/run-container-tests.yaml",
+          "detail": "Potentially unauthorized hostPath allocation on root disk: '/run/udev'"
         },
         {
           "source": "git:argo/workflow-templates/dakota-build-pipeline.yaml",
@@ -184,6 +205,18 @@
           "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
         },
         {
+          "source": "git:manifests/orphan-vm-cleanup.yaml",
+          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
+        },
+        {
+          "source": "git:manifests/pr-image-gc.yaml",
+          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
+        },
+        {
+          "source": "git:manifests/bst-cache-proxy.yaml",
+          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
+        },
+        {
           "source": "git:manifests/golden-disk-gc.yaml",
           "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
         },
@@ -192,31 +225,7 @@
           "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: exo-0'"
         },
         {
-          "source": "git:manifests/pr-image-gc.yaml",
-          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
-        },
-        {
           "source": "git:manifests/zot-writable.yaml",
-          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
-        },
-        {
-          "source": "git:manifests/bst-cache-proxy.yaml",
-          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
-        },
-        {
-          "source": "git:manifests/orphan-vm-cleanup.yaml",
-          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
-        },
-        {
-          "source": "git:argo/workflow-templates/zot-candidate-lifecycle.yaml",
-          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
-        },
-        {
-          "source": "git:argo/workflow-templates/ghost-cleanup.yaml",
-          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
-        },
-        {
-          "source": "git:argo/workflow-templates/flatcar-kernel-build.yaml",
           "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
         },
         {
@@ -226,6 +235,18 @@
         {
           "source": "git:argo/workflow-templates/homelab-print-device.yaml",
           "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
+        },
+        {
+          "source": "git:argo/workflow-templates/zot-candidate-lifecycle.yaml",
+          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
+        },
+        {
+          "source": "git:argo/workflow-templates/flatcar-kernel-build.yaml",
+          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
+        },
+        {
+          "source": "git:argo/workflow-templates/ghost-cleanup.yaml",
+          "detail": "Hard node hostname selector pin found: 'kubernetes.io/hostname: ghost'"
         }
       ]
     },
@@ -233,10 +254,23 @@
       "id": "no_hard_node_pins_cluster",
       "name": "No Hard Node Selectors in Cluster",
       "description": "No active pods with hard node selector pinning (excluding approved infrastructure controllers).",
-      "status": "passed",
-      "total_checked": 0,
-      "violations_count": 0,
-      "violations": []
+      "status": "failed",
+      "total_checked": 9,
+      "violations_count": 3,
+      "violations": [
+        {
+          "source": "cluster:argo/argo-workflows-workflow-controller-7669dc897d-fcff6",
+          "detail": "Pod hard-pinned to node: {'kubernetes.io/hostname': 'ghost', 'kubernetes.io/os': 'linux'}"
+        },
+        {
+          "source": "cluster:argo/bst-cache-proxy-56f9bb6f5b-6jr54",
+          "detail": "Pod hard-pinned to node: {'kubernetes.io/hostname': 'ghost'}"
+        },
+        {
+          "source": "cluster:argocd/argocd-application-controller-0",
+          "detail": "Pod hard-pinned to node: {'kubernetes.io/hostname': 'ghost', 'kubernetes.io/os': 'linux'}"
+        }
+      ]
     }
   ]
 }

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -103,16 +103,23 @@ old kernel command line.
 
 ## Local LLM deployment — quick checks
 
-The lab also has a repo-managed vLLM deployment in `manifests/llm-d.yaml` for `unsloth/Llama-3.2-3B-Instruct`. It is enabled by default, pinned to `exo-0`, and requests one `amd.com/gpu` device so the ROCm device plugin exposes the GPU to vLLM. A preemptive priority class lets it take over the node when needed.
+The lab also has a repo-managed llama.cpp deployment in `manifests/llm-d.yaml`
+serving `Qwen3-30B-A3B-Instruct-2507` at Q6_K over the Vulkan backend. It is
+pinned to `exo-0` (the only node with the Strix Halo iGPU) and requests one
+`amd.com/gpu`. A preemptive priority class lets it take over the node when
+needed. See [ADR 0007](../adr/0007-local-inference-runtime.md) for why Vulkan,
+why Q6_K, and why it is not vLLM.
 
 ```bash
 kubectl -n llm-d get deploy llm-d-modelserver
 kubectl -n llm-d get pods -w
+kubectl -n llm-d get pvc llm-d-model-cache
 kubectl -n llm-d get svc llm-d-modelserver
 kubectl -n llm-d logs -l app.kubernetes.io/name=llm-d-modelserver -c modelserver --tail=100
 ```
 
-The endpoint is exposed on NodePort `30800` and can be queried at `http://<exo-0-ip>:30800/v1/models` after the pod reaches `Running`.
+The endpoint is exposed on NodePort `30800` and can be queried at
+`http://<exo-0-ip>:30800/v1/models` after the pod reaches `Running`.
 
 ## Flatcar kernel lifecycle — quick checks
 
@@ -405,16 +412,19 @@ Expected steady state:
 
 ## 13. llm-d local inference node
 
-`llm-d` is managed by the `testing-lab-infra` ArgoCD Application (`manifests/llm-d.yaml`) and is **enabled by default** with one replica.
-The vLLM container requests one `amd.com/gpu` device so the ROCm device plugin exposes the GPU into the pod.
+`llm-d` is managed by the `testing-lab-infra` ArgoCD Application (`manifests/llm-d.yaml`).
+The llama.cpp container requests one `amd.com/gpu` device so the device plugin exposes the GPU into the pod.
 
-**Model choice:** the deployment serves `unsloth/Llama-3.2-3B-Instruct` through vLLM on the OpenAI-compatible endpoint at `http://<ghost-ip>:30800/v1`.
+**Model choice:** the deployment serves `Qwen3-30B-A3B-Instruct-2507` at Q6_K (~25 GB) through llama.cpp on the **Vulkan** backend, on the OpenAI-compatible endpoint at `http://<ghost-ip>:30800/v1`.
+It is a Mixture-of-Experts model with 3B active parameters: `exo-0` is memory-bandwidth bound (~85 GB/s host-to-device), so active parameters set decode speed and a 30B MoE runs ~6x faster than a dense 32B of the same size.
 The pod uses a dedicated preemptive `PriorityClass` so it can evict lower-priority work when needed.
+See [ADR 0007](../adr/0007-local-inference-runtime.md) for the full rationale.
 
-**Check status (expected default):**
+**Check status:**
 ```bash
-kubectl -n llm-d get deploy llm-d-modelserver -o jsonpath='{.spec.replicas}{"\n"}'   # expect 1
+kubectl -n llm-d get deploy llm-d-modelserver -o jsonpath='{.spec.replicas}{"\n"}'
 kubectl get pods -n llm-d                                                             # expect one Running pod
+kubectl -n llm-d get pvc llm-d-model-cache                                            # expect Bound
 kubectl get node exo-0 -o jsonpath='{.status.allocatable.amd\.com/gpu}{"\n"}'       # expect >= 1
 ```
 
@@ -452,13 +462,24 @@ kubectl get node exo-0 -o jsonpath='{.status.allocatable.amd\.com/gpu}{"\n"}'
 ```bash
 kubectl logs -n llm-d <pod-name> -c modelserver
 ```
-The model will be cached in the pod's `emptyDir` at `/root/.cache/huggingface` until the pod is deleted.
+The model is cached on the `llm-d-model-cache` PVC at `/models`, so it survives
+pod restarts and is not re-downloaded.
+
+**If generation dies mid-run after a while:** look for a spurious GPU reset.
+```bash
+kubectl get node exo-0 -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/amdgpu-kargs}{"\n"}'   # expect: applied
+```
+`manifests/amdgpu-kargs.yaml` sets `amdgpu.lockup_timeout=20000` because the
+~10s amdgpu default trips a false "device lost" reset under sustained inference
+on gfx1151. If the annotation says `pending-reboot`, the fix is not live yet.
 
 **Key constraints:**
-- The default deployment stays baseline-compliant and uses ordinary pod networking; if you revisit this later for tighter ROCm IPC tuning, you may need to re-test with host-network settings in a dedicated namespace
-- The pod is intentionally not pinned to a specific node, so it can land on whichever node later exposes the GPU resource
-- `unsloth/Llama-3.2-3B-Instruct` is intentionally small enough to be practical on the local lab node while still giving a useful chat experience
-- For long prompts, raise `--max-model-len` or use a larger model later; for short local use, the current defaults are a good fit
+- The pod is pinned to `exo-0` via a `kubernetes.io/hostname` nodeSelector — it is the only node with the Strix Halo iGPU
+- The Deployment uses `strategy: Recreate`. With one `amd.com/gpu` and an RWO cache PVC, a rolling update would deadlock, so updates cause brief downtime by design
+- The image is pinned by digest so rollback is reproducible; do not switch it to a floating tag
+- Rollback is `replicas: 0` or a revert; the PVC persists, so re-enabling does not re-download the model
+- `exo-0` is a 64 GB node shared with BuildBarn, KubeVirt and KubeStellar. GTT is system RAM and the kernel OOM-killer cannot reclaim it, so raising `--ctx-size` or the model quant risks the whole node, not just this pod
+- The endpoint has no authentication and permissive CORS; keep it on the trusted LAN
 
 ---
 

--- a/manifests/amdgpu-kargs.yaml
+++ b/manifests/amdgpu-kargs.yaml
@@ -1,5 +1,7 @@
 # manifests/amdgpu-kargs.yaml
-# Raises the GPU-addressable memory ceiling on AMD "Strix Halo" nodes.
+# Tunes the AMD "Strix Halo" nodes for GPU compute: raises the GPU-addressable
+# memory ceiling, and raises the GPU lockup timeout so sustained inference does
+# not trip spurious resets.
 #
 # Why this exists:
 #   amdgpu sizes GTT from TTM's global page limit, which defaults to half of
@@ -19,6 +21,24 @@
 #   Deliberately NOT set: ttm.page_pool_size. That option pre-allocates memory
 #   and permanently removes it from the OS. On a 64 GB node shared with k3s and
 #   BuildStream workers, setting it near pages_limit would be actively harmful.
+#   (Some Strix Halo guides — e.g. LLMKube's onboarding doc — do recommend it.
+#   Those target dedicated 128 GB inference boxes; these nodes are shared, so
+#   the reasoning above still stands. Noted so the disagreement is deliberate.)
+#
+# GPU lockup timeout (amdgpu.lockup_timeout):
+#   The amdgpu default (~10s) is tuned for interactive desktop workloads. Under
+#   sustained heavy inference on gfx1151 — long-context generation, hours-long
+#   sessions — the default trips a *spurious* GPU reset ("device lost", ring
+#   timeout) that kills the inference backend mid-run even though the GPU is
+#   healthy and simply busy. Raising it to 20s avoids the false positive without
+#   masking a genuine hang: a truly wedged GPU still resets, just 10s later.
+#   See kyuz0/amd-strix-halo-toolboxes and defilantech/LLMKube (Strix Halo
+#   onboarding) for the community consensus on this value.
+#
+#   Deliberately NOT set: amd_iommu=off. It is measured 5-12% faster than
+#   iommu=pt on Strix Halo, but it disables IOMMU device isolation host-wide,
+#   and these nodes also run KubeVirt VMs that rely on that isolation. Inference
+#   here is throughput-tolerant, so the security property wins.
 #
 #   Note the exact spelling: "gtt_size" (with underscore) is not a valid
 #   parameter and is silently ignored.
@@ -125,6 +145,10 @@ spec:
               value: "49152"
             - name: TTM_PAGES_LIMIT
               value: "12582912"
+            # Milliseconds. Raises the GPU lockup/reset timeout from the ~10s
+            # default so sustained inference does not trip a spurious reset.
+            - name: GPU_LOCKUP_TIMEOUT_MS
+              value: "20000"
           command: [bash, -c]
           args:
             - |
@@ -132,7 +156,7 @@ spec:
 
               ostree_kargs() { nsenter -t 1 -m -- rpm-ostree kargs "$@"; }
 
-              DESIRED="amdgpu.gttsize=${GTT_SIZE_MIB} ttm.pages_limit=${TTM_PAGES_LIMIT}"
+              DESIRED="amdgpu.gttsize=${GTT_SIZE_MIB} ttm.pages_limit=${TTM_PAGES_LIMIT} amdgpu.lockup_timeout=${GPU_LOCKUP_TIMEOUT_MS}"
               CURRENT="$(ostree_kargs)"
 
               CHANGES=()

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -17,6 +17,26 @@ metadata:
     pod-security.kubernetes.io/warn: baseline
     pod-security.kubernetes.io/audit: baseline
 ---
+# Persistent GGUF cache. Replaces the previous emptyDir, which forced a ~25 GB
+# re-download on every pod restart. local-path is RWO and WaitForFirstConsumer,
+# so this binds on whichever node the pod lands on — deterministic here because
+# the Deployment pins to exo-0.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llm-d-model-cache
+  namespace: llm-d
+  labels:
+    app.kubernetes.io/name: llm-d-modelserver
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 100Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,107 +46,190 @@ metadata:
     app.kubernetes.io/name: llm-d-modelserver
     app.kubernetes.io/part-of: testing-lab
 spec:
+  # Enabled in a separate GitOps change once the kargs reboot, the PVC bind and
+  # node capacity are confirmed. See docs/adr/0007-local-inference-runtime.md.
   replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: llm-d-modelserver
+  # Recreate, not RollingUpdate: the node exposes exactly one amd.com/gpu and
+  # the cache PVC is RWO. A rolling update would create the replacement before
+  # deleting the old pod, the replacement could never obtain the GPU, and
+  # maxUnavailable=0 would keep the old pod forever — a permanent deadlock.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         app.kubernetes.io/name: llm-d-modelserver
       annotations:
-        lab.projectbluefin.io/config-version: podsecurity-v1
+        lab.projectbluefin.io/config-version: llamacpp-vulkan-v1
     spec:
       priorityClassName: llm-d-preempt
       nodeSelector:
         kubernetes.io/hostname: exo-0
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
       containers:
         - name: modelserver
-          image: vllm/vllm-openai-rocm:latest
+          # llama.cpp on Vulkan (Mesa RADV), not ROCm/HIP. On gfx1151 the Vulkan
+          # backend is the reliable, well-supported inference path and ROCm is
+          # not required — confirmed independently by Foxlight-Foundation/Skulk
+          # and defilantech/LLMKube. It also keeps us on an allowlisted registry:
+          # ggml-org publishes no ROCm tags at all.
+          #
+          # Pinned by digest so a rollback is reproducible. Tag: server-vulkan.
+          image: ghcr.io/ggml-org/llama.cpp:server-vulkan@sha256:654482cfc988042fe25c2255199d512bcfd057fcde9b87b8dc07b9a2d3336b6c
           imagePullPolicy: IfNotPresent
+          # Not privileged. /dev/dri/renderD128 is mode 0666 on these nodes, so
+          # the Vulkan backend needs the device node and nothing else. The
+          # previous /dev/kfd, /sys and /lib/modules mounts were ROCm-era and are
+          # unnecessary on the Vulkan path.
           securityContext:
-            privileged: true
+            privileged: false
+            allowPrivilegeEscalation: false
           args:
-            - --model
-            - unsloth/Llama-3.2-3B-Instruct
-            - --served-model-name
+            # Model: Qwen3-30B-A3B-Instruct-2507 at Q6_K (~25.1 GB).
+            #
+            # MoE, 3B active of 30B total. Strix Halo is memory-bandwidth bound
+            # (~85 GB/s host-to-device), so *active* parameters set decode speed
+            # while total parameters mostly cost capacity — which is why a 30B
+            # MoE runs ~6x faster than a dense 32B of the same size.
+            #
+            # Q6_K rather than Q8_0: published quantization guidance rates Q6_K
+            # "very low" loss and recommends it for models up to 32B, while Q8_0
+            # is "minimal". The extra 7.4 GB buys almost nothing and spends the
+            # KV-cache headroom a long-context assistant actually needs.
+            - --hf-repo
+            - unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q6_K
+            - --alias
             - local-llm
-            - --host
-            - 0.0.0.0
             - --port
             - "8000"
-            - --tensor-parallel-size
-            - "1"
-            - --max-model-len
+            # Offload every layer to the iGPU.
+            - -ngl
+            - "999"
+            # Flash attention is required on Strix Halo: without it the community
+            # toolboxes report crashes and severe slowdowns.
+            - -fa
+            - "on"
+            # Disable mmap. Same intent as the --no-mmap that the Strix Halo
+            # guides mandate (mmap/SVM interaction causes trouble on this APU),
+            # expressed with the current flag since --no-mmap is deprecated.
+            - --load-mode
+            - none
+            # KV cache quantized to q8_0 — the Strix Halo toolbox default.
+            # At 64k context this costs ~3 GiB instead of ~6 GiB at f16.
+            - --cache-type-k
+            - q8_0
+            - --cache-type-v
+            - q8_0
+            # 64k context. The model supports far more, but this node has 62 GiB
+            # of RAM shared with BuildBarn/KubeVirt/KubeStellar, so start
+            # conservative; raise once steady-state headroom is measured.
+            - --ctx-size
+            - "65536"
+            - --batch-size
             - "4096"
-            - --gpu-memory-utilization
-            - "0.90"
-            - --trust-remote-code
+            - --ubatch-size
+            - "512"
+            - --threads
+            - "12"
+            # Single user: one slot, so we stay well clear of the GPU MES
+            # scheduler crashes reported under high concurrency with large
+            # batches on this hardware.
+            - --parallel
+            - "1"
+            - --cache-reuse
+            - "256"
+            # Qwen3-Instruct-2507 sampling recommended by the model authors.
+            - --temp
+            - "0.7"
+            - --top-p
+            - "0.8"
+            - --top-k
+            - "20"
+            - --min-p
+            - "0.0"
           env:
-            - name: HF_HOME
-              value: /root/.cache/huggingface
-            - name: VLLM_LOGGING_LEVEL
-              value: INFO
-            - name: HIP_VISIBLE_DEVICES
-              value: all
-            - name: ROCM_VISIBLE_DEVICES
-              value: all
+            # Where --hf-repo stores the downloaded GGUF. Points at the PVC so
+            # the model survives restarts.
+            - name: LLAMA_CACHE
+              value: /models
           ports:
             - name: http
               containerPort: 8000
               protocol: TCP
           volumeMounts:
-            - name: hf-cache
-              mountPath: /root/.cache/huggingface
-            - name: dev-kfd
-              mountPath: /dev/kfd
+            - name: model-cache
+              mountPath: /models
             - name: dev-dri
               mountPath: /dev/dri
-            - name: sys
-              mountPath: /sys
-            - name: lib-modules
-              mountPath: /lib/modules
           resources:
             requests:
               cpu: "4"
-              memory: 16Gi
+              # Reserves scheduler space for the model so nothing else fills the
+              # node underneath it. GTT is system RAM on this APU.
+              memory: 34Gi
               amd.com/gpu: "1"
             limits:
-              cpu: "8"
-              memory: 24Gi
+              cpu: "12"
+              # Generous rather than snug: GPU-backed pages may or may not be
+              # charged to this cgroup depending on kernel behaviour, and a tight
+              # limit risks an OOM kill during model load.
+              memory: 44Gi
               amd.com/gpu: "1"
+          # /health returns HTTP 503 {"error":"Loading model"} until the model is
+          # loaded. The first start downloads ~25 GB, so startup is gated by a
+          # startupProbe with a long budget (30 x 60s = 30 min) and liveness does
+          # not engage until it succeeds.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 60
             periodSeconds: 15
             timeoutSeconds: 5
-            failureThreshold: 10
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 120
             periodSeconds: 30
             timeoutSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 5
       volumes:
-        - name: hf-cache
-          emptyDir: {}
-        - name: dev-kfd
-          hostPath:
-            path: /dev/kfd
-            type: CharDevice
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: llm-d-model-cache
         - name: dev-dri
           hostPath:
             path: /dev/dri
             type: Directory
-        - name: sys
-          hostPath:
-            path: /sys
-            type: Directory
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
-            type: Directory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-d-modelserver
+  namespace: llm-d
+  labels:
+    app.kubernetes.io/name: llm-d-modelserver
+    app.kubernetes.io/part-of: testing-lab
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: llm-d-modelserver
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      nodePort: 30800
+      protocol: TCP


### PR DESCRIPTION
Replaces the vLLM placeholder in `manifests/llm-d.yaml` with a quality-first, single-user inference stack sized for `exo-0`. Rationale and evidence in [ADR 0007](docs/adr/0007-local-inference-runtime.md).

## Why this shape

`exo-0` is a **64 GB** Framework Desktop (62.1 GiB allocatable), not the 128 GB box every published Strix Halo guide assumes. It is memory-bandwidth bound (~85 GB/s host-to-device), so *active* parameters set decode speed while total parameters mostly cost capacity.

- **llama.cpp, not vLLM** — continuous batching buys nothing for one user and costs KV-cache memory.
- **Vulkan, not ROCm** — two independent sources conclude Vulkan/RADV is the reliable llama.cpp path on `gfx1151`. `ggml-org/llama.cpp` publishes **no ROCm tags at all**, so this also moves off an implicit Docker Hub reference onto an allowlisted registry. Pinned by digest.
- **Qwen3-30B-A3B-Instruct-2507 @ Q6_K (~25.1 GB)** — MoE, 3B active. Published guidance rates Q6_K "very low" loss for ≤32B; Q8_0's extra 7.4 GB moves it to "minimal" while spending KV headroom a long-context assistant needs. Serving flags taken from the Strix Halo toolbox maintainer's tested presets.
- Rejected: Qwen3-Next-80B-A3B @ Q3 (same speed, 2.7× params) — Q3 is rated "noticeable" loss and reserved for 100B+, and its linear attention is unproven on Vulkan. Re-evaluation trigger recorded in the ADR.

## Latent defects fixed along the way

| Found | Impact |
|---|---|
| **No Service existed**; NodePort 30800 unused cluster-wide | The `:30800/v1` endpoint in the docs was fiction |
| Default rolling update | **Permanent deadlock** — one `amd.com/gpu` + RWO PVC + `maxUnavailable: 0` means the replacement can never start. Now `Recreate` |
| `/health` returns 503 while loading | Old liveness probe would kill the pod mid-download. Now a `startupProbe` with a 30 min budget |
| `emptyDir` cache | Full ~25 GB re-download every restart. Now a 100Gi `local-path` PVC |
| `privileged: true` + 4 hostPaths | Vulkan needs only `/dev/dri` (render node is mode 0666 here). Now unprivileged |

Plus `amdgpu.lockup_timeout=20000` in `amdgpu-kargs.yaml`: the ~10s amdgpu default trips a **spurious "device lost" GPU reset under sustained gfx1151 inference** — the exact failure mode for hours-long sessions. `amd_iommu=off` deliberately *not* adopted (5–12% faster, but disables IOMMU isolation the KubeVirt VMs rely on).

## Verification

- `just lint` — clean
- `check_gitops_policy.py` — **87.4% → 88.4%** (57 → 53 violations). Two `llm-d` findings remain by design: the `/dev/dri` hostPath and the `exo-0` nodeSelector, both inherent to pinning a GPU workload to the one node with the GPU. Documented as accepted exceptions in the ADR.
- `kubectl apply --dry-run=server` — passes
- **Ran the pinned image with this exact flag set**: all 18 flags parse, model loads, `/health` → `{"status":"ok"}`, `/v1/models` shows the `local-llm` alias, and `/v1/chat/completions` returns with `.timings.predicted_per_second` populated. Cache confirmed landing under `LLAMA_CACHE`.

## Rollout

Ships at **`replicas: 0`**. Enabling is a separate change once the kargs reboot, the PVC bind and node headroom are confirmed — GTT is system RAM the OOM-killer cannot reclaim, so an oversized model can deadlock the node rather than evict a pod.