### PR TITLE
fix(argo): report nested provisioning exit code explicitly

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -303,7 +303,8 @@ spec:
         # terminates at the first inner apostrophe, which previously mangled the
         # `printf '%s\n'` calls below into `printf %sn` and corrupted /etc/group.
         # Do not convert this back to `bash -c`.
-        if ! podman exec -i "${TARGET_NAME}" bash -s <<'NESTED_SETUP'
+        setup_rc=0
+        podman exec -i "${TARGET_NAME}" bash -s <<'NESTED_SETUP' || setup_rc=$?
           set -euo pipefail
 
           # Ensure runtime directories GDM and logind need are present before any
@@ -440,12 +441,17 @@ spec:
             exit 1
           fi
 
-          systemctl start gdm
+          echo "Starting GDM in nested target..." >&2
+          if ! systemctl start gdm; then
+            gdm_rc=$?
+            echo "systemctl start gdm failed (rc=${gdm_rc})" >&2
+            systemctl status gdm --no-pager --full >&2 || true
+            exit 1
+          fi
+          echo "Nested target provisioning complete." >&2
         NESTED_SETUP
-        then
-          :
-        else
-          echo "Nested target provisioning failed; see the errors above." >&2
+        if [ "${setup_rc}" -ne 0 ]; then
+          echo "Nested target provisioning failed (rc=${setup_rc}); see the errors above." >&2
           podman exec "${TARGET_NAME}" journalctl --no-pager -n 200 >&2 || true
           exit 1
         fi


### PR DESCRIPTION
Follow-up to #607.

After #607 fixed the `/etc/group` corruption, the lanes still failed — but now
*after* the nested script had actually completed. The journal dump showed GDM
started and a Wayland session for `bluefin-test` was created, yet the outer
script still took the failure branch and printed only
`Nested target provisioning failed`.

The heredoc was being consumed inside an `if ! podman exec ... <<'NESTED_SETUP'`
compound command. Replaced with an explicit exit-status capture, and made the
final `systemctl start gdm` fail loudly (rc + `systemctl status gdm --full`)
instead of being the silent last statement of the block.

## Proof

One-off probe workflow `probe-nested-setup-6xr8s` (submitted as a standalone
Workflow so no template was applied out of band) using this exact template:

```
275: Provisioning nested target (groups, test user, GDM, Python deps)...
276: Installing test-only Python dependencies in nested target...
282: Starting GDM in nested target...
283: Nested target provisioning complete.
291: Waiting for GNOME Shell AT-SPI to start...
     headless: Version of qecore installed: '4.18'.
     headless: Running 'wayland' with desktop 'gnome'
     headless: Started the script with PID 2292.
```

The lane now reaches behave execution. The remaining failure is test content,
not lab infrastructure.

## Validation

- `just lint` — clean.
- `yaml.safe_load` + `bash -n` on the outer and extracted nested scripts — OK.
- Live probe workflow as above.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI