### PR TITLE
fix: give local kagent model a placeholder key

### DIFF
--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -56,8 +56,10 @@ metadata:
 Applications: `kagent-crds` in sync wave 0, then `kagent` in wave 1. The
 default `ModelConfig` uses the lab's OpenAI-compatible llm-d endpoint
 (`http://llm-d-modelserver.llm-d.svc.cluster.local:8000/v1`, model
-`local-llm`) with no API key. Keep the UI ClusterIP-only; do not expose another
-general-purpose dashboard.
+`local-llm`). The endpoint itself is unauthenticated, but the ADK OpenAI client
+requires an API key environment variable, so the chart installs the non-secret
+placeholder `sk-local-noauth` as `kagent-openai`. Keep the UI ClusterIP-only; do
+not expose another general-purpose dashboard.
 
 Install-specific traps from the first rollout:
 

--- a/manifests/kagent-apps.yaml
+++ b/manifests/kagent-apps.yaml
@@ -58,13 +58,15 @@ spec:
           image:
             registry: ghcr.io
         # Default to the lab's local OpenAI-compatible llama.cpp endpoint. The
-        # service does not require an API key, so leave the secret refs empty.
+        # service does not require authentication, but the ADK OpenAI client
+        # requires an API key env var, so install a non-secret placeholder.
         providers:
           default: openAI
           openAI:
             model: local-llm
-            apiKeySecretRef: ""
-            apiKeySecretKey: ""
+            apiKey: sk-local-noauth
+            apiKeySecretRef: kagent-openai
+            apiKeySecretKey: OPENAI_API_KEY
             config:
               baseUrl: http://llm-d-modelserver.llm-d.svc.cluster.local:8000/v1
         database:


### PR DESCRIPTION
## Summary
- Configure kagent's local llm-d ModelConfig with a non-secret placeholder OPENAI_API_KEY
- Document why the unauthenticated local endpoint still needs the placeholder

## Validation
- helm template kagent 0.9.12 confirms the generated Secret and ModelConfig
- just lint

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>