### PR TITLE
fix(llm-d): pin the image by build tag, not digest, so the zot mirror can pull

### DIFF
--- a/docs/adr/0007-local-inference-runtime.md
+++ b/docs/adr/0007-local-inference-runtime.md
@@ -74,7 +74,11 @@ the patched ROCm toolboxes live on Docker Hub, which is not in the lab registry
 allowlist. Vulkan keeps us on an allowlisted registry with an upstream-maintained
 image.
 
-The image is **pinned by digest**, not `latest`, so rollback is reproducible.
+The image is **pinned to an immutable per-build tag** (`server-vulkan-b10290`),
+not `latest` and not a bare digest. A digest pin was tried first and fails in
+this cluster: pulls go through the zot registry mirror, whose on-demand sync
+only triggers on *tag* references, so a bare `@sha256:` reference for an
+uncached image returns 404. The build tag is equally immutable and mirror-safe.
 
 ### 3. Qwen3-30B-A3B-Instruct-2507 at Q6_K, not Q8_0
 

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -476,7 +476,7 @@ on gfx1151. If the annotation says `pending-reboot`, the fix is not live yet.
 **Key constraints:**
 - The pod is pinned to `exo-0` via a `kubernetes.io/hostname` nodeSelector — it is the only node with the Strix Halo iGPU
 - The Deployment uses `strategy: Recreate`. With one `amd.com/gpu` and an RWO cache PVC, a rolling update would deadlock, so updates cause brief downtime by design
-- The image is pinned by digest so rollback is reproducible; do not switch it to a floating tag
+- The image is pinned to an immutable per-build tag (`server-vulkan-b10290`) so rollback is reproducible. Do not use the floating `:server-vulkan` tag, and do not pin by bare digest — the zot mirror's on-demand sync only triggers on tag references, so a digest reference 404s for an uncached image
 - Rollback is a runtime `kubectl -n llm-d scale deploy/llm-d-modelserver --replicas=0` or a revert; the PVC persists, so re-enabling does not re-download the model. Do not commit `replicas: 0` — with a `WaitForFirstConsumer` PVC that deadlocks ArgoCD's sync
 - `exo-0` is a 64 GB node shared with BuildBarn, KubeVirt and KubeStellar. GTT is system RAM and the kernel OOM-killer cannot reclaim it, so raising `--ctx-size` or the model quant risks the whole node, not just this pod
 - The endpoint has no authentication and permissive CORS; keep it on the trusted LAN

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -85,8 +85,14 @@ spec:
           # and defilantech/LLMKube. It also keeps us on an allowlisted registry:
           # ggml-org publishes no ROCm tags at all.
           #
-          # Pinned by digest so a rollback is reproducible. Tag: server-vulkan.
-          image: ghcr.io/ggml-org/llama.cpp:server-vulkan@sha256:654482cfc988042fe25c2255199d512bcfd057fcde9b87b8dc07b9a2d3336b6c
+          # Pinned to an immutable per-build tag rather than a digest. The lab
+          # pulls through the zot mirror, whose on-demand sync only triggers on
+          # *tag* references — a bare @sha256 digest for an uncached image 404s.
+          # server-vulkan-b10290 resolves to
+          # sha256:654482cfc988042fe25c2255199d512bcfd057fcde9b87b8dc07b9a2d3336b6c
+          # (llama.cpp b10290, upstream commit c8e03ce8). Bump the build number
+          # to upgrade; never use the floating :server-vulkan tag.
+          image: ghcr.io/ggml-org/llama.cpp:server-vulkan-b10290
           imagePullPolicy: IfNotPresent
           # Not privileged. /dev/dri/renderD128 is mode 0666 on these nodes, so
           # the Vulkan backend needs the device node and nothing else. The


### PR DESCRIPTION
Third and final fix in the llm-d series (after #600, #601), found by watching the pod actually start.

## The bug

The digest pin from #600 is unpullable in this cluster. Pod sat in `ImagePullBackOff`:

```
failed to resolve reference "ghcr.io/ggml-org/llama.cpp@sha256:654482cf...": not found
```

Node pulls route through the zot mirror (`override_path = true`, no upstream fallback), and **zot's on-demand sync only triggers on tag references**. A bare `@sha256:` reference for an image it hasn't cached returns 404.

Isolated it cleanly:

| Reference | ghcr.io direct | via zot mirror |
|---|---|---|
| `@sha256:654482cf...` | 200 | **404** |
| `:server-vulkan-b10290` | 200 | syncs normally |

So the digest is valid — the mirror just can't resolve one it has never seen.

## Fix

Pin to the immutable per-build tag `server-vulkan-b10290`, which resolves to **exactly the same digest** (`sha256:654482cf...`, llama.cpp b10290, upstream commit `c8e03ce8`). Keeps the reproducibility the digest was for, while remaining pullable through the mirror. The digest is recorded in a comment for auditability.

Worth knowing generally: **digest-pinned images do not work in this cluster** unless already cached. Documented in the ADR and the cheatsheet.