### PR TITLE
docs: record 2026-08 bandwidth cuts, enforce common doc structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ ArgoCD, KubeVirt, and the manifests that run the lab test cluster.
 ## Start here
 
 1. Read this file.
-2. Find the skill for the area you need in [`docs/skills/README.md`](docs/skills/README.md)
-   and load only that skill.
+2. Find the skill for the area you need in [`docs/SKILL.md`](docs/SKILL.md)
+   (the skill router, same convention as `projectbluefin/common`) and load
+   only that skill.
 3. For deterministic commands, check the [`Justfile`](Justfile) or
    [`docs/reference/agent-cheatsheet.md`](docs/reference/agent-cheatsheet.md).
 4. For operational failure modes, read [`docs/ops/RUNBOOK.md`](docs/ops/RUNBOOK.md).
@@ -58,7 +59,7 @@ npm ci && npm run build
 
 | Task | Where to go |
 |---|---|
-| Which skill should I load? | [`docs/skills/README.md`](docs/skills/README.md) |
+| Which skill should I load? | [`docs/SKILL.md`](docs/SKILL.md) |
 | Authoring Argo workflow templates (YAML) | [`docs/skills/argo-workflows/SKILL.md`](docs/skills/argo-workflows/SKILL.md) |
 | KubeVirt VM provisioning / boot failures | [`docs/skills/kubevirt-vms/SKILL.md`](docs/skills/kubevirt-vms/SKILL.md) |
 | ArgoCD sync, GitOps rules, bootstrap vs managed | [`docs/skills/gitops-argocd/SKILL.md`](docs/skills/gitops-argocd/SKILL.md) |

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -270,6 +270,10 @@ filed issue.
 
 ### `nightly-kde`
 
