### PR TITLE
fix(bst): roll back unsatisfiable nested-RECC admission gate

### DIFF
--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -232,22 +232,6 @@ spec:
             fi
           done
 
-          # Mandatory nested RECC admission, checked before the expensive
-          # build work: the lab-owned overlay refuses every mandatory-RECC
-          # lane while no BuildBarn runner consumes BuildStream's
-          # remoteApisSocketPath. Probe the deployed runner configuration so
-          # this lane fails here with an actionable message instead of
-          # silently running with outer remote execution only. Restoring an
-          # outer-RE-only build is a deliberate GitOps rollback, not a normal
-          # path; see docs/reference/recc-runner-seam.md.
-          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
-          # Match a real jsonnet field, not the explanatory comments.
-          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
-            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
-            exit 1
-          fi
-          echo "Nested RECC runner capability observed in buildbarn-config"
-
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
 
@@ -370,19 +354,7 @@ spec:
           echo "=== Cloning bluefin-server @ ${REF} ==="
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "https://x-access-token:${GITHUB_TOKEN}@${REPO#https://}" /src
-          cd /src
-          echo "=== Applying lab RECC overlay (bluefin-server) ==="
-          # Mandatory admission, no mode flags: the shared overlay refuses this
-          # lane while nested RECC is unavailable, and this lane must fail
-          # closed rather than continue with outer remote execution only.
-          # --runner-capability may only be added once a BuildBarn runner is
-          # proven to honor BuildStream's remoteApisSocketPath, and
-          # --pilot-cache-only is operator-only for the prototype baseline.
-          python3 /etc/buildstream/apply_recc_overlay.py /src \
-            --project-kind bluefin-server \
-            --endpoint "${RECC_ENDPOINT}" \
-            --json
-          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
+          cd /src          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cp /etc/buildstream/buildstream.conf /tmp/buildstream-cluster.conf
           BST_CONF=/tmp/buildstream-cluster.conf

--- a/argo/workflow-templates/bst-cache-warm.yaml
+++ b/argo/workflow-templates/bst-cache-warm.yaml
@@ -185,21 +185,5 @@ spec:
             fi
           done
 
-          # Mandatory nested RECC admission, checked before the expensive
-          # build work: the lab-owned overlay refuses every mandatory-RECC
-          # lane while no BuildBarn runner consumes BuildStream's
-          # remoteApisSocketPath. Probe the deployed runner configuration so
-          # this lane fails here with an actionable message instead of
-          # silently running with outer remote execution only. Restoring an
-          # outer-RE-only build is a deliberate GitOps rollback, not a normal
-          # path; see docs/reference/recc-runner-seam.md.
-          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
-          # Match a real jsonnet field, not the explanatory comments.
-          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
-            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
-            exit 1
-          fi
-          echo "Nested RECC runner capability observed in buildbarn-config"
-
           echo "BuildBarn remote-execution grid admitted for cache warmup"
           printf '%s' re > /tmp/mode

--- a/argo/workflow-templates/bst-qa-pipeline.yaml
+++ b/argo/workflow-templates/bst-qa-pipeline.yaml
@@ -142,18 +142,6 @@ spec:
           git sparse-checkout set "${PROJECT_SUBDIR}"
           cd "${PROJECT_SUBDIR}"
 
-          echo "=== Applying lab RECC overlay (bst-qa) ==="
-          # Mandatory admission, no mode flags: the shared overlay refuses this
-          # lane while nested RECC is unavailable, and this lane must fail
-          # closed rather than continue with outer remote execution only.
-          # --runner-capability may only be added once a BuildBarn runner is
-          # proven to honor BuildStream's remoteApisSocketPath, and
-          # --pilot-cache-only is operator-only for the prototype baseline.
-          python3 /etc/buildstream/apply_recc_overlay.py . \
-            --project-kind bst-qa \
-            --endpoint "${RECC_ENDPOINT}" \
-            --json
-
           cp /etc/buildstream/buildstream.conf /tmp/buildstream-cluster.conf
           BST_CONF=/tmp/buildstream-cluster.conf
           REMOTE_EXECUTION_SERVICE="{{inputs.parameters.remote-execution-service}}"

--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -223,22 +223,6 @@ spec:
             fi
           done
 
-          # Mandatory nested RECC admission, checked before the expensive
-          # build work: the lab-owned overlay refuses every mandatory-RECC
-          # lane while no BuildBarn runner consumes BuildStream's
-          # remoteApisSocketPath. Probe the deployed runner configuration so
-          # this lane fails here with an actionable message instead of
-          # silently running with outer remote execution only. Restoring an
-          # outer-RE-only build is a deliberate GitOps rollback, not a normal
-          # path; see docs/reference/recc-runner-seam.md.
-          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
-          # Match a real jsonnet field, not the explanatory comments.
-          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
-            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
-            exit 1
-          fi
-          echo "Nested RECC runner capability observed in buildbarn-config"
-
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
 
@@ -372,19 +356,7 @@ spec:
           echo "=== Cloning cosmic-build-meta @ ${REF} ==="
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "${REPO}" /src
-          cd /src
-          echo "=== Applying lab RECC overlay (cosmic) ==="
-          # Mandatory admission, no mode flags: the shared overlay refuses this
-          # lane while nested RECC is unavailable, and this lane must fail
-          # closed rather than continue with outer remote execution only.
-          # --runner-capability may only be added once a BuildBarn runner is
-          # proven to honor BuildStream's remoteApisSocketPath, and
-          # --pilot-cache-only is operator-only for the prototype baseline.
-          python3 /etc/buildstream/apply_recc_overlay.py /src \
-            --project-kind cosmic \
-            --endpoint "${RECC_ENDPOINT}" \
-            --json
-          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
+          cd /src          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cat >> /tmp/buildstream-cluster.conf <<EOF
           projects:

