### PR TITLE
chore(lab): cut uplink bandwidth — upstream digest polls, suspend unreviewed crons

### DIFF
--- a/argo/workflow-templates/image-poller.yaml
+++ b/argo/workflow-templates/image-poller.yaml
@@ -160,29 +160,30 @@ spec:
           limits:
             cpu: 500m
             memory: 256Mi
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
         source: |
           set -eu
           IMAGE_REF="{{inputs.parameters.image}}:{{inputs.parameters.image-tag}}"
-          zot_image() {
-            case "$1" in
-              ghcr.io/*) printf '192.168.1.102:30501/ghcr/%s' "${1#ghcr.io/}" ;;
-              quay.io/*) printf '192.168.1.102:30501/quay/%s' "${1#quay.io/}" ;;
-              docker.io/*) printf '192.168.1.102:30501/docker/%s' "${1#docker.io/}" ;;
-              registry.fedoraproject.org/*) printf '192.168.1.102:30501/fedora/%s' "${1#registry.fedoraproject.org/}" ;;
-              registry.k8s.io/*) printf '192.168.1.102:30501/k8s/%s' "${1#registry.k8s.io/}" ;;
-              cgr.dev/*) printf '192.168.1.102:30501/cgr/%s' "${1#cgr.dev/}" ;;
-              public.ecr.aws/*) printf '192.168.1.102:30501/ecr/%s' "${1#public.ecr.aws/}" ;;
-              lscr.io/*) printf '192.168.1.102:30501/lscr/%s' "${1#lscr.io/}" ;;
-              *) printf '%s' "$1" ;;
-            esac
-          }
-          ZOT_IMAGE_REF=$(zot_image "${IMAGE_REF}")
+          # Inspect upstream directly, NOT through the zot cache: zot on-demand
+          # sync copies the manifest AND all blobs on a tag reference, so polling
+          # through zot pulled every new multi-GB image even when QA was skipped.
+          # A direct inspect fetches the manifest only (kilobytes).
+          CREDS_ARGS=()
+          case "${IMAGE_REF}" in
+            ghcr.io/*) CREDS_ARGS=(--creds "_token:${GITHUB_TOKEN}") ;;
+          esac
           REMOTE=""
           for i in 1 2 3; do
-            REMOTE=$(timeout 60s skopeo inspect --tls-verify=false --no-tags \
-              --format '{{.Digest}}' "docker://${ZOT_IMAGE_REF}" 2>/dev/null || true)
+            REMOTE=$(timeout 60s skopeo inspect --no-tags \
+              --format '{{.Digest}}' "${CREDS_ARGS[@]}" \
+              "docker://${IMAGE_REF}" 2>/dev/null || true)
             [ -n "${REMOTE}" ] && break
-            echo "Zot skopeo attempt ${i}/3 failed for ${IMAGE_REF}; retrying in $(( i * 15 ))s" >&2
+            echo "skopeo attempt ${i}/3 failed for ${IMAGE_REF}; retrying in $(( i * 15 ))s" >&2
             sleep $(( i * 15 ))
           done
 

--- a/manifests/cosmic-commit-poller.yaml
+++ b/manifests/cosmic-commit-poller.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/component: commit-poller
     app.kubernetes.io/part-of: bluefin-test-suite
 spec:
-  suspend: false
+  # Suspended 2026-08: cosmic (RazorfinOS-org) is not a reviewed product and
+  # cold BST builds are the suspected ~1 TiB/day spike driver. Dakota/bluefin
+  # PR testing builds its own images via pr-poller and is unaffected.
+  # On-demand: `just force-dakota-poll` pattern / argo submit --from.
+  suspend: true
   schedules:
     - "4-59/5 * * * *"
   timezone: "UTC"

--- a/manifests/image-poll-akmods-44.yaml
+++ b/manifests/image-poll-akmods-44.yaml
@@ -13,6 +13,10 @@ metadata:
     bluefin.io/trigger: digest-poll
     bluefin.io/role: base-image-watcher
 spec:
+  # Suspended 2026-08 together with the aurora lanes (their base-image digests
+  # are no longer consumed while aurora QA is dark). Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-akmods-44 -n argo`.
+  suspend: true
   schedules:
     - "25 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-aurora-main.yaml
+++ b/manifests/image-poll-aurora-main.yaml
@@ -9,7 +9,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  # Suspended 2026-08: aurora is a third-party lane not under review; QA fired
+  # on every upstream digest change. Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-aurora-main -n argo`.
+  suspend: true
   schedules:
     - "22 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-aurora-stable.yaml
+++ b/manifests/image-poll-aurora-stable.yaml
@@ -10,7 +10,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  # Suspended 2026-08: aurora is a third-party lane not under review; QA fired
+  # on every upstream digest change. Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-aurora-stable -n argo`.
+  suspend: true
   schedules:
     - "27 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-aurora-testing.yaml
+++ b/manifests/image-poll-aurora-testing.yaml
@@ -11,7 +11,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  # Suspended 2026-08: aurora is a third-party lane not under review; QA fired
+  # on every upstream digest change. Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-aurora-testing -n argo`.
+  suspend: true
   schedules:
     - "20 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-bluefin-main.yaml
+++ b/manifests/image-poll-bluefin-main.yaml
@@ -9,7 +9,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  # Suspended 2026-08: tracks ublue-os/bluefin (third-party rebuild lane) not
+  # under review; QA fired on every digest change. Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-bluefin-main -n argo`.
+  suspend: true
   schedules:
     - "12 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-fedora-bootc-latest.yaml
+++ b/manifests/image-poll-fedora-bootc-latest.yaml
@@ -9,7 +9,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  # Suspended 2026-08: unreviewed lane; QA fired on every upstream digest
+  # change. Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-fedora-bootc-latest -n argo`.
+  suspend: true
   schedules:
     - "10 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-fedora-bootc-rawhide.yaml
+++ b/manifests/image-poll-fedora-bootc-rawhide.yaml
@@ -9,7 +9,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  # Suspended 2026-08: unreviewed lane; QA fired on every upstream digest
+  # change. Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-fedora-bootc-rawhide -n argo`.
+  suspend: true
   schedules:
     - "42 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-kinoite-44.yaml
+++ b/manifests/image-poll-kinoite-44.yaml
@@ -12,6 +12,10 @@ metadata:
     bluefin.io/trigger: digest-poll
     bluefin.io/role: base-image-watcher
 spec:
+  # Suspended 2026-08 together with the aurora lanes (their base-image digests
+  # are no longer consumed while aurora QA is dark). Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-kinoite-44 -n argo`.
+  suspend: true
   schedules:
     - "50 */3 * * *"
   timezone: "UTC"

--- a/manifests/image-poll-snosi-latest.yaml
+++ b/manifests/image-poll-snosi-latest.yaml
@@ -10,7 +10,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  # Suspended 2026-08: unreviewed lane; QA fired on every upstream digest
+  # change. Submit on demand via
+  # `argo submit --from cronworkflow/image-poll-snosi-latest -n argo`.
+  suspend: true
   schedules:
     - "30 */3 * * *"
   timezone: "UTC"

--- a/manifests/nightly-kde.yaml
+++ b/manifests/nightly-kde.yaml
@@ -11,7 +11,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: lab
 spec:
-  suspend: false
+  # Suspended 2026-08: aurora VM QA suspended together with the aurora
+  # pollers (third-party lane not under review). Submit on demand via
+  # `argo submit --from cronworkflow/nightly-kde -n argo`.
+  suspend: true
   schedules:
     - "0 4 * * *"
   timezone: "UTC"

--- a/manifests/nightly-knuckle.yaml
+++ b/manifests/nightly-knuckle.yaml
@@ -9,7 +9,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: lab
 spec:
-  suspend: false
+  # Suspended 2026-08: nightly ISO build + VM boot for an unreviewed lane.
+  # Submit on demand via
+  # `argo submit --from cronworkflow/nightly-knuckle -n argo`.
+  suspend: true
   schedules:
     - "30 3 * * *"
   timezone: "UTC"

--- a/manifests/nightly-smoke-lts-stable.yaml
+++ b/manifests/nightly-smoke-lts-stable.yaml
@@ -8,7 +8,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: lab
 spec:
-  suspend: false
+  # Suspended 2026-08: stable lane changes rarely and is not under burst
+  # review. Submit on demand via
+  # `argo submit --from cronworkflow/nightly-smoke-lts-stable -n argo`.
+  suspend: true
   schedules:
     - "30 3 * * *"
   timezone: "UTC"

--- a/manifests/nightly-smoke-stable.yaml
+++ b/manifests/nightly-smoke-stable.yaml
@@ -8,7 +8,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: lab
 spec:
-  suspend: false
+  # Suspended 2026-08: stable lane changes rarely and is not under burst
+  # review. Submit on demand via
+  # `argo submit --from cronworkflow/nightly-smoke-stable -n argo`.
+  suspend: true
   schedules:
     - "0 3 * * *"
   timezone: "UTC"

--- a/manifests/qa-run-reconciler.yaml
+++ b/manifests/qa-run-reconciler.yaml
@@ -42,7 +42,7 @@ metadata:
       public-safe QA-run evidence contract.
 spec:
   schedules:
-    - "*/5 * * * *"
+    - "*/10 * * * *"
   timezone: UTC
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 120

--- a/tests/unit/test_bst_poller_admission.py
+++ b/tests/unit/test_bst_poller_admission.py
@@ -10,7 +10,12 @@ def load(path):
     return yaml.safe_load((ROOT / path).read_text(encoding="utf-8"))
 
 
-def test_shared_bst_pollers_are_enabled_and_staggered():
+def test_shared_bst_pollers_are_suspended_but_staggered_for_on_demand():
+    # Both commit pollers stay suspended: dakota since #609 (failing poller),
+    # cosmic since the 2026-08 bandwidth cuts (unreviewed lane whose cold BST
+    # builds drove ~1 TiB/day uplink spikes). Files and staggered schedules are
+    # kept so `argo submit --from cronworkflow/<name>-commit-poller` and
+    # `just force-dakota-poll` remain the on-demand escape hatch.
     template = load("argo/workflow-templates/bst-commit-poller.yaml")
     templates = {item["name"]: item for item in template["spec"]["templates"]}
 
@@ -34,7 +39,7 @@ def test_shared_bst_pollers_are_enabled_and_staggered():
         ("cosmic", "4-59/5 * * * *", "poll-cosmic"),
     ):
         cron = load(f"manifests/{name}-commit-poller.yaml")
