### PR TITLE
fix(llm-d): enable the model server, unblocking an ArgoCD sync deadlock

### DIFF
--- a/docs/adr/0007-local-inference-runtime.md
+++ b/docs/adr/0007-local-inference-runtime.md
@@ -171,8 +171,12 @@ The model cache moves from `emptyDir` to a 100Gi `local-path` PVC, so a restart
 no longer re-downloads ~25 GB. `local-path` is RWO and `WaitForFirstConsumer`;
 placement is deterministic because the Deployment pins to `exo-0`.
 
-The Deployment ships at `replicas: 0` and is enabled in a **separate** GitOps
-change once the kargs reboot, the PVC bind and node headroom are confirmed.
+The Deployment ships **enabled** (`replicas: 1`). A phased `replicas: 0` rollout
+was attempted and does not work with this PVC: `WaitForFirstConsumer` means the
+PVC cannot bind until a pod consumes it, ArgoCD blocks its sync waiting for the
+PVC to report healthy, and so the Deployment is never created — a circular
+deadlock. Taking the server down is therefore a runtime `kubectl scale`, not a
+committed `replicas: 0`.
 
 ## Consequences
 

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -477,7 +477,7 @@ on gfx1151. If the annotation says `pending-reboot`, the fix is not live yet.
 - The pod is pinned to `exo-0` via a `kubernetes.io/hostname` nodeSelector — it is the only node with the Strix Halo iGPU
 - The Deployment uses `strategy: Recreate`. With one `amd.com/gpu` and an RWO cache PVC, a rolling update would deadlock, so updates cause brief downtime by design
 - The image is pinned by digest so rollback is reproducible; do not switch it to a floating tag
-- Rollback is `replicas: 0` or a revert; the PVC persists, so re-enabling does not re-download the model
+- Rollback is a runtime `kubectl -n llm-d scale deploy/llm-d-modelserver --replicas=0` or a revert; the PVC persists, so re-enabling does not re-download the model. Do not commit `replicas: 0` — with a `WaitForFirstConsumer` PVC that deadlocks ArgoCD's sync
 - `exo-0` is a 64 GB node shared with BuildBarn, KubeVirt and KubeStellar. GTT is system RAM and the kernel OOM-killer cannot reclaim it, so raising `--ctx-size` or the model quant risks the whole node, not just this pod
 - The endpoint has no authentication and permissive CORS; keep it on the trusted LAN
 

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -46,9 +46,14 @@ metadata:
     app.kubernetes.io/name: llm-d-modelserver
     app.kubernetes.io/part-of: testing-lab
 spec:
-  # Enabled in a separate GitOps change once the kargs reboot, the PVC bind and
-  # node capacity are confirmed. See docs/adr/0007-local-inference-runtime.md.
-  replicas: 0
+  # Enabled. Note this cannot be staged at replicas: 0 while the cache PVC uses
+  # local-path: local-path is WaitForFirstConsumer, so the PVC only binds once a
+  # pod consumes it, and ArgoCD blocks its sync waiting for the PVC to become
+  # healthy — which never happens without a pod. replicas: 0 plus this PVC is a
+  # circular deadlock that also prevents the Deployment itself from being
+  # created. To take the server down, scale it to 0 at runtime rather than
+  # committing replicas: 0.
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: llm-d-modelserver


### PR DESCRIPTION
Follow-up to #600, fixing a deadlock found during live verification.

## The bug

Shipping the Deployment at `replicas: 0` alongside the new `local-path` PVC deadlocks:

1. `local-path` is `WaitForFirstConsumer` → the PVC only binds once a pod consumes it
2. ArgoCD blocks its sync `waiting for healthy state of /PersistentVolumeClaim/llm-d-model-cache`
3. Because the sync is blocked, **the Deployment is never created at all**
4. No Deployment → no pod → no consumer → PVC stays `Pending` → back to (2)

Observed live: `testing-lab-infra` sat `OutOfSync/Progressing` with the `llm-d` Deployment object entirely absent from the cluster.

## Fix

Enable the server (`replicas: 1`), and document that taking it down is a runtime `kubectl scale`, not a committed `replicas: 0`.

Node headroom checked first: `exo-0` has 62.1Gi allocatable with ~10.9Gi requested, so the 34Gi request schedules comfortably.

## Known follow-up

The `amdgpu.lockup_timeout=20000` karg from #600 staged correctly but `exo-0` now reads `pending-reboot`, so the spurious-GPU-reset protection is **not live until a maintainer reboots the node**. Until then, very long generations remain exposed to the ~10s amdgpu default timeout.

## Verification

- `just lint` clean
- Live cluster state confirmed the deadlock and the absent Deployment before this change