### PR TITLE
docs(llm-d): record measured inference results and Strix Halo GPU findings

### DIFF
--- a/docs/adr/0007-local-inference-runtime.md
+++ b/docs/adr/0007-local-inference-runtime.md
@@ -222,6 +222,27 @@ A healthy result is a completion returned with all layers offloaded to Vulkan, a
 sustained multi-hour session with **zero** amdgpu resets, and no node memory
 pressure or evictions on `exo-0`.
 
+## Measured result (2026-08-06, first deployment)
+
+| Metric | Value |
+|---|---|
+| Decode | **73.7 tok/s** (200 tok), **70.8 tok/s** sustained (1200 tok) |
+| Prompt | 59.2 tok/s |
+| GTT resident | 26.5 GiB (`mem_info_gtt_used`), model + KV |
+| Model load | ~5 s from the warm PVC cache |
+| First download | ~25 GB at ~0.5 GB/min, ~50 min |
+| Node | `MemoryPressure=False`, 0 pod restarts |
+
+This lands in the same band as the published 69.6 tok/s for a 30B-A3B MoE at
+Q4_K_M, while running the higher-quality Q6_K — confirming the model is
+GPU-resident and that the extra quantization bits are effectively free here.
+
+**Confirmed hazard:** during this run `kubectl top node exo-0` reported 8%
+memory use while 26.5 GiB was resident in GTT. GPU-backed pages really do escape
+ordinary node memory accounting, so **`kubectl top` cannot be used to judge
+headroom on this node** and pod memory limits should not be treated as a
+guarantee. Node-level eviction thresholds remain the real protection.
+
 ## References
 
 - [`kyuz0/amd-strix-halo-toolboxes`](https://github.com/kyuz0/amd-strix-halo-toolboxes) — Strix Halo llama.cpp images, tested `models.ini` presets, host tuning

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -268,6 +268,46 @@ Do not guess flags, chart schema, or MCP method names. The K8sGPT MCP server exp
       scrape healthy.
 - [ ] Build workflow metric labels remain limited to `pipeline` and `status`.
 
+## GPU inference on Strix Halo (`exo-0`)
+
+`exo-0` is a **64 GB** Framework Desktop (62.1 GiB allocatable), not the 128 GB
+box every published Strix Halo guide assumes. Scale all community advice down.
+
+- **Use Vulkan, not ROCm.** On `gfx1151` the Vulkan/RADV backend is the reliable
+  llama.cpp path; ROCm is not required for inference. `ghcr.io/ggml-org/llama.cpp`
+  publishes **no ROCm tags at all** — only `vulkan`, `cuda`, `musa`, `intel`.
+- **The 48 GiB GTT ceiling is not a budget.** GTT is system RAM shared with
+  BuildBarn, KubeVirt and KubeStellar. amdgpu GTT pins pages the OOM-killer
+  cannot reclaim, so overcommitting deadlocks the node rather than evicting a pod.
+- **`kubectl top` cannot measure GPU memory here.** Measured: `top node` reported
+  8% while 26.5 GiB was resident in GTT. Read
+  `/sys/class/drm/card*/device/mem_info_gtt_used` instead.
+- **MoE beats dense ~6-12x.** The node is bandwidth-bound (~85 GB/s
+  host-to-device), so *active* parameters set decode speed. A 30B-A3B MoE
+  measured 70-74 tok/s at Q6_K; a dense 32B manages ~11 tok/s.
+- **Tensor parallelism over the USB4 link is dead.** ~128 collectives/token x
+  70-100 us = 9-13 ms/token of stall. Independently measured elsewhere as ~15%
+  *slower* than single-node. The link helps load time, not decode.
+- **`-fa on` and no-mmap (`--load-mode none`) are mandatory** on Strix Halo.
+- **`amdgpu.lockup_timeout=20000`** prevents a spurious "device lost" GPU reset
+  that kills long generations; the ~10s default is a desktop tuning. Needs a
+  reboot — check the `lab.projectbluefin.io/amdgpu-kargs` node annotation.
+- Never raise the BIOS UMA carve-out above its 512 MiB minimum; it steals system
+  RAM and *shrinks* GTT.
+
+Two cluster-specific traps that cost real time:
+
+- **Digest-pinned images cannot be pulled.** Node pulls go through the zot mirror
+  (`override_path = true`, no upstream fallback) and zot's on-demand sync only
+  triggers on *tag* references. A bare `@sha256:` for an uncached image 404s.
+  Pin to an immutable per-build tag instead.
+- **`replicas: 0` + a `WaitForFirstConsumer` PVC deadlocks ArgoCD.** The PVC
+  cannot bind without a pod, ArgoCD blocks its sync waiting for PVC health, and
+  so the Deployment is never created at all. Scale at runtime instead of
+  committing `replicas: 0`.
+
+See `docs/adr/0007-local-inference-runtime.md`.
+
 ## Key references
 
 - Cluster topology: `/AGENTS.md`

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -193,16 +193,19 @@ spec:
               memory: 44Gi
               amd.com/gpu: "1"
           # /health returns HTTP 503 {"error":"Loading model"} until the model is
-          # loaded. The first start downloads ~25 GB, so startup is gated by a
-          # startupProbe with a long budget (30 x 60s = 30 min) and liveness does
-          # not engage until it succeeds.
+          # loaded. The first start downloads ~25 GB as a single file, which is
+          # network-bound and measured at ~30-60 min on the lab link, so the
+          # budget here is deliberately generous (120 x 60s = 2h). It costs
+          # nothing after the first success, and an undersized budget kills the
+          # pod mid-download and restarts the transfer. Liveness does not engage
+          # until the startupProbe succeeds.
           startupProbe:
             httpGet:
               path: /health
               port: 8000
             periodSeconds: 60
             timeoutSeconds: 10
-            failureThreshold: 30
+            failureThreshold: 120
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Closes out the llm-d series (#600, #601, #602, #603) with measured evidence and a skill write-back.

## Measured on `exo-0`

| Metric | Value |
|---|---|
| Decode | **73.7 tok/s** (200 tok), **70.8 tok/s** sustained (1200 tok) |
| Prompt | 59.2 tok/s |
| GTT resident | 26.5 GiB (model + KV) |
| Model load | ~5 s from warm PVC cache |
| First download | ~25 GB at ~0.5 GB/min (~50 min) |
| Node | `MemoryPressure=False`, 0 restarts, ArgoCD Synced/Healthy |

That matches the published **69.6 tok/s** for a 30B-A3B MoE at Q4_K_M while running the higher-quality **Q6_K** — confirming the model is GPU-resident and that the extra quantization bits are effectively free on bandwidth-bound hardware.

## Hazard confirmed empirically

During the run `kubectl top node exo-0` reported **8% memory while 26.5 GiB was resident in GTT**. GPU-backed pages really do escape ordinary node accounting, so `kubectl top` cannot judge headroom on this node — read `mem_info_gtt_used`. Node-level eviction thresholds remain the real protection.

## Skill write-back

`cluster-tooling` gains a Strix Halo GPU inference section, including the two cluster traps this work hit the hard way: digest-pinned images are unpullable through the zot mirror, and `replicas: 0` + a `WaitForFirstConsumer` PVC deadlocks ArgoCD.