### PR TITLE
fix: allow zot to cache kagent images

### DIFF
--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -69,6 +69,7 @@ data:
                 { "prefix": "flatcar/*", "destination": "/ghcr" },
                 { "prefix": "frostyard/*", "destination": "/ghcr" },
                 { "prefix": "ggml-org/*", "destination": "/ghcr" },
+                { "prefix": "kagent-dev/*", "destination": "/ghcr" },
                 { "prefix": "kubestellar/*", "destination": "/ghcr" },
                 { "prefix": "project-zot/*", "destination": "/ghcr" },
                 { "prefix": "projectbluefin/*", "destination": "/ghcr" },
@@ -173,7 +174,7 @@ spec:
         app: zot-cache
         app.kubernetes.io/part-of: lab
       annotations:
-        lab.projectbluefin.io/config-version: sync-policy-v2
+        lab.projectbluefin.io/config-version: sync-policy-v3
     spec:
       automountServiceAccountToken: false
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
## Summary
- Add kagent-dev/* to the GHCR zot sync policy
- Bump the zot config-version annotation so the DaemonSet reloads the config

## Validation
- just lint

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>