### PR TITLE
revert(pr-poller): stop auto-dispatching bluefin, lts, and dakota

### DIFF
--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -216,23 +216,16 @@ spec:
               -o /dev/null
           }
 
-          # Repos tested on every PR — no label required. Every product with a
-          # per-PR lane below is listed here: the dispatcher already carries the
-          # image, suite, reporter, and BST settings for each, so a missing entry
-          # only meant the run waited on someone hand-applying test-on-lab.
-          # The label pass below still works for repos that are not listed.
-          #
-          # Throughput is bounded by the existing throttles, not by this list:
-          # MAX_DISPATCH caps dispatches per poll, one workflow per head SHA is
-          # deduped, a newer push stops the superseded run, and dakota's BST lane
-          # refuses to start a third concurrent build.
+          # Repos tested on every PR — no label required. Bluefin, Bluefin LTS,
+          # and Dakota are deliberately NOT here: the container QA lane they
+          # would use fails 100% of the time today, so auto-dispatching them
+          # only paints failing ghost-lab statuses on every open pull request.
+          # Restore them once a lane is observed passing end to end. An
+          # operator can still opt an individual PR in with test-on-lab.
           AUTO_REPOS=(
            "projectbluefin/common"
            "projectbluefin/knuckle"
            "projectbluefin/testsuite"
-           "projectbluefin/bluefin"
-           "projectbluefin/bluefin-lts"
-           "projectbluefin/dakota"
           )
 
           dispatch_pr() {


### PR DESCRIPTION
Reverts the AUTO_REPOS half of #630.

The container QA lane these dispatch into fails 100% of the time — 44 consecutive runs, zero passes. Auto-dispatching three more repositories into it only paints a failing `ghost-lab` status on every open PR, which inflates the review queue it was meant to drain.

#619 (uinput + `setuptools<81`) and #618 (dconf TOCTOU) fix the two known causes and are live on the cluster, but no lane has been observed passing end to end yet. Restore these repos once one has.

`test-on-lab` still opts an individual PR in.

Verified: `just lint` passes, embedded script passes `bash -n`.