-        assert cron["spec"]["suspend"] is False
+        assert cron["spec"]["suspend"] is True
         assert cron["spec"]["schedules"] == [schedule]
         assert cron["spec"]["concurrencyPolicy"] == "Forbid"
         assert cron["spec"]["workflowSpec"]["entrypoint"] == entrypoint

--- a/tests/unit/test_image_poll_bandwidth.py
+++ b/tests/unit/test_image_poll_bandwidth.py
@@ -33,6 +33,17 @@ def test_image_poller_serializes_each_state_key():
     assert mutexes == [{"name": "image-poll-{{workflow.parameters.state-key}}"}]
 
 
+def test_image_poller_inspects_upstream_not_zot():
+    # Polling through the zot cache on a tag reference triggers zot on-demand
+    # sync, which copies the full image (manifest + blobs) into the cache on
+    # every new digest even when QA is skipped. The poller must inspect the
+    # upstream registry directly so a poll costs kilobytes, not gigabytes.
+    source = (ROOT / "argo/workflow-templates/image-poller.yaml").read_text()
+    assert "30501" not in source
+    assert "zot_image" not in source
+    assert "github-token" in source  # ghcr.io inspects need --creds _token:...
+
+
 def test_container_runner_preserves_digest_pinning_and_has_no_extra_closer():
     source = (ROOT / "argo/workflow-templates/run-container-tests.yaml").read_text()
     assert 'TARGET_IMAGE="${IMAGE_REPO}@${IMAGE_DIGEST}"' in source


