### PR TITLE
fix: complete kagent image and database rollout

### DIFF
--- a/manifests/kagent-apps.yaml
+++ b/manifests/kagent-apps.yaml
@@ -75,6 +75,15 @@ spec:
                 repository: chainguard
                 name: postgres
                 tag: latest
+              # Chainguard's postgres user is uid/gid 70, unlike the chart's
+              # default Alpine postgres assumption of 999.
+              podSecurityContext:
+                fsGroup: 70
+                runAsUser: 70
+                runAsGroup: 70
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
         # Keep the install to the core k8s agent. The lab has no Grafana, and
         # querydoc would otherwise require a separate OpenAI key.
         grafana-mcp:

--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -69,7 +69,7 @@ data:
                 { "prefix": "flatcar/*", "destination": "/ghcr" },
                 { "prefix": "frostyard/*", "destination": "/ghcr" },
                 { "prefix": "ggml-org/*", "destination": "/ghcr" },
-                { "prefix": "kagent-dev/*", "destination": "/ghcr" },
+                { "prefix": "kagent-dev/**", "destination": "/ghcr" },
                 { "prefix": "kubestellar/*", "destination": "/ghcr" },
                 { "prefix": "project-zot/*", "destination": "/ghcr" },
                 { "prefix": "projectbluefin/*", "destination": "/ghcr" },
@@ -174,7 +174,7 @@ spec:
         app: zot-cache
         app.kubernetes.io/part-of: lab
       annotations:
-        lab.projectbluefin.io/config-version: sync-policy-v3
+        lab.projectbluefin.io/config-version: sync-policy-v4
     spec:
       automountServiceAccountToken: false
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
## Summary
- Use a recursive zot sync prefix for nested kagent-dev GHCR repositories
- Run the Chainguard PostgreSQL image as its built-in uid/gid 70

## Validation
- helm template kagent 0.9.12 with committed values
- podman smoke test of cgr.dev/chainguard/postgres as uid/gid 70
- just lint

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>