### PR TITLE
fix(bst): idempotent atomic bootc patch; suspend failing dakota poller

### DIFF
--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -567,20 +567,32 @@ spec:
             build-commands:
             - |
               python3 - <<'PY'
-              import hashlib, os
+              import os
               from pathlib import Path
-              print("RE-DIAG cwd:", os.getcwd())
-              print("RE-DIAG dir:", sorted(x.name for x in Path('.').iterdir())[:40])
               p = Path("Makefile")
               t = p.read_text()
-              print("RE-DIAG Makefile sha256:", hashlib.sha256(t.encode()).hexdigest(), "len:", len(t))
               old = ".PHONY: manpages\nmanpages:\n\tcargo run --release --package xtask -- manpages\n"
               new = ".PHONY: manpages\nmanpages:\n\t@true\n"
-              if old not in t:
+              if new in t:
+                  # The bb_worker native file pool hardlinks input-root files;
+                  # an in-place write through a hardlink poisons the pooled
+                  # blob for every later action. A previous run's truncate-
+                  # write already mutated this file, so treat the neutralized
+                  # target as success.
+                  print("bootc manpages target already neutralized; skipping")
+              elif old in t:
+                  # Atomic replace: never mutate the hardlinked input file in
+                  # place (that corrupts the worker file pool).
+                  tmp = p.with_name(".Makefile.patch-tmp")
+                  tmp.write_text(t.replace(old, new, 1))
+                  os.replace(tmp, p)
+              else:
+                  import hashlib
                   i = t.find("manpages")
+                  print("RE-DIAG cwd:", os.getcwd())
+                  print("RE-DIAG Makefile sha256:", hashlib.sha256(t.encode()).hexdigest(), "len:", len(t))
                   print("RE-DIAG manpages context:", repr(t[max(0, i - 120):i + 200]))
                   raise SystemExit("bootc Makefile layout changed unexpectedly")
-              p.write_text(t.replace(old, new, 1))
               PY
             - make PREFIX="/usr"
 

--- a/manifests/dakota-commit-poller.yaml
+++ b/manifests/dakota-commit-poller.yaml
@@ -8,7 +8,10 @@ metadata:
     app.kubernetes.io/component: commit-poller
     app.kubernetes.io/part-of: bluefin-test-suite
 spec:
-  suspend: false
+  # Suspended 2026-08-07: the poller was fire-and-forget failing every 5 min
+  # on the red distributed lane and its runs steal the bst-build semaphore
+  # from supervised validation runs. Re-enable after the lane is green again.
+  suspend: true
   schedules:
     - "2-59/5 * * * *"
   timezone: "UTC"


### PR DESCRIPTION
## Summary

Two distributed-lane repairs diagnosed live on the cluster today:

1. **bootc.bst repeating Makefile assert failure** — the bb_worker native file pool hardlinks input-root files; the manpage patch's truncate-in-place `write_text()` mutated the pooled blob, so every later action staged an already-patched Makefile and failed its own assert. Patch is now idempotent (accept already-neutralized) and atomic (temp + `os.replace`), with RE-DIAG output retained for the mismatch case.
2. **dakota-commit-poller suspended** — it was fire-and-forget failing every 5 min on the red lane and stealing the `bst-build` semaphore from supervised validation runs. Re-enable once the lane is green.

Note: this branch is based on main which already carries the gaming-lane + RE-DIAG template changes.

## Verification

- Worker file pools wiped on ghost + exo-0, DaemonSet rolled, supervised 4-lane pipeline running with the patch live (kubectl-applied).
- [ ] I am using an agent and I take responsibility for this PR

Assisted-by: Kimi K3 via GitHub Copilot