+> **Suspended 2026-08** (bandwidth cuts, PR #632) together with the aurora
+> image-poll lanes. Submit on demand with
+> `argo submit --from cronworkflow/nightly-kde -n argo`.
+
 The `nightly-kde` CronWorkflow schedules the `aurora-qa-pipeline` at 04:00 UTC.
 The schedule is only a trigger: the pipeline's `aurora-vm-qa` key in the
 GitOps-managed `workflow-semaphores` ConfigMap is the serialization guard, so

--- a/docs/reference/agent-cheatsheet.md
+++ b/docs/reference/agent-cheatsheet.md
@@ -271,6 +271,12 @@ argo submit -n argo --from cronworkflow/orphan-vm-cleanup
 | `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` (`lts-testing`) |
 | `orphan-vm-cleanup` | every 30 min | Clean orphan test VMs |
 
+Suspended since the 2026-08 bandwidth cuts (PR #632) but runnable on demand via
+`argo submit -n argo --from cronworkflow/<name>`: `nightly-smoke-stable`,
+`nightly-smoke-lts-stable`, `nightly-knuckle`, `nightly-kde`, the aurora /
+snosi / fedora-bootc / bluefin-main image pollers, and both BST commit pollers.
+Full list: `docs/reference/workflow-reference.md`.
+
 Any patch that must survive beyond a short debug session also needs a matching git change under `manifests/`.
 
 ---

--- a/docs/reference/bluefin-integration.md
+++ b/docs/reference/bluefin-integration.md
@@ -74,19 +74,21 @@ Flatcar OS substrate tests. Not part of the Bluefin image pipelines; runs via
 The Bluefin and Bluefin-LTS image-poll CronWorkflows run every 10 minutes at
 staggered offsets (`:00`, `:02`, `:04`, and `:06`) and call the generic
 `image-poller` WorkflowTemplate. Dakota's `image-poll-dakota` CronWorkflow runs
-at `:08` and owns a small check-and-trigger DAG that calls the Dakota pipeline.
-Each poll run:
+at `:08` with `run-qa=false`: it tracks the Dakota testing digest for freshness
+only, and daily QA comes from `nightly-dakota` at 03:00 UTC. Each poll run:
 
-1. Pulls the current digest for the target image from ghcr.io
+1. Resolves the current digest for the target image by inspecting the upstream
+   registry directly (never through the zot cache — a tag read triggers zot
+   on-demand sync of the full image; see PR #632)
 2. Reads the last-known digest from `image-polling-digests` in namespace `argo`
 3. If digests match: exits cleanly (no test run)
-4. If the digest changed: submits `bluefin-qa-pipeline` for Bluefin/LTS or
-   `dakota-qa-pipeline` for Dakota; each fans out `run-container-tests`
+4. If the digest changed: submits `bluefin-qa-pipeline` for Bluefin/LTS
+   (Dakota tracks only); each fans out `run-container-tests`
 5. Each selected suite attempts to publish its structured results back into this repo
 6. The generic Bluefin/LTS `image-poller` persists its new digest only after the
    downstream workflow succeeds
 
-This means a changed Bluefin, Bluefin-LTS, or Dakota digest triggers
+This means a changed Bluefin or Bluefin-LTS digest triggers
 container-only validation within 10 minutes, automatically, with no human action.
 
 ---
@@ -168,6 +170,7 @@ To force a run outside `AUTO_REPOS`: add the `test-on-lab` label to a PR in the
 
 Dakota runs through `dakota-qa-pipeline` rather than `bluefin-qa-pipeline`, but
 the QA lane uses the same container-only fan-out through `run-container-tests`.
-BuildStream artifact builds remain separate in `dakota-build-pipeline`; the active
-`image-poll-dakota` lane tests the resulting `:testing` image. Dakota PRs can also
+BuildStream artifact builds remain separate in `dakota-build-pipeline`; the
+`image-poll-dakota` lane tracks the resulting `:testing` digest (`run-qa=false`)
+and `nightly-dakota` at 03:00 UTC runs the daily QA. Dakota PRs can also
 use the `test-on-lab` label via the PR label poller.

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -193,15 +193,15 @@ must fail for repair; it must not use an Ethernet, local, or cache-only fallback
 
 | CronWorkflow | Interval | Triggers | Keeps warm |
 | --- | --- | --- | --- |
-| `dakota-commit-poller` | every 5 min at minute +2 | shared `bst-commit-poller` → `dakota-build-pipeline` when `dakota:testing` changes | Dakota BuildStream cache/execution path |
-| `cosmic-commit-poller` | every 5 min at minute +4 | shared `bst-commit-poller` → `cosmic-build-pipeline` when `cosmic-build-meta:main` changes | Cosmic BuildStream cache/execution path |
+| `dakota-commit-poller` | **suspended** (was every 5 min at minute +2) | shared `bst-commit-poller` → `dakota-build-pipeline` when `dakota:testing` changes | Dakota BuildStream cache/execution path; on-demand via `just force-dakota-poll` |
+| `cosmic-commit-poller` | **suspended** 2026-08 (was every 5 min at minute +4) | shared `bst-commit-poller` → `cosmic-build-pipeline` when `cosmic-build-meta:main` changes | Cosmic BuildStream cache/execution path; on-demand via `argo submit --from cronworkflow/cosmic-commit-poller` |
 | `image-poll-bluefin-testing` | every 10 min at :00 | `image-poller` when `ghcr.io/projectbluefin/bluefin:testing` changes | Bluefin container-only QA (`smoke`) |
 | `image-poll-lts-testing` | every 10 min at :02 | `image-poller` when `ghcr.io/projectbluefin/bluefin-lts:testing` changes | Bluefin-LTS container-only QA (`smoke`) |
 | `image-poll-bluefin-stable` | every 10 min at :04 | `image-poller` when `ghcr.io/projectbluefin/bluefin:stable` changes | Bluefin container-only QA (full suite) |
 | `image-poll-lts-stable` | every 10 min at :06 | `image-poller` when `ghcr.io/projectbluefin/bluefin-lts:stable` changes | Bluefin-LTS container-only QA (full suite) |
 | `image-poll-dakota` | every 10 min at :08 | custom digest DAG with `run-qa=false` | Dakota testing digest freshness; daily QA runs at 03:00 UTC |
-| `image-poll-bluefin-main` | every 3h at :12 | `image-poller` when `ghcr.io/ublue-os/bluefin:latest` changes | Bluefin latest container-only QA (full suite) |
-| `image-poll-snosi-latest` | every 3h at :30 | `image-poller` when `ghcr.io/frostyard/snow:latest` changes | Snosi GNOME desktop image coverage |
+| `image-poll-bluefin-main` | **suspended** 2026-08 (was every 3h at :12) | `image-poller` when `ghcr.io/ublue-os/bluefin:latest` changes | Bluefin latest container-only QA (full suite) |
+| `image-poll-snosi-latest` | **suspended** 2026-08 (was every 3h at :30) | `image-poller` when `ghcr.io/frostyard/snow:latest` changes | Snosi GNOME desktop image coverage |
 | `flatcar-kernel-poller` | 10 min | `flatcar-kernel-build` when kernel.org's latest stable version changes | Flatcar kernel build cache |
 | `flatcar-kernel-gate` | 30 min | (gate/promotion check, see `/docs/skills/flatcar-node-onboarding/SKILL.md`) | N/A |
 
@@ -239,16 +239,33 @@ until `run-pipeline.Succeeded`. If the digest is written before QA passes, the
 poller will treat the image as already seen and silently skip the failed lane on
 the next cycle.
 
+**Bandwidth contract (PR #632):** `image-poller` resolves digests by inspecting
+the **upstream registry directly** — never through the zot cache. Zot on-demand
+sync copies manifest + all blobs on a tag read, so polling through zot pulled
+every new multi-GB image even when QA was skipped. The regression test in
+`tests/unit/test_image_poll_bandwidth.py` enforces this.
+
+**Suspended in the 2026-08 bandwidth cuts** (files kept; run on demand with
+`argo submit --from cronworkflow/<name> -n argo`): `image-poll-aurora-main`,
+`image-poll-aurora-stable`, `image-poll-aurora-testing`, `image-poll-akmods-44`,
+`image-poll-kinoite-44`, `image-poll-snosi-latest`,
+`image-poll-fedora-bootc-latest`, `image-poll-fedora-bootc-rawhide`,
+`image-poll-bluefin-main`, `nightly-kde`, `nightly-knuckle`,
+`nightly-smoke-stable`, `nightly-smoke-lts-stable`, `dakota-commit-poller`,
+`cosmic-commit-poller`. Unreviewed lanes go dark together: the aurora pollers,
+their akmods/kinoite base-image watchers, and `nightly-kde` are one group — do
+not resume a member without the others.
+
 ## Nightly Schedule
 
 | CronWorkflow | Time (UTC) | Pipeline | Parameters |
 | --- | --- | --- | --- |
 | `nightly-smoke` | 02:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin` |
-| `nightly-smoke-stable` | 03:00 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=stable`, `suites=smoke`, `variant=bluefin` |
+| `nightly-smoke-stable` | **suspended** 2026-08 (was 03:00) | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin`, `image-tag=stable`, `suites=smoke`, `variant=bluefin` |
 | `nightly-smoke-lts` | 02:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=bluefin-lts` |
-| `nightly-smoke-lts-stable` | 03:30 | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=stable`, `suites=smoke`, `variant=bluefin-lts` |
+| `nightly-smoke-lts-stable` | **suspended** 2026-08 (was 03:30) | `bluefin-qa-pipeline` | `image=ghcr.io/projectbluefin/bluefin-lts`, `image-tag=stable`, `suites=smoke`, `variant=bluefin-lts` |
 | `nightly-dakota` | 03:00 | `dakota-qa-pipeline` | `image=ghcr.io/projectbluefin/dakota`, `image-tag=testing`, `suites=smoke,developer,system`, `variant=dakota` |
-| `nightly-knuckle` | 03:30 | `knuckle-qa-pipeline` | `branch=main`, `namespace=knuckle-test`, `suite=smoke`, `tests-branch=main` |
+| `nightly-knuckle` | **suspended** 2026-08 (was 03:30) | `knuckle-qa-pipeline` | `branch=main`, `namespace=knuckle-test`, `suite=smoke`, `tests-branch=main` |
 
 ## Priority Classes
 

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -488,7 +488,8 @@ kubectl patch workflow <name> -n argo -p '{"spec":{"shutdown":"Stop"}}' --type=m
 
 **Dakota lanes and the mutex:** keep the lanes separate.
 - `dakota-commit-poller` → `bst-commit-poller` → `dakota-build-pipeline`
-  (BuildStream publish lane) is expected to run.
+  (BuildStream publish lane) is suspended by default (#609); drive it on demand
+  with `just force-dakota-poll`.
 - `image-poll-dakota` → `dakota-qa-pipeline` is the active container-only QA lane.
 If mutex contention appears, stop stale failed workflows holding `ghost-heavy-compute`; do not
 blanket-stop all Dakota build-publish runs or suspend the active QA poller.

--- a/docs/skills/gitops-argocd/SKILL.md
+++ b/docs/skills/gitops-argocd/SKILL.md
@@ -242,9 +242,11 @@ Commit and push. ArgoCD sets the CronWorkflow's suspend flag and stops schedulin
 
 **Suspend vs delete:** temporarily broken → suspend. Permanently abandoned → delete the file; ArgoCD prune removes the CronWorkflow.
 
-**Currently suspended:** `image-poll-dakota` (the QA poller that triggers
-`dakota-qa-pipeline`). Keep this suspended while the QA lane still requires
-`bootc install to-disk` on a dakota image without UKI support.
+**Currently suspended:** see the full list in
+[`docs/reference/workflow-reference.md`](../../reference/workflow-reference.md#cache-warming-pollers)
+("Suspended in the 2026-08 bandwidth cuts"). Notable: `dakota-commit-poller`
+(suspended in #609 while the QA lane still requires `bootc install to-disk` on a
+dakota image without UKI support) and the aurora/KDE cron cluster.
 
 ### 9. Taking GitOps ownership of unmanaged Deployments/Services
 

--- a/scripts/validate-docs.py
+++ b/scripts/validate-docs.py
@@ -93,6 +93,29 @@ def find_forbidden(files: set[Path]) -> list[str]:
     return hits
 
 
+def validate_router() -> list[str]:
+    """Enforce the projectbluefin/common doc structure: AGENTS.md routes to
+    docs/SKILL.md (the skill router), which indexes every skill."""
+    errors: list[str] = []
+    router = ROOT / "docs" / "SKILL.md"
+    if not router.exists():
+        return ["docs/SKILL.md: missing skill router (common doc structure)"]
+    text = router.read_text(encoding="utf-8")
+    for section in ("Read order", "Skill index"):
+        if f"## {section}" not in text:
+            errors.append(f"docs/SKILL.md: missing '## {section}' section")
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    if "docs/SKILL.md" not in agents:
+        errors.append("AGENTS.md: must route skill discovery to docs/SKILL.md")
+    for skill in skills():
+        rel = skill.relative_to(router.parent)
+        if rel.parts[0].startswith("_") or any(part.startswith("_") for part in rel.parts):
+            continue  # underscore-prefixed dirs are templates, not live skills
+        if f"]({rel})" not in text:
+            errors.append(f"docs/SKILL.md: skill index does not list {rel}")
+    return errors
+
+
 def main() -> int:
     errors: list[str] = []
     warnings: list[str] = []
@@ -112,6 +135,7 @@ def main() -> int:
                                 for _ in [0] if len(p.read_text(encoding="utf-8").splitlines()) > REFERENCE_MAX_LINES)
 
     errors.extend(validate_links(files))
+    errors.extend(validate_router())
     warnings.extend(find_forbidden(files))
 
     if warnings:


### PR DESCRIPTION
Documentation sweep after PR #632: cron tables and skill files now reflect which crons are suspended and why, the image-poller upstream-inspect bandwidth contract is recorded, and stale dakota-poller claims are fixed. Also aligns AGENTS.md skill routing with the projectbluefin/common convention (docs/SKILL.md as router) and extends scripts/validate-docs.py (CI-enforced via docs.yml) to keep the router structure intact: missing router, missing Read order/Skill index sections, AGENTS.md not linking it, or an unindexed skill now fail validation. Validator passes locally.