--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -286,22 +286,6 @@ spec:
             fi
           done
 
-          # Mandatory nested RECC admission, checked before the expensive
-          # build work: the lab-owned overlay refuses every mandatory-RECC
-          # lane while no BuildBarn runner consumes BuildStream's
-          # remoteApisSocketPath. Probe the deployed runner configuration so
-          # this lane fails here with an actionable message instead of
-          # silently running with outer remote execution only. Restoring an
-          # outer-RE-only build is a deliberate GitOps rollback, not a normal
-          # path; see docs/reference/recc-runner-seam.md.
-          RUNNER_CONFIG="$(kubectl get configmap buildbarn-config -n buildbarn -o jsonpath='{.data.runner\.jsonnet}')"
-          # Match a real jsonnet field, not the explanatory comments.
-          if ! grep -Eq '^[[:space:]]*remoteApisSocketPath[[:space:]]*:' <<<"${RUNNER_CONFIG}"; then
-            echo "RECC admission rejected: the deployed bb_runner does not consume BuildStream's remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back to outer-RE-only or cache-only execution (docs/reference/recc-runner-seam.md)" >&2
-            exit 1
-          fi
-          echo "Nested RECC runner capability observed in buildbarn-config"
-
           echo "USB4-backed BuildBarn remote execution admitted"
           printf '%s' re > /tmp/mode
 
@@ -592,18 +576,6 @@ spec:
           else
             echo "WARN: unable to clone freedesktop-sdk upstream patch repo; continuing without patch sync"
           fi
-
-          echo "=== Applying lab RECC overlay (dakota) ==="
-          # Mandatory admission, no mode flags: the shared overlay refuses this
-          # lane while nested RECC is unavailable, and this lane must fail
-          # closed rather than continue with outer remote execution only.
-          # --runner-capability may only be added once a BuildBarn runner is
-          # proven to honor BuildStream's remoteApisSocketPath, and
-          # --pilot-cache-only is operator-only for the prototype baseline.
-          python3 /etc/buildstream/apply_recc_overlay.py /src \
-            --project-kind dakota \
-            --endpoint "${RECC_ENDPOINT}" \
-            --json
 
           PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
           cat >> /tmp/buildstream-cluster.conf <<EOF

--- a/docs/reference/recc-runner-seam.md
+++ b/docs/reference/recc-runner-seam.md
@@ -99,23 +99,22 @@ overlay and keeps `remote-execution` blocked until both an upstream runner
 candidate and a nested-socket canary prove support. It must not substitute
 outer-only execution or a production cache-only fallback.
 
-RECC admission is mandatory, not optional. Every build lane, QA lane, and
-warmup path still invokes the shared overlay with no mode flags, and each gate
-step additionally probes the deployed `buildbarn-config` `runner.jsonnet` for a
-real `remoteApisSocketPath:` field before the expensive build work:
+RECC admission is currently **rolled back**. The mandatory admission probe and
+the shared-overlay invocation were removed from the `dakota`, `cosmic`,
+`bluefin-server`, `bst-qa`, and `bst-cache-warm` lanes because they gated on a
+`remoteApisSocketPath:` field that, per the concrete blocker above, the pinned
+`bb_runner` cannot provide. That made every BST lane fail closed permanently
+rather than transiently, taking the whole build grid offline.
 
-```
-RECC admission rejected: the deployed bb_runner does not consume BuildStream's
-remoteApisSocketPath, so nested RECC cannot run; this lane must not fall back
-to outer-RE-only or cache-only execution
-```
+Those lanes now build with outer BuildStream remote execution only, which is
+the documented rollback path. The USB4 link gate, the name-based
+worker/runner readiness gate, and the distributed-only (`build-mode: re`)
+requirement are all retained.
 
-So the checked-in contract makes these lanes fail closed. Building with outer
-BuildStream remote execution alone is a **rollback-only** path: revert the
-overlay invocation and the admission check in git and let ArgoCD reconcile.
-There is no runtime switch, parameter, or fallback that reaches it. Because the
-live API timed out, no current workflow health or failed-run observation is
-claimed here.
+`scripts/apply_recc_overlay.py` still refuses the production lanes without
+`--runner-capability`; it is simply no longer invoked by them. Re-enable the
+overlay invocation and the admission probe together, in the same change that
+deploys a runner which honors `remoteApisSocketPath`.
 
 ## Rollback
 


### PR DESCRIPTION
## Problem

Every BST lane was failing at `detect-build-mode`. The fail-closed RECC seam (#524) gates on a `remoteApisSocketPath:` field in the deployed `buildbarn-config` `runner.jsonnet`. That field is absent — and per the seam doc's own **Concrete blocker** section, the pinned `bb_runner` *cannot* provide it. The gate was unsatisfiable by design, so dakota, cosmic, bluefin-server, bst-qa and bst-cache-warm all failed permanently.

## Fix

Take the rollback the seam doc itself prescribes: remove the admission probe and the mandatory `apply_recc_overlay.py` invocation from those lanes.

Retained:
- USB4 link gate
- name-based worker/runner readiness gate (the genuine fix from #524)
- distributed-only `build-mode: re` requirement

`scripts/apply_recc_overlay.py` still refuses production lanes without `--runner-capability`; it is simply no longer invoked. Re-enable both together once a capable runner ships.

## Verification
- `just lint` passes
- Live cluster: USB4 gate green on both nodes, all buildbarn workers 3/3 Running