### PR TITLE
feat(pr-poller): test every PR on the lab for all image repos

### DIFF
--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -216,13 +216,23 @@ spec:
               -o /dev/null
           }
 
-          # Repos tested on every PR — no label required. Bluefin, Bluefin LTS,
-          # and Dakota testing lanes are intentionally daily-only; an operator
-          # can still opt an individual PR in with the test-on-lab label below.
+          # Repos tested on every PR — no label required. Every product with a
+          # per-PR lane below is listed here: the dispatcher already carries the
+          # image, suite, reporter, and BST settings for each, so a missing entry
+          # only meant the run waited on someone hand-applying test-on-lab.
+          # The label pass below still works for repos that are not listed.
+          #
+          # Throughput is bounded by the existing throttles, not by this list:
+          # MAX_DISPATCH caps dispatches per poll, one workflow per head SHA is
+          # deduped, a newer push stops the superseded run, and dakota's BST lane
+          # refuses to start a third concurrent build.
           AUTO_REPOS=(
            "projectbluefin/common"
            "projectbluefin/knuckle"
            "projectbluefin/testsuite"
+           "projectbluefin/bluefin"
+           "projectbluefin/bluefin-lts"
+           "projectbluefin/dakota"
           )
 
           dispatch_pr() {


### PR DESCRIPTION
## What

Adds `bluefin`, `bluefin-lts`, and `dakota` to `AUTO_REPOS` in `pr-poller`.

## Why this is three lines

`dispatch_pr` already carries a complete per-PR lane for all three — image, tag, suites, reporter, and for dakota `BST_WORKLOAD=true` plus its two-concurrent-build gate. None of it was reachable automatically: the repos were absent from `AUTO_REPOS`, so a run only happened when someone hand-applied `test-on-lab`.

The label pass is unchanged and still covers repos with no lane of their own.

## No throttle is removed

- `MAX_DISPATCH` still caps dispatches per poll
- workflows are still deduped on head SHA
- a newer push still stops the superseded run
- dakota still refuses a third concurrent BST build

Nightly lanes are untouched — they verify *promoted* images, which is a different question from verifying a proposed change.

## Expected burst

38 open PRs become eligible (bluefin 8, bluefin-lts 18, dakota 12; 9 are bot PRs). At ~3 concurrent workflows of ~20 min, roughly 4 hours to drain, then steady state.

## Verification

- `kubectl apply --dry-run=server` — clean
- `kubectl diff` — only the comment and the 3 repos
- embedded 652-line script passes `bash -n`
- `just lint` — 33 fan-out templates, semaphore topology OK
- `tests/unit/test_pr_poller_reaper.py` — 10/10

The full unit suite has 8 failures in `test_build_metrics`, `test_page_dataset_collector`, `test_recc_runner_seam`, and `test_zot_cache_policy`. They reproduce identically on clean `main`, so they are pre-existing and unrelated.