### PR DESCRIPTION
## Why

Bandwidth audit (Prometheus, enp191s0): baseline ~170–225 GiB/day inbound, spiking to ~1 TiB on 2 of the last 5 days. Zot is an on-demand pull-through cache, so external bytes ≈ one pull per new digest — the cut is "stop pulling digests nobody asked for." On-demand dakota/bluefin PR testing is fully preserved.

## Root cause found during review

`image-poller` resolved digests **through zot by tag**. Zot on-demand sync copies manifest **+ all blobs** on a tag reference, so every 10-minute poll across 12 lanes pulled each new multi-GB image even when `run-qa=false`. The poller now inspects upstream directly (manifest only, kilobytes), with `--creds _token:` for ghcr.io — same pattern as `image-poll-akmods-44.yaml`.

## Changes

- **image-poller.yaml**: direct upstream `skopeo inspect`; regression test asserts no `30501`/`zot_image` in the poller
- **Suspended** (`suspend: true`, files kept for tests/dashboard + on-demand `argo submit --from cronworkflow/<name>`):
  - image-poll-aurora-{main,stable,testing}, akmods-44, kinoite-44, snosi-latest, fedora-bootc-{latest,rawhide}, bluefin-main
  - nightly-kde (whole aurora/KDE cluster goes dark together)
  - nightly-smoke-stable, nightly-smoke-lts-stable, nightly-knuckle
  - cosmic-commit-poller (dakota-commit-poller already suspended in #609; test updated to the suspended-but-staggered on-demand contract)
- **qa-run-reconciler** `*/5` → `*/10` (evidence export only); pr-label-poller stays at `*/5` per the documented 5-minute on-demand PR contract
- **Kept**: nightly-smoke + nightly-dakota (only automated QA for the reviewed `:testing` lanes), all PR-triggered dakota/bluefin paths

## Validation

- `just lint` ✅
- `pytest tests/unit/`: 357 passed; the 7 remaining failures are pre-existing on clean main (zot metrics, page datasets, recc) — baseline had 8 including the BST poller test this PR fixes

## Follow-up

Re-measure with `scripts/traffic_report.py` after a day; the baseline should collapse from the poller fix alone. If dakota BST build cache is cold after the gap, the first on-demand dakota PR build will be a warm-up pull (accepted per burst-tolerance requirement).