### PR TITLE
feat: register GitHub MCP server with kagent

### DIFF
--- a/manifests/kagent-github-mcp.yaml
+++ b/manifests/kagent-github-mcp.yaml
@@ -1,0 +1,21 @@
+# GitHub hosted MCP server for kagent. The Authorization header value is stored
+# out-of-band in the github-mcp-castrojo Secret; never commit the token.
+apiVersion: kagent.dev/v1alpha2
+kind: RemoteMCPServer
+metadata:
+  name: github-castrojo
+  namespace: kagent
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: lab
+spec:
+  description: GitHub MCP server authenticated as castrojo
+  protocol: STREAMABLE_HTTP
+  url: https://api.githubcopilot.com/mcp/
+  headersFrom:
+    - name: Authorization
+      valueFrom:
+        type: Secret
+        name: github-mcp-castrojo
+        key: AUTHORIZATION


### PR DESCRIPTION
## Summary
- Register GitHub's hosted MCP endpoint as a kagent RemoteMCPServer
- Read the Authorization header from the uncommitted github-mcp-castrojo secret

## Validation
- Verified the current GitHub token against https://api.githubcopilot.com/mcp/ without printing it
- just lint

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>