### PR TITLE
feat(qa): add ChairLift Homebrew container lane

### DIFF
--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -169,7 +169,21 @@ spec:
             ;;
         esac
 
-        trap 'kubectl delete pod "${TARGET_POD}" -n "{{workflow.namespace}}" --ignore-not-found --wait=false' EXIT
+        # activeDeadlineSeconds expiry and `argo terminate` both reach this
+        # runner as a signal, and an untrapped SIGTERM kills bash without ever
+        # running the EXIT trap — the target Pod would then survive until
+        # owner-reference GC, holding this node's 8Gi/4CPU reservation. Trap
+        # TERM and INT as well and exit from the handler so the deadline path
+        # deletes the Pod promptly. Deleting twice is harmless because
+        # --ignore-not-found makes the delete idempotent.
+        cleanup_target() {
+          kubectl delete pod "${TARGET_POD}" -n "{{workflow.namespace}}" \
+            --ignore-not-found --wait=false || true
+        }
+        trap cleanup_target EXIT
+        trap 'cleanup_target; exit 143' TERM
+        trap 'cleanup_target; exit 130' INT
+
         kubectl wait --for=condition=Ready "pod/${TARGET_POD}" \
           -n "{{workflow.namespace}}" --timeout=600s
 
@@ -348,24 +362,54 @@ spec:
 
         if [[ "${SUITE}" == "homebrew" ]]; then
           # brew-preinstall.service is WantedBy=graphical-session.target with
-          # Restart=on-failure, RestartSec=30, and StartLimitBurst=3, so the
-          # session qecore just started may already have run it, failed, and
-          # rate-limited it. Report that first — the real failure must not be
-          # swallowed — then clear the state so the suite's own explicit start
-          # reports the unit's actual error instead of "start request repeated
-          # too quickly". Use the runtime directory the lane validated: it is
-          # the manager the suite talks to, and a mismatch here is the session
-          # split rule 8 warns about, so say so out loud.
+          # Type=oneshot, RemainAfterExit=true, Restart=on-failure,
+          # RestartSec=30, and StartLimitBurst=3, so the session qecore just
+          # started may already have run it. Report whatever state it is in
+          # first — the real failure must not be swallowed — then put the unit
+          # back to a clean inactive state so the suite's own explicit start
+          # reports the unit's actual error. Use the runtime directory the lane
+          # validated: it is the manager the suite talks to, and a mismatch here
+          # is the session split rule 8 warns about, so say so out loud.
           if [[ "${XDG_RUNTIME_DIR:-}" != "${RUNTIME_DIR}" ]]; then
             echo "warning: session XDG_RUNTIME_DIR='${XDG_RUNTIME_DIR:-}' differs from the lane's '${RUNTIME_DIR}'" >&2
           fi
-          if [[ "$(env XDG_RUNTIME_DIR="${RUNTIME_DIR}" systemctl --user is-failed brew-preinstall.service || true)" == "failed" ]]; then
-            echo "brew-preinstall.service was already failed before behave started it:" >&2
+          BREW_PREINSTALL_STATE=$(env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+            systemctl --user show brew-preinstall.service \
+            --property=ActiveState --value 2>/dev/null || true)
+          BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}
+          # `failed` is only half the race: between attempts Restart=on-failure
+          # parks the unit in `activating (auto-restart)`, where it is neither
+          # failed nor idle, so is-failed says nothing and reset-failed clears
+          # nothing. Anything that is not a settled inactive/active is worth a
+          # status dump before it is cleared away.
+          if [[ "${BREW_PREINSTALL_STATE}" != "inactive" \
+            && "${BREW_PREINSTALL_STATE}" != "active" ]]; then
+            echo "brew-preinstall.service was ${BREW_PREINSTALL_STATE} before behave started it:" >&2
             env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
               systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
           fi
+          # Stop before reset-failed: stopping cancels a queued auto-restart
+          # job (reset-failed does not), and with RemainAfterExit=true it also
+          # clears a stale `active` left by the session's own run so the suite's
+          # start actually executes the unit instead of being a no-op.
+          BREW_PREINSTALL_STOP_RC=0
           env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
-            systemctl --user reset-failed brew-preinstall.service || true
+            systemctl --user stop brew-preinstall.service || BREW_PREINSTALL_STOP_RC=$?
+          if [[ "${BREW_PREINSTALL_STOP_RC}" -ne 0 ]]; then
+            echo "warning: stopping brew-preinstall.service before behave exited ${BREW_PREINSTALL_STOP_RC} (state was ${BREW_PREINSTALL_STATE}); a queued auto-restart may still race the suite's explicit start" >&2
+            env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+              systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
+          fi
+          # Now clear the failure state and the start-limit counter. Never
+          # after the suite's start: that would hide real failures.
+          BREW_PREINSTALL_RESET_RC=0
+          env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+            systemctl --user reset-failed brew-preinstall.service || BREW_PREINSTALL_RESET_RC=$?
+          if [[ "${BREW_PREINSTALL_RESET_RC}" -ne 0 ]]; then
+            echo "warning: reset-failed brew-preinstall.service exited ${BREW_PREINSTALL_RESET_RC} (state was ${BREW_PREINSTALL_STATE}); the suite may report a stale start limit instead of the real error" >&2
+            env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+              systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
+          fi
         fi
 
         BEHAVE_RC=0

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -578,8 +578,11 @@ spec:
           cat /workspace/results.json > /tmp/results/results.json
 
         BEHAVE_RC=$(cat /tmp/results/behave-rc.txt)
-        python3 - <<'PY'
+        SUMMARY_RC=0
+        python3 - <<'PY' || SUMMARY_RC=$?
         import json
+        import os
+        import sys
 
         with open("/tmp/results/results.json", encoding="utf-8") as result_file:
             data = json.load(result_file)
@@ -589,9 +592,30 @@ spec:
         )
         total = sum(len(feature.get("elements", [])) for feature in data)
         print(f"{total - failed}/{total} scenarios passed")
+
+        # behave exits 0 when --tags matches nothing, so a typo in behave-tags
+        # ("@chairlfit", "@chairlift_casks") produced "0/0 scenarios passed"
+        # and a green lane that validated nothing. Targeted tag runs are
+        # exactly what this lane is for, so refuse the empty result. Every
+        # other precondition in this runner fails closed; this was the last
+        # place it could still report a false green.
+        if total == 0:
+            sys.exit(
+                "no scenarios ran (suite="
+                f"{os.environ.get('SUITE', '')!r}, behave-tags="
+                f"{os.environ.get('BEHAVE_TAGS', '')!r}); behave exits 0 when "
+                "--tags matches nothing, so this is not a passing run"
+            )
         PY
 
+        # Ranked so a real failure still reports its own cause: qecore's
+        # session errors first, then behave's own verdict, and only then the
+        # empty-run refusal, which is the only one that can fire when both of
+        # those are 0.
         if [[ "${QECORE_RC}" -ne 0 ]]; then
           exit "${QECORE_RC}"
         fi
-        exit "${BEHAVE_RC}"
+        if [[ "${BEHAVE_RC}" -ne 0 ]]; then
+          exit "${BEHAVE_RC}"
+        fi
+        exit "${SUMMARY_RC}"

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -123,11 +123,17 @@ spec:
     # Pod Ready incl. bootc image pull <=600s (the kubectl wait timeout),
     # systemd reaching a usable state <=120s, clone + pip install ~300s,
     # brew-setup.service unpacking and chowning the Homebrew prefix ~300s,
-    # user manager + GDM/qecore session ~360s, brew-preinstall.service pulling
-    # casks over the network with Restart=on-failure/StartLimitBurst=3 ~900s,
-    # and 15 Ptyxis/dogtail-driven scenarios at ~180s each ~2700s => ~89min
-    # before any node contention. Every other suite finishes far inside this;
-    # the deadline is a hang guard, not a budget.
+    # user manager + GDM/qecore session ~360s, one network cask install ~900s,
+    # and 15 Ptyxis/dogtail-driven scenarios at ~180s each ~2700s => ~88min
+    # before any node contention. The cask install is budgeted once, not once
+    # per restart attempt: brew-preinstall is content-addressed, so whichever
+    # run does the work — the session's own in-flight run, which run-behave.sh
+    # waits out for at most BREW_PREINSTALL_WAIT_SECONDS (the same 900s),
+    # or the suite's explicit start — leaves the other exiting early on the
+    # unchanged Brewfile hash. The one path that pays the 900s twice is an
+    # in-flight run that fails after being waited out and is then redone by
+    # the suite; that still lands ~17min inside this deadline. Every other
+    # suite finishes far inside it; the deadline is a hang guard, not a budget.
     activeDeadlineSeconds: 7200
     inputs:
       parameters:
@@ -364,41 +370,89 @@ spec:
           # brew-preinstall.service is WantedBy=graphical-session.target with
           # Type=oneshot, RemainAfterExit=true, Restart=on-failure,
           # RestartSec=30, and StartLimitBurst=3, so the session qecore just
-          # started may already have run it. Report whatever state it is in
-          # first — the real failure must not be swallowed — then put the unit
-          # back to a clean inactive state so the suite's own explicit start
-          # reports the unit's actual error. Use the runtime directory the lane
-          # validated: it is the manager the suite talks to, and a mismatch here
-          # is the session split rule 8 warns about, so say so out loud.
+          # started may already have finished it, be running it right now, or
+          # be sitting between retries. Settle whichever of those it is before
+          # behave's explicit start, using the runtime directory the lane
+          # validated: it is the manager the suite talks to, and a mismatch
+          # here is the session split rule 8 warns about, so say so out loud.
           if [[ "${XDG_RUNTIME_DIR:-}" != "${RUNTIME_DIR}" ]]; then
             echo "warning: session XDG_RUNTIME_DIR='${XDG_RUNTIME_DIR:-}' differs from the lane's '${RUNTIME_DIR}'" >&2
           fi
-          BREW_PREINSTALL_STATE=$(env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
-            systemctl --user show brew-preinstall.service \
-            --property=ActiveState --value 2>/dev/null || true)
-          BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}
-          # `failed` is only half the race: between attempts Restart=on-failure
-          # parks the unit in `activating (auto-restart)`, where it is neither
-          # failed nor idle, so is-failed says nothing and reset-failed clears
-          # nothing. Anything that is not a settled inactive/active is worth a
-          # status dump before it is cleared away.
-          if [[ "${BREW_PREINSTALL_STATE}" != "inactive" \
-            && "${BREW_PREINSTALL_STATE}" != "active" ]]; then
-            echo "brew-preinstall.service was ${BREW_PREINSTALL_STATE} before behave started it:" >&2
+          # The activeDeadlineSeconds budget pays for one network cask install.
+          # Spend it waiting for an in-flight one rather than killing it and
+          # repeating the download; the cap keeps a wedged install bounded.
+          BREW_PREINSTALL_WAIT_SECONDS=900
+          BREW_PREINSTALL_POLL_SECONDS=10
+          brew_preinstall_property() {
+            env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+              systemctl --user show brew-preinstall.service \
+              --property="$1" --value 2>/dev/null || true
+          }
+          brew_preinstall_status() {
             env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
               systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
+          }
+          BREW_PREINSTALL_STATE=$(brew_preinstall_property ActiveState)
+          BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}
+          BREW_PREINSTALL_SUBSTATE=$(brew_preinstall_property SubState)
+          BREW_PREINSTALL_SUBSTATE=${BREW_PREINSTALL_SUBSTATE:-unknown}
+          # ActiveState=activating covers two opposite situations and only
+          # SubState tells them apart. `start` is a healthy run in flight —
+          # the session's own cask install, already paying the network cost
+          # budgeted above — so killing it discards that work and hands the
+          # suite a half-applied prefix. `auto-restart` (`auto-restart-queued`
+          # on systemd >= 254) is the RestartSec gap after a failure, holding
+          # a queued restart job that reset-failed does not cancel and that
+          # would otherwise race the suite's own start. Wait out the first,
+          # cancel the second.
+          if [[ "${BREW_PREINSTALL_STATE}" == "activating" \
+            && "${BREW_PREINSTALL_SUBSTATE}" != auto-restart* ]]; then
+            echo "brew-preinstall.service is activating (${BREW_PREINSTALL_SUBSTATE}); waiting up to ${BREW_PREINSTALL_WAIT_SECONDS}s for the in-flight run instead of killing it" >&2
+            BREW_PREINSTALL_WAITED=0
+            while [[ "${BREW_PREINSTALL_WAITED}" -lt "${BREW_PREINSTALL_WAIT_SECONDS}" ]]; do
+              sleep "${BREW_PREINSTALL_POLL_SECONDS}"
+              BREW_PREINSTALL_WAITED=$((BREW_PREINSTALL_WAITED + BREW_PREINSTALL_POLL_SECONDS))
+              BREW_PREINSTALL_STATE=$(brew_preinstall_property ActiveState)
+              BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}
+              BREW_PREINSTALL_SUBSTATE=$(brew_preinstall_property SubState)
+              BREW_PREINSTALL_SUBSTATE=${BREW_PREINSTALL_SUBSTATE:-unknown}
+              if [[ "${BREW_PREINSTALL_STATE}" != "activating" \
+                || "${BREW_PREINSTALL_SUBSTATE}" == auto-restart* ]]; then
+                break
+              fi
+            done
+            echo "brew-preinstall.service is ${BREW_PREINSTALL_STATE} (${BREW_PREINSTALL_SUBSTATE}) after waiting ${BREW_PREINSTALL_WAITED}s" >&2
+          fi
+          if [[ "${BREW_PREINSTALL_STATE}" == "inactive" \
+            || "${BREW_PREINSTALL_STATE}" == "active" ]]; then
+            # The two settled states, but `inactive` is also what a unit that
+            # never ran looks like: brew-preinstall.service carries
+            # ConditionUser=!@system and ConditionPathExists=<brew binary>, and
+            # a condition-skipped start exits 0, as does a start of a unit that
+            # is not installed at all. Print LoadState and ConditionResult so a
+            # missing or skipped unit is visible instead of passing for a clean
+            # slate that the suite's start will then silently succeed against.
+            echo "brew-preinstall.service is ${BREW_PREINSTALL_STATE} (${BREW_PREINSTALL_SUBSTATE}, LoadState=$(brew_preinstall_property LoadState), ConditionResult=$(brew_preinstall_property ConditionResult)) before behave started it" >&2
+          else
+            # failed, the auto-restart gap, or an activating run that outlasted
+            # the wait above: dump the real failure before the stop clears it.
+            echo "brew-preinstall.service was ${BREW_PREINSTALL_STATE} (${BREW_PREINSTALL_SUBSTATE}) before behave started it:" >&2
+            brew_preinstall_status
           fi
           # Stop before reset-failed: stopping cancels a queued auto-restart
           # job (reset-failed does not), and with RemainAfterExit=true it also
-          # clears a stale `active` left by the session's own run so the suite's
-          # start actually executes the unit instead of being a no-op.
+          # clears a latched `active` so behave's start runs the unit instead
+          # of returning success from that latch. What that re-run re-covers is
+          # the unit's start path, not the install: brew-preinstall is
+          # content-addressed, so after a successful run it exits early on the
+          # unchanged Brewfile hash. After a failed run nothing was recorded,
+          # so the re-run does the real work and reports the real error.
           BREW_PREINSTALL_STOP_RC=0
           env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
             systemctl --user stop brew-preinstall.service || BREW_PREINSTALL_STOP_RC=$?
           if [[ "${BREW_PREINSTALL_STOP_RC}" -ne 0 ]]; then
-            echo "warning: stopping brew-preinstall.service before behave exited ${BREW_PREINSTALL_STOP_RC} (state was ${BREW_PREINSTALL_STATE}); a queued auto-restart may still race the suite's explicit start" >&2
-            env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
-              systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
+            echo "warning: stopping brew-preinstall.service before behave exited ${BREW_PREINSTALL_STOP_RC} (state was ${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE}); a queued auto-restart may still race the suite's explicit start" >&2
+            brew_preinstall_status
           fi
           # Now clear the failure state and the start-limit counter. Never
           # after the suite's start: that would hide real failures.
@@ -406,9 +460,8 @@ spec:
           env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
             systemctl --user reset-failed brew-preinstall.service || BREW_PREINSTALL_RESET_RC=$?
           if [[ "${BREW_PREINSTALL_RESET_RC}" -ne 0 ]]; then
-            echo "warning: reset-failed brew-preinstall.service exited ${BREW_PREINSTALL_RESET_RC} (state was ${BREW_PREINSTALL_STATE}); the suite may report a stale start limit instead of the real error" >&2
-            env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
-              systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
+            echo "warning: reset-failed brew-preinstall.service exited ${BREW_PREINSTALL_RESET_RC} (state was ${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE}); the suite may report a stale start limit instead of the real error" >&2
+            brew_preinstall_status
           fi
         fi
 

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -119,7 +119,16 @@ spec:
             emptyDir: {}
 
   - name: run-tests
-    activeDeadlineSeconds: 3600
+    # 2h, sized for the slowest lane (suite=homebrew) rather than the fastest:
+    # Pod Ready incl. bootc image pull <=600s (the kubectl wait timeout),
+    # systemd reaching a usable state <=120s, clone + pip install ~300s,
+    # brew-setup.service unpacking and chowning the Homebrew prefix ~300s,
+    # user manager + GDM/qecore session ~360s, brew-preinstall.service pulling
+    # casks over the network with Restart=on-failure/StartLimitBurst=3 ~900s,
+    # and 15 Ptyxis/dogtail-driven scenarios at ~180s each ~2700s => ~89min
+    # before any node contention. Every other suite finishes far inside this;
+    # the deadline is a hang guard, not a budget.
+    activeDeadlineSeconds: 7200
     inputs:
       parameters:
       - name: target-pod
@@ -215,49 +224,104 @@ spec:
         chown -R 1000:1000 /home/bluefin-test
 
         if [[ "${SUITE}" == "homebrew" ]]; then
+          report_user_manager_failure() {
+            echo "$1" >&2
+            systemctl status --no-pager --full user@1000.service >&2 || true
+            loginctl show-user bluefin-test >&2 || true
+          }
+
           # brew-setup.service ships enabled and carries
           # ConditionPathExists=!/etc/.linuxbrew, so once it has run systemd
           # *skips* it and `start` still exits 0. Only the binary proves the
-          # prefix was provisioned; the suite fails on the same path.
+          # prefix was provisioned, so capture the start result instead of
+          # letting `set -e` end the run before that gate can report anything.
           systemctl unmask --runtime brew-setup.service
-          systemctl start brew-setup.service
+          BREW_SETUP_RC=0
+          systemctl start brew-setup.service || BREW_SETUP_RC=$?
           if [[ ! -x /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
-            echo "brew-setup.service left no brew at /var/home/linuxbrew/.linuxbrew/bin/brew" >&2
+            echo "brew-setup.service left no brew at /var/home/linuxbrew/.linuxbrew/bin/brew (systemctl start exit ${BREW_SETUP_RC})" >&2
             systemctl status --no-pager --full brew-setup.service >&2 || true
+            journalctl --no-pager --unit brew-setup.service >&2 || true
             exit 1
+          fi
+          if [[ "${BREW_SETUP_RC}" -ne 0 ]]; then
+            echo "brew-setup.service start exited ${BREW_SETUP_RC} but the prefix is provisioned; continuing on the binary gate" >&2
+            systemctl status --no-pager --full brew-setup.service >&2 || true
           fi
 
           # brew-preinstall.service is a *user* unit, so the suite needs a live
           # user manager. Lingering makes logind create the user object, its
           # runtime directory, and user@1000.service; the session bus follows
-          # from that manager's dbus.socket (ListenStream=%t/bus).
-          loginctl enable-linger bluefin-test
-          systemctl start user@1000.service
-          RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value)
+          # from that manager's dbus.socket (ListenStream=%t/bus). Each step is
+          # captured rather than fatal on its own so the sockets below stay the
+          # authoritative gate and every exit carries diagnostics.
+          LINGER_RC=0
+          loginctl enable-linger bluefin-test || LINGER_RC=$?
+          USER_MANAGER_RC=0
+          systemctl start user@1000.service || USER_MANAGER_RC=$?
+          RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value 2>/dev/null || true)
           if [[ -z "${RUNTIME_DIR}" ]]; then
-            echo "logind assigned no runtime directory to bluefin-test" >&2
+            report_user_manager_failure "logind assigned no runtime directory to bluefin-test (enable-linger exit ${LINGER_RC}, user@1000.service start exit ${USER_MANAGER_RC})"
             exit 1
           fi
+          DBUS_SOCKET_RC=0
           runuser -u bluefin-test -- env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
-            systemctl --user start dbus.socket
+            systemctl --user start dbus.socket || DBUS_SOCKET_RC=$?
           # The two lookups the lane owns must agree: `systemctl --user` reaches
           # the manager over local transport at ${XDG_RUNTIME_DIR}/systemd/private,
           # while qecore/dogtail reach the session and a11y bus over the absolute
           # DBUS_SESSION_BUS_ADDRESS/AT_SPI_BUS_ADDRESS below. Both are derived
           # from this directory, so assert it carries both sockets before behave.
-          test -S "${RUNTIME_DIR}/systemd/private"
-          test -S "${RUNTIME_DIR}/bus"
+          if [[ ! -S "${RUNTIME_DIR}/systemd/private" ]]; then
+            report_user_manager_failure "user@1000.service exposed no control socket at ${RUNTIME_DIR}/systemd/private (start exit ${USER_MANAGER_RC}); systemctl --user cannot reach the manager"
+            exit 1
+          fi
+          if [[ ! -S "${RUNTIME_DIR}/bus" ]]; then
+            report_user_manager_failure "the bluefin-test user manager exposed no session bus at ${RUNTIME_DIR}/bus (dbus.socket start exit ${DBUS_SOCKET_RC}); qecore and dogtail would have no a11y bus"
+            exit 1
+          fi
+
+          # Hand the validated directory to the runner and the suite through the
+          # same durable /workspace contract the suite inputs already use, so
+          # nothing downstream asks logind a second time and acts on an answer
+          # that was never checked against these two sockets.
+          printf '%s\n' "${RUNTIME_DIR}" >/workspace/qa-runtime-dir
         fi
         TARGET_SETUP
 
         kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
           test -x /usr/libexec/gnome-ponytail-daemon
+
+        # Every suite but homebrew keeps the runner-created
+        # /home/bluefin-test/run. The homebrew lane instead uses the directory
+        # logind assigned to the user manager started above, and derives both
+        # bus addresses from it: `systemctl --user` (which the suite calls to
+        # start brew-preinstall.service) resolves the manager through
+        # XDG_RUNTIME_DIR and ignores the bus variables, while qecore/dogtail
+        # use the bus variables and ignore XDG_RUNTIME_DIR. Moving one without
+        # the other yields an unreachable manager or a dead a11y bus. Read the
+        # directory TARGET_SETUP validated and persisted; do not re-query
+        # logind, whose answer would be unvalidated and could differ.
+        RUNTIME_DIR=/home/bluefin-test/run
+        if [[ "${SUITE}" == "homebrew" ]]; then
+          RUNTIME_DIR=$(kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
+            cat /workspace/qa-runtime-dir 2>/dev/null | tr -d '\r\n' || true)
+          if [[ -z "${RUNTIME_DIR}" ]]; then
+            echo "TARGET_SETUP persisted no user-manager runtime directory at /workspace/qa-runtime-dir" >&2
+            kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
+              loginctl show-user bluefin-test >&2 || true
+            exit 1
+          fi
+          echo "homebrew lane: user manager and session bus rooted at ${RUNTIME_DIR}"
+        fi
+
         kubectl exec -i -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
-          env SUITE="${SUITE}" BEHAVE_TAGS="${BEHAVE_TAGS}" bash -s <<'TARGET_SUITE'
+          env SUITE="${SUITE}" BEHAVE_TAGS="${BEHAVE_TAGS}" RUNTIME_DIR="${RUNTIME_DIR}" bash -s <<'TARGET_SUITE'
         set -euo pipefail
         mkdir -p /workspace/results
         chown 1000:1000 /workspace/results
-        printf 'SUITE=%q\nBEHAVE_TAGS=%q\n' "${SUITE}" "${BEHAVE_TAGS}" \
+        printf 'SUITE=%q\nBEHAVE_TAGS=%q\nRUNTIME_DIR=%q\n' \
+          "${SUITE}" "${BEHAVE_TAGS}" "${RUNTIME_DIR}" \
           >/workspace/qa-suite.env
         cat >/workspace/run-behave.sh <<'RUN_BEHAVE'
         #!/bin/bash
@@ -282,6 +346,28 @@ spec:
           TAGS_ARG="${BEHAVE_TAGS}"
         fi
 
+        if [[ "${SUITE}" == "homebrew" ]]; then
+          # brew-preinstall.service is WantedBy=graphical-session.target with
+          # Restart=on-failure, RestartSec=30, and StartLimitBurst=3, so the
+          # session qecore just started may already have run it, failed, and
+          # rate-limited it. Report that first — the real failure must not be
+          # swallowed — then clear the state so the suite's own explicit start
+          # reports the unit's actual error instead of "start request repeated
+          # too quickly". Use the runtime directory the lane validated: it is
+          # the manager the suite talks to, and a mismatch here is the session
+          # split rule 8 warns about, so say so out loud.
+          if [[ "${XDG_RUNTIME_DIR:-}" != "${RUNTIME_DIR}" ]]; then
+            echo "warning: session XDG_RUNTIME_DIR='${XDG_RUNTIME_DIR:-}' differs from the lane's '${RUNTIME_DIR}'" >&2
+          fi
+          if [[ "$(env XDG_RUNTIME_DIR="${RUNTIME_DIR}" systemctl --user is-failed brew-preinstall.service || true)" == "failed" ]]; then
+            echo "brew-preinstall.service was already failed before behave started it:" >&2
+            env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+              systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
+          fi
+          env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+            systemctl --user reset-failed brew-preinstall.service || true
+        fi
+
         BEHAVE_RC=0
         python3 -m behave "/workspace/testsuite/tests/${SUITE}/features/" \
           --format json.pretty \
@@ -294,25 +380,6 @@ spec:
         TARGET_SUITE
 
         mkdir -p /tmp/results
-        # Every suite but homebrew keeps the runner-created
-        # /home/bluefin-test/run. The homebrew lane instead uses the directory
-        # logind assigned to the user manager started above, and derives both
-        # bus addresses from it: `systemctl --user` (which the suite calls to
-        # start brew-preinstall.service) resolves the manager through
-        # XDG_RUNTIME_DIR and ignores the bus variables, while qecore/dogtail
-        # use the bus variables and ignore XDG_RUNTIME_DIR. Moving one without
-        # the other yields an unreachable manager or a dead a11y bus.
-        RUNTIME_DIR=/home/bluefin-test/run
-        if [[ "${SUITE}" == "homebrew" ]]; then
-          RUNTIME_DIR=$(kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
-            loginctl show-user bluefin-test --property=RuntimePath --value | tr -d '\r\n')
-          if [[ -z "${RUNTIME_DIR}" ]]; then
-            echo "Could not read the runtime directory of the bluefin-test user manager" >&2
-            exit 1
-          fi
-          echo "homebrew lane: user manager and session bus rooted at ${RUNTIME_DIR}"
-        fi
-
         QECORE_RC=0
         kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
           runuser -u bluefin-test -- env \

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -8,7 +8,8 @@ metadata:
       Runs desktop BDD suites against a scheduler-managed, privileged bootc OCI
       Pod with systemd as PID 1. The target Pod is owned by the Workflow and is
       deleted by the runner on every exit; no virtual machine or disk artifact
-      is created.
+      is created. The `homebrew` suite additionally provisions Homebrew and a
+      systemd user manager in the target before qecore starts.
   labels:
     app.kubernetes.io/component: test-runner
     app.kubernetes.io/part-of: bluefin-test-suite
@@ -152,7 +153,7 @@ spec:
       source: |
         set -euo pipefail
         case "${SUITE}" in
-          smoke|common|developer|software|system) ;;
+          smoke|common|developer|software|system|homebrew) ;;
           *)
             echo "Unsupported container suite: ${SUITE}" >&2
             exit 2
@@ -188,7 +189,7 @@ spec:
           tee /workspace/resolv.conf < /etc/resolv.conf
 
         kubectl exec -i -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
-          env TSREPO="${TSREPO}" TSBRANCH="${TSBRANCH}" bash -s <<'TARGET_SETUP'
+          env TSREPO="${TSREPO}" TSBRANCH="${TSBRANCH}" SUITE="${SUITE}" bash -s <<'TARGET_SETUP'
         set -euo pipefail
         rm -f /etc/resolv.conf
         install -m 0644 /workspace/resolv.conf /etc/resolv.conf
@@ -212,6 +213,41 @@ spec:
         echo "bluefin-test ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/bluefin-test
         chmod 0440 /etc/sudoers.d/bluefin-test
         chown -R 1000:1000 /home/bluefin-test
+
+        if [[ "${SUITE}" == "homebrew" ]]; then
+          # brew-setup.service ships enabled and carries
+          # ConditionPathExists=!/etc/.linuxbrew, so once it has run systemd
+          # *skips* it and `start` still exits 0. Only the binary proves the
+          # prefix was provisioned; the suite fails on the same path.
+          systemctl unmask --runtime brew-setup.service
+          systemctl start brew-setup.service
+          if [[ ! -x /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
+            echo "brew-setup.service left no brew at /var/home/linuxbrew/.linuxbrew/bin/brew" >&2
+            systemctl status --no-pager --full brew-setup.service >&2 || true
+            exit 1
+          fi
+
+          # brew-preinstall.service is a *user* unit, so the suite needs a live
+          # user manager. Lingering makes logind create the user object, its
+          # runtime directory, and user@1000.service; the session bus follows
+          # from that manager's dbus.socket (ListenStream=%t/bus).
+          loginctl enable-linger bluefin-test
+          systemctl start user@1000.service
+          RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value)
+          if [[ -z "${RUNTIME_DIR}" ]]; then
+            echo "logind assigned no runtime directory to bluefin-test" >&2
+            exit 1
+          fi
+          runuser -u bluefin-test -- env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+            systemctl --user start dbus.socket
+          # The two lookups the lane owns must agree: `systemctl --user` reaches
+          # the manager over local transport at ${XDG_RUNTIME_DIR}/systemd/private,
+          # while qecore/dogtail reach the session and a11y bus over the absolute
+          # DBUS_SESSION_BUS_ADDRESS/AT_SPI_BUS_ADDRESS below. Both are derived
+          # from this directory, so assert it carries both sockets before behave.
+          test -S "${RUNTIME_DIR}/systemd/private"
+          test -S "${RUNTIME_DIR}/bus"
+        fi
         TARGET_SETUP
 
         kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
@@ -230,7 +266,7 @@ spec:
         export PYTHONPATH="/workspace/testsuite"
 
         case "${SUITE}" in
-          smoke|common|developer|software|system) ;;
+          smoke|common|developer|software|system|homebrew) ;;
           *)
             echo "Unsupported container suite: ${SUITE}" >&2
             exit 2
@@ -258,15 +294,34 @@ spec:
         TARGET_SUITE
 
         mkdir -p /tmp/results
+        # Every suite but homebrew keeps the runner-created
+        # /home/bluefin-test/run. The homebrew lane instead uses the directory
+        # logind assigned to the user manager started above, and derives both
+        # bus addresses from it: `systemctl --user` (which the suite calls to
+        # start brew-preinstall.service) resolves the manager through
+        # XDG_RUNTIME_DIR and ignores the bus variables, while qecore/dogtail
+        # use the bus variables and ignore XDG_RUNTIME_DIR. Moving one without
+        # the other yields an unreachable manager or a dead a11y bus.
+        RUNTIME_DIR=/home/bluefin-test/run
+        if [[ "${SUITE}" == "homebrew" ]]; then
+          RUNTIME_DIR=$(kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
+            loginctl show-user bluefin-test --property=RuntimePath --value | tr -d '\r\n')
+          if [[ -z "${RUNTIME_DIR}" ]]; then
+            echo "Could not read the runtime directory of the bluefin-test user manager" >&2
+            exit 1
+          fi
+          echo "homebrew lane: user manager and session bus rooted at ${RUNTIME_DIR}"
+        fi
+
         QECORE_RC=0
         kubectl exec -n "{{workflow.namespace}}" "${TARGET_POD}" -- \
           runuser -u bluefin-test -- env \
             SUITE="${SUITE}" \
             BEHAVE_TAGS="${BEHAVE_TAGS}" \
             HOME=/home/bluefin-test \
-            XDG_RUNTIME_DIR=/home/bluefin-test/run \
-            DBUS_SESSION_BUS_ADDRESS=unix:path=/home/bluefin-test/run/bus \
-            AT_SPI_BUS_ADDRESS=unix:path=/home/bluefin-test/run/bus \
+            XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+            DBUS_SESSION_BUS_ADDRESS="unix:path=${RUNTIME_DIR}/bus" \
+            AT_SPI_BUS_ADDRESS="unix:path=${RUNTIME_DIR}/bus" \
             XDG_SESSION_TYPE=wayland \
             XDG_SESSION_DESKTOP=gnome \
             LIBGL_ALWAYS_SOFTWARE=1 \

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -119,21 +119,36 @@ spec:
             emptyDir: {}
 
   - name: run-tests
-    # 2h, sized for the slowest lane (suite=homebrew) rather than the fastest:
-    # Pod Ready incl. bootc image pull <=600s (the kubectl wait timeout),
-    # systemd reaching a usable state <=120s, clone + pip install ~300s,
-    # brew-setup.service unpacking and chowning the Homebrew prefix ~300s,
-    # user manager + GDM/qecore session ~360s, one network cask install ~900s,
-    # and 15 Ptyxis/dogtail-driven scenarios at ~180s each ~2700s => ~88min
-    # before any node contention. The cask install is budgeted once, not once
-    # per restart attempt: brew-preinstall is content-addressed, so whichever
-    # run does the work — the session's own in-flight run, which run-behave.sh
-    # waits out for at most BREW_PREINSTALL_WAIT_SECONDS (the same 900s),
-    # or the suite's explicit start — leaves the other exiting early on the
-    # unchanged Brewfile hash. The one path that pays the 900s twice is an
-    # in-flight run that fails after being waited out and is then redone by
-    # the suite; that still lands ~17min inside this deadline. Every other
-    # suite finishes far inside it; the deadline is a hang guard, not a budget.
+    # 2h, sized for the slowest lane (suite=homebrew) rather than the fastest.
+    # The phases below are machine-checked: the unit suite parses these
+    # `phase:` and `headroom:` lines, sums them, and compares the totals
+    # against activeDeadlineSeconds and against BREW_PREINSTALL_WAIT_SECONDS in
+    # run-behave.sh. Edit the numbers here, not the derived minutes in prose.
+    #   phase: 600 - Pod Ready incl. bootc image pull (the kubectl wait timeout)
+    #   phase: 120 - systemd inside the target reaching a usable state
+    #   phase: 300 - testsuite clone + pip install
+    #   phase: 300 - brew-setup.service unpacking and chowning the Homebrew prefix
+    #   phase: 360 - user manager + GDM/qecore session handoff
+    #   phase: 900 - one network cask install via brew-preinstall.service
+    #   phase: 2700 - 15 Ptyxis/dogtail-driven scenarios at ~180s each
+    # That is ~88min with no node contention, leaving ~32min of headroom. The
+    # cask install is budgeted once, not once per restart attempt:
+    # brew-preinstall is content-addressed, so whichever run does the work —
+    # the session's own in-flight run, which run-behave.sh waits out for at
+    # most BREW_PREINSTALL_WAIT_SECONDS (the same 900s), or the suite's
+    # explicit start — leaves the other exiting early on the unchanged Brewfile
+    # hash. Two real costs are deliberately *not* phases above, because they
+    # are exceptional rather than expected; the headroom absorbs them:
+    #   headroom: 900 - a second cask install, when an in-flight run fails
+    #     after being waited out and the suite's start then redoes the work
+    #   headroom: 600 - Restart=on-failure attempts the session burns before
+    #     run-behave.sh ever samples the unit. Those attempts are already
+    #     running while the lane is in its earlier phases, and
+    #     StartLimitBurst=3 within StartLimitIntervalSec=600 caps them, so the
+    #     worst case is bounded by that interval rather than by the deadline.
+    # Even the case that hits both still lands ~7min inside the deadline. Every
+    # other suite finishes far inside it; the deadline is a hang guard, not a
+    # budget.
     activeDeadlineSeconds: 7200
     inputs:
       parameters:
@@ -383,19 +398,61 @@ spec:
           # repeating the download; the cap keeps a wedged install bounded.
           BREW_PREINSTALL_WAIT_SECONDS=900
           BREW_PREINSTALL_POLL_SECONDS=10
-          brew_preinstall_property() {
-            env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+          BREW_PREINSTALL_PROGRESS_SECONDS=60
+          # One `systemctl show` per sample, setting both variables together.
+          # Two separate reads can straddle a transition and pair an
+          # ActiveState with a SubState the unit never actually held — exactly
+          # the pair this block branches on. `--value` cannot be used for a
+          # multi-property read: systemctl prints properties in its own order,
+          # not the requested one, so read the `key=value` form and parse it.
+          brew_preinstall_sample() {
+            local key value sample
+            BREW_PREINSTALL_STATE=unknown
+            BREW_PREINSTALL_SUBSTATE=unknown
+            sample=$(env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
               systemctl --user show brew-preinstall.service \
-              --property="$1" --value 2>/dev/null || true
+              --property=ActiveState --property=SubState 2>/dev/null || true)
+            while IFS='=' read -r key value; do
+              case "${key}" in
+                ActiveState) BREW_PREINSTALL_STATE="${value:-unknown}" ;;
+                SubState) BREW_PREINSTALL_SUBSTATE="${value:-unknown}" ;;
+              esac
+            done <<< "${sample}"
+          }
+          # ConditionResult=no means two opposite things and only
+          # ConditionTimestamp separates them: an empty timestamp means the
+          # conditions were never evaluated at all (systemd never tried to
+          # start the unit, including the not-found case, where it also reports
+          # ConditionResult=no), while a timestamp means they were evaluated
+          # then and genuinely failed, so the start really was skipped.
+          brew_preinstall_condition_report() {
+            local key value load_state="" result="" stamp="" verdict sample
+            sample=$(env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+              systemctl --user show brew-preinstall.service \
+              --property=LoadState --property=ConditionResult \
+              --property=ConditionTimestamp 2>/dev/null || true)
+            while IFS='=' read -r key value; do
+              case "${key}" in
+                LoadState) load_state="${value}" ;;
+                ConditionResult) result="${value}" ;;
+                ConditionTimestamp) stamp="${value}" ;;
+              esac
+            done <<< "${sample}"
+            if [[ -z "${stamp}" ]]; then
+              verdict="conditions never evaluated, so systemd has not tried to start this unit"
+            elif [[ "${result}" == "no" ]]; then
+              verdict="conditions evaluated and failed, so the start was skipped"
+            else
+              verdict="conditions evaluated and passed"
+            fi
+            printf 'LoadState=%s, ConditionResult=%s, ConditionTimestamp=%s, %s' \
+              "${load_state:-unknown}" "${result:-unknown}" "${stamp:-<empty>}" "${verdict}"
           }
           brew_preinstall_status() {
             env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
               systemctl --user status --no-pager --full brew-preinstall.service >&2 || true
           }
-          BREW_PREINSTALL_STATE=$(brew_preinstall_property ActiveState)
-          BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}
-          BREW_PREINSTALL_SUBSTATE=$(brew_preinstall_property SubState)
-          BREW_PREINSTALL_SUBSTATE=${BREW_PREINSTALL_SUBSTATE:-unknown}
+          brew_preinstall_sample
           # ActiveState=activating covers two opposite situations and only
           # SubState tells them apart. `start` is a healthy run in flight —
           # the session's own cask install, already paying the network cost
@@ -409,16 +466,23 @@ spec:
             && "${BREW_PREINSTALL_SUBSTATE}" != auto-restart* ]]; then
             echo "brew-preinstall.service is activating (${BREW_PREINSTALL_SUBSTATE}); waiting up to ${BREW_PREINSTALL_WAIT_SECONDS}s for the in-flight run instead of killing it" >&2
             BREW_PREINSTALL_WAITED=0
+            BREW_PREINSTALL_REPORTED=0
             while [[ "${BREW_PREINSTALL_WAITED}" -lt "${BREW_PREINSTALL_WAIT_SECONDS}" ]]; do
               sleep "${BREW_PREINSTALL_POLL_SECONDS}"
               BREW_PREINSTALL_WAITED=$((BREW_PREINSTALL_WAITED + BREW_PREINSTALL_POLL_SECONDS))
-              BREW_PREINSTALL_STATE=$(brew_preinstall_property ActiveState)
-              BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}
-              BREW_PREINSTALL_SUBSTATE=$(brew_preinstall_property SubState)
-              BREW_PREINSTALL_SUBSTATE=${BREW_PREINSTALL_SUBSTATE:-unknown}
+              brew_preinstall_sample
               if [[ "${BREW_PREINSTALL_STATE}" != "activating" \
                 || "${BREW_PREINSTALL_SUBSTATE}" == auto-restart* ]]; then
                 break
+              fi
+              # Argo's log view is the only window into a lane that can sit
+              # here for a quarter of an hour. Say it is still waiting on a
+              # known state, so a wedged install is visibly different from a
+              # runner that stopped producing output.
+              if [[ $((BREW_PREINSTALL_WAITED - BREW_PREINSTALL_REPORTED)) \
+                -ge "${BREW_PREINSTALL_PROGRESS_SECONDS}" ]]; then
+                BREW_PREINSTALL_REPORTED="${BREW_PREINSTALL_WAITED}"
+                echo "brew-preinstall.service is still activating (${BREW_PREINSTALL_SUBSTATE}) after ${BREW_PREINSTALL_WAITED}s of ${BREW_PREINSTALL_WAIT_SECONDS}s" >&2
               fi
             done
             echo "brew-preinstall.service is ${BREW_PREINSTALL_STATE} (${BREW_PREINSTALL_SUBSTATE}) after waiting ${BREW_PREINSTALL_WAITED}s" >&2
@@ -429,10 +493,10 @@ spec:
             # never ran looks like: brew-preinstall.service carries
             # ConditionUser=!@system and ConditionPathExists=<brew binary>, and
             # a condition-skipped start exits 0, as does a start of a unit that
-            # is not installed at all. Print LoadState and ConditionResult so a
-            # missing or skipped unit is visible instead of passing for a clean
-            # slate that the suite's start will then silently succeed against.
-            echo "brew-preinstall.service is ${BREW_PREINSTALL_STATE} (${BREW_PREINSTALL_SUBSTATE}, LoadState=$(brew_preinstall_property LoadState), ConditionResult=$(brew_preinstall_property ConditionResult)) before behave started it" >&2
+            # is not installed at all. Report LoadState plus the condition
+            # verdict so a missing unit, a skipped start, and a clean slate are
+            # three distinguishable outcomes instead of one silent success.
+            echo "brew-preinstall.service is ${BREW_PREINSTALL_STATE} (${BREW_PREINSTALL_SUBSTATE}, $(brew_preinstall_condition_report)) before behave started it" >&2
           else
             # failed, the auto-restart gap, or an activating run that outlasted
             # the wait above: dump the real failure before the stop clears it.
@@ -451,7 +515,20 @@ spec:
           env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
             systemctl --user stop brew-preinstall.service || BREW_PREINSTALL_STOP_RC=$?
           if [[ "${BREW_PREINSTALL_STOP_RC}" -ne 0 ]]; then
-            echo "warning: stopping brew-preinstall.service before behave exited ${BREW_PREINSTALL_STOP_RC} (state was ${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE}); a queued auto-restart may still race the suite's explicit start" >&2
+            # A failed stop leaves the unit in whatever state it was really in,
+            # which decides how bad this is — so look again rather than
+            # guessing from the pre-stop sample.
+            BREW_PREINSTALL_STOPPED_FROM="${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE}"
+            brew_preinstall_sample
+            echo "warning: stopping brew-preinstall.service before behave exited ${BREW_PREINSTALL_STOP_RC} (state was ${BREW_PREINSTALL_STOPPED_FROM}, now ${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE})" >&2
+            if [[ "${BREW_PREINSTALL_STATE}" == "activating" \
+              && "${BREW_PREINSTALL_SUBSTATE}" != auto-restart* ]]; then
+              echo "warning: a live brew-preinstall.service install is still running; the suite's explicit start will run brew concurrently against the same Homebrew prefix" >&2
+            elif [[ "${BREW_PREINSTALL_SUBSTATE}" == auto-restart* ]]; then
+              echo "warning: brew-preinstall.service still holds a queued auto-restart that may race the suite's explicit start" >&2
+            elif [[ "${BREW_PREINSTALL_STATE}" == "active" ]]; then
+              echo "warning: brew-preinstall.service is still active, so RemainAfterExit keeps it latched and the suite's explicit start may be a no-op" >&2
+            fi
             brew_preinstall_status
           fi
           # Now clear the failure state and the start-limit counter. Never
@@ -460,7 +537,7 @@ spec:
           env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
             systemctl --user reset-failed brew-preinstall.service || BREW_PREINSTALL_RESET_RC=$?
           if [[ "${BREW_PREINSTALL_RESET_RC}" -ne 0 ]]; then
-            echo "warning: reset-failed brew-preinstall.service exited ${BREW_PREINSTALL_RESET_RC} (state was ${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE}); the suite may report a stale start limit instead of the real error" >&2
+            echo "warning: reset-failed brew-preinstall.service exited ${BREW_PREINSTALL_RESET_RC} (last observed state ${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE}); the suite may report a stale start limit instead of the real error" >&2
             brew_preinstall_status
           fi
         fi

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -177,13 +177,36 @@ from an EXIT trap on every outcome.
 
 #### ChairLift / Homebrew lane
 
+> **Status: statically validated only — never executed against the cluster.**
+> `argo lint`, the unit suite, `bash -n`, and mocked branch runs all pass, but
+> no `suite=homebrew` workflow has been submitted yet. The live risk is the
+> **GNOME desktop session handoff** inside the container target: full desktop
+> suites are still unproven there, and this lane needs a real session for the
+> Ptyxis-driven Brew/bctl scenarios and the two `@chairlift_ui` scenarios. If
+> `qecore-headless` cannot produce a `gnome-session`, the lane fails at that
+> pre-existing boundary before Behave starts, not in the provisioning added
+> for this suite. Treat the first live run as the experiment that settles it.
+
 `suite=homebrew` is the only suite that provisions Homebrew and a systemd user
-manager in the target — `brew-setup.service` is unmasked and started, then
-`loginctl enable-linger bluefin-test` and `user@1000.service` bring up the user
-manager whose `RuntimePath` supplies `XDG_RUNTIME_DIR`,
-`DBUS_SESSION_BUS_ADDRESS`, and `AT_SPI_BUS_ADDRESS` for that run. Every other
-suite keeps the runner-created `/home/bluefin-test/run`. This lane is not
-runnable on the QEMU `e2e.yml` path, which masks `brew-setup.service`.
+manager in the target — `brew-setup.service` is unmasked and started (the
+`brew` binary, not the unit's exit code, is the gate), then `loginctl
+enable-linger bluefin-test` and `user@1000.service` bring up the user manager
+whose `RuntimePath` supplies `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, and
+`AT_SPI_BUS_ADDRESS` for that run. That directory is validated in the target
+(both `systemd/private` and `bus` must be live sockets) and persisted to
+`/workspace/qa-runtime-dir`, which the runner and `run-behave.sh` both read —
+logind is never asked twice. Every other suite keeps the runner-created
+`/home/bluefin-test/run`. This lane is not runnable on the QEMU `e2e.yml` path,
+which masks `brew-setup.service`.
+
+`activeDeadlineSeconds` on `run-tests` is **7200** (2h), sized for this lane:
+image pull and Pod readiness (≤600s), systemd start (≤120s), clone plus pip
+install (~300s), `brew-setup.service` (~300s), user manager and GDM/qecore
+session (~360s), the network-bound cask install driven by
+`brew-preinstall.service` (~900s, it retries on failure), and 15
+Ptyxis/dogtail-driven scenarios at ~180s each (~2700s) — about 89 minutes with
+no node contention. Other suites finish far inside it; the deadline is a hang
+guard, not a budget.
 
 Submit it against a `common` PR build:
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -206,18 +206,26 @@ whose `RuntimePath` supplies `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, and
 to `run-behave.sh` through `/workspace/qa-suite.env` — logind is never asked
 twice. Immediately before Behave, `run-behave.sh` settles
 `brew-preinstall.service` with that same runtime directory. It reads
-`ActiveState` **and** `SubState`, because `activating` means two opposite
+`ActiveState` **and** `SubState` — in a single `systemctl show` so the pair
+cannot straddle a transition — because `activating` means two opposite
 things: `start` is the session's own install still running, which the lane
-waits out for up to 900s rather than discarding, while `auto-restart` (or
-`auto-restart-queued`) is the `RestartSec` gap holding a queued restart job
-that `reset-failed` does not cancel. `failed`, an auto-restart gap, and a run
-that outlasts the wait get a `status` dump; the settled `inactive`/`active`
-states are logged with `LoadState` and `ConditionResult`, so a unit that is
-missing or that systemd skipped on `ConditionUser`/`ConditionPathExists` is
-visible instead of passing for a clean slate. The unit is then stopped
-(cancelling a queued auto-restart and clearing a latched
-`RemainAfterExit=true` success) and `reset-failed`, so Behave's explicit start
-runs the unit instead of returning success from that latch. That re-run
+waits out for up to 900s (logging progress every 60s) rather than discarding,
+while `auto-restart` (or `auto-restart-queued`) is the `RestartSec` gap holding
+a queued restart job that `reset-failed` does not cancel. `failed`, an
+auto-restart gap, a run that outlasts the wait, and an unreadable state all get
+a `status` dump; the settled `inactive`/`active` states are logged with
+`LoadState`, `ConditionResult` **and** `ConditionTimestamp`, because
+`ConditionResult=no` alone cannot distinguish a start systemd skipped on
+`ConditionUser`/`ConditionPathExists` (populated timestamp) from a unit whose
+conditions were never evaluated at all, including one that is not installed
+(empty timestamp). The lane prints that verdict, so neither case passes for a
+clean slate. The unit is then stopped (cancelling a queued auto-restart and
+clearing a latched `RemainAfterExit=true` success) and `reset-failed`, so
+Behave's explicit start runs the unit instead of returning success from that
+latch. If the stop itself fails, the lane re-reads the unit and names what
+survived — a live install still running (the worst case: the suite's start
+would run brew concurrently against the same prefix), a queued auto-restart, or
+a latched `active`. That re-run
 re-covers the unit's start path, not the install: `brew-preinstall` is
 content-addressed, so after a successful run it exits early on the unchanged
 Brewfile hash, and only after a failed run does it redo the work and report the
@@ -225,18 +233,28 @@ real error. Every other suite keeps the runner-created
 `/home/bluefin-test/run`. This lane is not runnable on the QEMU `e2e.yml` path,
 which masks `brew-setup.service`.
 
-`activeDeadlineSeconds` on `run-tests` is **7200** (2h), sized for this lane:
-image pull and Pod readiness (≤600s), systemd start (≤120s), clone plus pip
-install (~300s), `brew-setup.service` (~300s), user manager and GDM/qecore
-session (~360s), one network-bound cask install (~900s), and 15
-Ptyxis/dogtail-driven scenarios at ~180s each (~2700s) — about 88 minutes with
-no node contention. The cask install is budgeted once, not once per restart
-attempt: whichever run does the work — the session's in-flight one that
-`run-behave.sh` waits out (capped at the same 900s) or the suite's explicit
-start — leaves the other exiting early on the unchanged Brewfile hash. Only an
-in-flight run that fails after being waited out pays the 900s twice, and that
-still lands ~17 minutes inside the deadline. Other suites finish far inside it;
+`activeDeadlineSeconds` on `run-tests` is **7200** (2h), sized for this lane.
+The template carries the breakdown as machine-checked `phase:` comment lines —
+image pull and Pod readiness (600s), systemd start (120s), clone plus pip
+install (300s), `brew-setup.service` (300s), user manager and GDM/qecore
+session (360s), one network-bound cask install (900s), and 15
+Ptyxis/dogtail-driven scenarios at ~180s each (2700s) — about 88 minutes with
+no node contention, leaving about 32 minutes of headroom. The cask install is
+budgeted once, not once per restart attempt: whichever run does the work — the
+session's in-flight one that `run-behave.sh` waits out (capped at the same
+900s) or the suite's explicit start — leaves the other exiting early on the
+unchanged Brewfile hash. Two costs are deliberately left to the headroom
+instead of a phase line, and the template records them as `headroom:` lines: a
+second 900s install when an in-flight run fails after being waited out, and the
+`Restart=on-failure` attempts the session can burn before `run-behave.sh` ever
+samples the unit, which `StartLimitBurst=3` within `StartLimitIntervalSec=600`
+bounds and which overlap the earlier phases anyway. A run that pays both still
+lands about 7 minutes inside the deadline. Other suites finish far inside it;
 the deadline is a hang guard, not a budget.
+`tests/unit/test_container_only_qa_workflows.py` parses those comment lines,
+re-derives the totals and the stated minutes, and compares them with
+`activeDeadlineSeconds` and the in-flight wait cap, so the numbers cannot drift
+apart from the prose.
 
 Submit it against a `common` PR build:
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -156,6 +156,56 @@ Test runner: `run-service-tests` (see supporting templates below). Uses
 the shared helpers in `tests/service_catalog/shared/` for deployment,
 persistence, reachability, redeploy, and teardown assertions.
 
+### `run-systemd-container-tests`
+
+Runs one desktop BDD suite against a **privileged disposable Pod with systemd
+as PID 1** — not a VM. There is no KubeVirt VMI, no golden disk, no
+containerDisk, and no disk artifact: the runner creates the target Pod from a
+bootc OCI image, waits for `systemctl is-system-running` plus `dbus` and
+`systemd-logind`, runs qecore-headless + Behave inside it, and deletes the Pod
+from an EXIT trap on every outcome.
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `image` | `ghcr.io/projectbluefin/bluefin` | Any bootc OCI image. |
+| `image-tag` | `testing` | Tag for that image, e.g. an `e2e-pr-<n>-<sha>` PR build. |
+| `suite` | `smoke` | One of `smoke`, `common`, `developer`, `software`, `system`, `homebrew`. Validated twice — in the runner and inside the target. |
+| `variant` | `bluefin` | Accepted for parity with the VM pipelines; the container lane does not consume it yet. |
+| `testsuite-repo` | `https://github.com/projectbluefin/testsuite` | Cloned into the target. |
+| `testsuite-branch` | `main` | Override only to validate an unmerged suite; a green run on a feature branch says nothing about `main`. |
+| `behave-tags` | empty | Replaces the default `--tags ~@wip`. |
+
+#### ChairLift / Homebrew lane
+
+`suite=homebrew` is the only suite that provisions Homebrew and a systemd user
+manager in the target — `brew-setup.service` is unmasked and started, then
+`loginctl enable-linger bluefin-test` and `user@1000.service` bring up the user
+manager whose `RuntimePath` supplies `XDG_RUNTIME_DIR`,
+`DBUS_SESSION_BUS_ADDRESS`, and `AT_SPI_BUS_ADDRESS` for that run. Every other
+suite keeps the runner-created `/home/bluefin-test/run`. This lane is not
+runnable on the QEMU `e2e.yml` path, which masks `brew-setup.service`.
+
+Submit it against a `common` PR build:
+
+```bash
+: "${COMMON_PR:?export COMMON_PR to the common pull request number}"
+IMAGE_TAG="$(gh api \
+  'orgs/projectbluefin/packages/container/common/versions?per_page=50' \
+  --jq '.[].metadata.container.tags[]?' \
+  | grep "^e2e-pr-${COMMON_PR}-" \
+  | head -1)"
+argo submit -n argo \
+  --from workflowtemplate/run-systemd-container-tests \
+  -p image=ghcr.io/projectbluefin/common \
+  -p image-tag="${IMAGE_TAG}" \
+  -p suite=homebrew \
+  -p variant=bluefin \
+  -p testsuite-branch=test/chairlift-homebrew
+```
+
+Drop `-p testsuite-branch` once the suite is on `main`. Lane internals and
+failure modes: [`docs/skills/test-authoring/systemd-container-tests.md`](../skills/test-authoring/systemd-container-tests.md).
+
 ---
 
 ## Supporting templates (called via `templateRef`)

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -180,11 +180,14 @@ leaving it to owner-reference GC.
 #### ChairLift / Homebrew lane
 
 > **Status: statically validated only — never executed against the cluster.**
-> `argo lint`, the unit suite (which now pins this lane's allowlists, deadline,
-> single `RuntimePath` lookup, `/workspace/qa-runtime-dir` contract, socket
-> diagnostics, `brew-preinstall` settling, and signal traps), `bash -n`, and
-> mocked branch runs all pass, but no `suite=homebrew` workflow has been
-> submitted yet. The live risk is the
+> `argo lint`, the unit suite (which now pins this lane's allowlists, deadline
+> and one-install budget, single `RuntimePath` lookup,
+> `/workspace/qa-runtime-dir` contract, socket diagnostics, `brew-preinstall`
+> settling, and signal traps), `bash -n` over every extracted runner/heredoc
+> block, and mocked-`systemctl` runs of the settle block's branches all pass,
+> but no `suite=homebrew` workflow has been submitted yet. Those runs exercise
+> the lane's own branch logic against stubs; nothing here has driven a real
+> systemd, logind, or Homebrew. The live risk is the
 > **GNOME desktop session handoff** inside the container target: full desktop
 > suites are still unproven there, and this lane needs a real session for the
 > Ptyxis-driven Brew/bctl scenarios and the two `@chairlift_ui` scenarios. If
@@ -202,23 +205,38 @@ whose `RuntimePath` supplies `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, and
 `/workspace/qa-runtime-dir`; the runner reads that file and passes the value on
 to `run-behave.sh` through `/workspace/qa-suite.env` — logind is never asked
 twice. Immediately before Behave, `run-behave.sh` settles
-`brew-preinstall.service` with that same runtime directory: it reads
-`ActiveState`, dumps `status` for anything that is not a settled
-`inactive`/`active`, stops the unit (cancelling a queued `Restart=on-failure`
-auto-restart and any latched `RemainAfterExit=true` success), then clears the
-start-limit counter with `reset-failed`, so the suite's own explicit start
-reports the unit's real error. Every other suite keeps the runner-created
+`brew-preinstall.service` with that same runtime directory. It reads
+`ActiveState` **and** `SubState`, because `activating` means two opposite
+things: `start` is the session's own install still running, which the lane
+waits out for up to 900s rather than discarding, while `auto-restart` (or
+`auto-restart-queued`) is the `RestartSec` gap holding a queued restart job
+that `reset-failed` does not cancel. `failed`, an auto-restart gap, and a run
+that outlasts the wait get a `status` dump; the settled `inactive`/`active`
+states are logged with `LoadState` and `ConditionResult`, so a unit that is
+missing or that systemd skipped on `ConditionUser`/`ConditionPathExists` is
+visible instead of passing for a clean slate. The unit is then stopped
+(cancelling a queued auto-restart and clearing a latched
+`RemainAfterExit=true` success) and `reset-failed`, so Behave's explicit start
+runs the unit instead of returning success from that latch. That re-run
+re-covers the unit's start path, not the install: `brew-preinstall` is
+content-addressed, so after a successful run it exits early on the unchanged
+Brewfile hash, and only after a failed run does it redo the work and report the
+real error. Every other suite keeps the runner-created
 `/home/bluefin-test/run`. This lane is not runnable on the QEMU `e2e.yml` path,
 which masks `brew-setup.service`.
 
 `activeDeadlineSeconds` on `run-tests` is **7200** (2h), sized for this lane:
 image pull and Pod readiness (≤600s), systemd start (≤120s), clone plus pip
 install (~300s), `brew-setup.service` (~300s), user manager and GDM/qecore
-session (~360s), the network-bound cask install driven by
-`brew-preinstall.service` (~900s, it retries on failure), and 15
-Ptyxis/dogtail-driven scenarios at ~180s each (~2700s) — about 89 minutes with
-no node contention. Other suites finish far inside it; the deadline is a hang
-guard, not a budget.
+session (~360s), one network-bound cask install (~900s), and 15
+Ptyxis/dogtail-driven scenarios at ~180s each (~2700s) — about 88 minutes with
+no node contention. The cask install is budgeted once, not once per restart
+attempt: whichever run does the work — the session's in-flight one that
+`run-behave.sh` waits out (capped at the same 900s) or the suite's explicit
+start — leaves the other exiting early on the unchanged Brewfile hash. Only an
+in-flight run that fails after being waited out pays the 900s twice, and that
+still lands ~17 minutes inside the deadline. Other suites finish far inside it;
+the deadline is a hang guard, not a budget.
 
 Submit it against a `common` PR build:
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -175,7 +175,7 @@ leaving it to owner-reference GC.
 | `variant` | `bluefin` | Accepted for parity with the VM pipelines; the container lane does not consume it yet. |
 | `testsuite-repo` | `https://github.com/projectbluefin/testsuite` | Cloned into the target. |
 | `testsuite-branch` | `main` | Override only to validate an unmerged suite; a green run on a feature branch says nothing about `main`. |
-| `behave-tags` | empty | Replaces the default `--tags ~@wip`. |
+| `behave-tags` | empty | Replaces the default `--tags ~@wip`. A tag that matches nothing is **not** a pass: behave exits 0, but the runner's result summary fails the lane with `no scenarios ran`, naming the suite and the tags. |
 
 #### ChairLift / Homebrew lane
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -163,7 +163,9 @@ as PID 1** — not a VM. There is no KubeVirt VMI, no golden disk, no
 containerDisk, and no disk artifact: the runner creates the target Pod from a
 bootc OCI image, waits for `systemctl is-system-running` plus `dbus` and
 `systemd-logind`, runs qecore-headless + Behave inside it, and deletes the Pod
-from an EXIT trap on every outcome.
+from a cleanup trap on `EXIT`, `TERM`, and `INT` — so deadline expiry and
+`argo terminate`, which arrive as signals, free the target promptly instead of
+leaving it to owner-reference GC.
 
 | Parameter | Default | Notes |
 |---|---|---|
@@ -178,8 +180,11 @@ from an EXIT trap on every outcome.
 #### ChairLift / Homebrew lane
 
 > **Status: statically validated only — never executed against the cluster.**
-> `argo lint`, the unit suite, `bash -n`, and mocked branch runs all pass, but
-> no `suite=homebrew` workflow has been submitted yet. The live risk is the
+> `argo lint`, the unit suite (which now pins this lane's allowlists, deadline,
+> single `RuntimePath` lookup, `/workspace/qa-runtime-dir` contract, socket
+> diagnostics, `brew-preinstall` settling, and signal traps), `bash -n`, and
+> mocked branch runs all pass, but no `suite=homebrew` workflow has been
+> submitted yet. The live risk is the
 > **GNOME desktop session handoff** inside the container target: full desktop
 > suites are still unproven there, and this lane needs a real session for the
 > Ptyxis-driven Brew/bctl scenarios and the two `@chairlift_ui` scenarios. If
@@ -194,8 +199,15 @@ enable-linger bluefin-test` and `user@1000.service` bring up the user manager
 whose `RuntimePath` supplies `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, and
 `AT_SPI_BUS_ADDRESS` for that run. That directory is validated in the target
 (both `systemd/private` and `bus` must be live sockets) and persisted to
-`/workspace/qa-runtime-dir`, which the runner and `run-behave.sh` both read —
-logind is never asked twice. Every other suite keeps the runner-created
+`/workspace/qa-runtime-dir`; the runner reads that file and passes the value on
+to `run-behave.sh` through `/workspace/qa-suite.env` — logind is never asked
+twice. Immediately before Behave, `run-behave.sh` settles
+`brew-preinstall.service` with that same runtime directory: it reads
+`ActiveState`, dumps `status` for anything that is not a settled
+`inactive`/`active`, stops the unit (cancelling a queued `Restart=on-failure`
+auto-restart and any latched `RemainAfterExit=true` success), then clears the
+start-limit counter with `reset-failed`, so the suite's own explicit start
+reports the unit's real error. Every other suite keeps the runner-created
 `/home/bluefin-test/run`. This lane is not runnable on the QEMU `e2e.yml` path,
 which masks `brew-setup.service`.
 

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -701,13 +701,25 @@ never directly under Argo emissary PID 1.
   failure exits with a named message plus `systemctl status` and `loginctl
   show-user` output instead of a silent abort.
 - Size `activeDeadlineSeconds` for the slowest suite the template can run, and
-  say in a comment which phases the number covers.
+  say in a comment which phases the number covers. Budget idempotent or
+  content-addressed work **once**, not once per restart attempt, and cap any
+  in-band wait the runner performs at that same number so the wait cannot
+  quietly become the deadline.
+- Settle a session-started unit before a suite starts it explicitly, and read
+  `ActiveState` *and* `SubState`: `activating (start)` is a healthy run in
+  flight to be waited out (bounded), while `activating (auto-restart)` holds a
+  queued restart that `reset-failed` does not cancel and must be `stop`ped.
+  Log `LoadState`/`ConditionResult` for settled `inactive`/`active` states so a
+  missing or `Condition*`-skipped unit cannot pass for a clean slate.
 - Delete the owner-referenced target from a `cleanup_target` function trapped on
   `EXIT`, `TERM`, **and** `INT` — deadline expiry and `argo terminate` arrive as
   signals, and an untrapped SIGTERM kills bash before the EXIT trap runs, so the
   target Pod lingers until owner-reference GC. Exit from the TERM/INT handler
   (`trap 'cleanup_target; exit 143' TERM`) so the shell does not resume;
   `kubectl delete --ignore-not-found` makes the double delete harmless.
+- Shell that only ever runs inside the target — the runner `source` and every
+  heredoc it writes — is unreachable by CI until the lane runs, so extract each
+  block in a unit test, normalise the `{{…}}` substitutions, and `bash -n` it.
 
 This runner validates the OCI userspace, systemd/logind startup, resolver
 repair, qecore, and GDM bootstrap. Tests requiring a bootloader, kernel,

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -702,8 +702,12 @@ never directly under Argo emissary PID 1.
   show-user` output instead of a silent abort.
 - Size `activeDeadlineSeconds` for the slowest suite the template can run, and
   say in a comment which phases the number covers.
-- Delete the owner-referenced target in the runner's EXIT trap as a prompt
-  cleanup fallback.
+- Delete the owner-referenced target from a `cleanup_target` function trapped on
+  `EXIT`, `TERM`, **and** `INT` — deadline expiry and `argo terminate` arrive as
+  signals, and an untrapped SIGTERM kills bash before the EXIT trap runs, so the
+  target Pod lingers until owner-reference GC. Exit from the TERM/INT handler
+  (`trap 'cleanup_target; exit 143' TERM`) so the shell does not resume;
+  `kubectl delete --ignore-not-found` makes the double delete harmless.
 
 This runner validates the OCI userspace, systemd/logind startup, resolver
 repair, qecore, and GDM bootstrap. Tests requiring a bootloader, kernel,

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -692,7 +692,16 @@ never directly under Argo emissary PID 1.
   under `/home` breaks whichever was left behind.
 - Pass test-suite inputs through a durable target file, not environment
   variables: qecore does not forward arbitrary env vars into the desktop
-  session.
+  session. Derived runtime facts belong there too: validate the user manager's
+  `RuntimePath` once in `TARGET_SETUP`, write it to `/workspace/qa-runtime-dir`,
+  and have the runner and `run-behave.sh` read that file. Re-querying logind
+  from the runner returns an answer nothing has checked.
+- Under `set -euo pipefail`, capture provisioning exit codes (`|| RC=$?`,
+  `$(cmd || true)`) so the binary/socket check stays authoritative and every
+  failure exits with a named message plus `systemctl status` and `loginctl
+  show-user` output instead of a silent abort.
+- Size `activeDeadlineSeconds` for the slowest suite the template can run, and
+  say in a comment which phases the number covers.
 - Delete the owner-referenced target in the runner's EXIT trap as a prompt
   cleanup fallback.
 

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -677,6 +677,19 @@ never directly under Argo emissary PID 1.
 - Do not overwrite qecore's desktop session environment with fake `/home`
   runtime-bus values; the real login session D-Bus socket and bus address must
   remain intact.
+- Validate `suite` in **both** guards — the runner's `case` and the second one
+  inside the heredoc that writes `/workspace/run-behave.sh`. Passing only the
+  first boots the target and then exits 2 from inside it.
+- Keep suite-specific provisioning behind `if [[ "${SUITE}" == "<suite>" ]]` in
+  `TARGET_SETUP` (which must be given `SUITE` explicitly — the heredoc is
+  quoted). `suite=homebrew` uses this to start `brew-setup.service` and, via
+  `loginctl enable-linger` + `user@1000.service`, a real systemd user manager.
+- When a suite needs `systemctl --user`, derive `XDG_RUNTIME_DIR`,
+  `DBUS_SESSION_BUS_ADDRESS`, and `AT_SPI_BUS_ADDRESS` from one directory —
+  `loginctl show-user <user> --property=RuntimePath`. The manager is reached at
+  `${XDG_RUNTIME_DIR}/systemd/private` and ignores the bus variables; qecore and
+  dogtail do the reverse. Pinning `/run/user/1000` for one and leaving the other
+  under `/home` breaks whichever was left behind.
 - Pass test-suite inputs through a durable target file, not environment
   variables: qecore does not forward arbitrary env vars into the desktop
   session.

--- a/docs/skills/argo-workflows/patterns.md
+++ b/docs/skills/argo-workflows/patterns.md
@@ -701,16 +701,30 @@ never directly under Argo emissary PID 1.
   failure exits with a named message plus `systemctl status` and `loginctl
   show-user` output instead of a silent abort.
 - Size `activeDeadlineSeconds` for the slowest suite the template can run, and
-  say in a comment which phases the number covers. Budget idempotent or
-  content-addressed work **once**, not once per restart attempt, and cap any
-  in-band wait the runner performs at that same number so the wait cannot
-  quietly become the deadline.
+  write the breakdown as machine-parseable comment lines (`phase: <seconds> -
+  …`, `headroom: <seconds> - …`) that a unit test sums and checks against the
+  deadline. Prose alone rots: a test asserting on sentences pins the line
+  wrapping, and one that re-adds the same literals on both sides of an `==`
+  asserts nothing. Budget idempotent or content-addressed work **once**, not
+  once per restart attempt, cap any in-band wait the runner performs at that
+  same number so the wait cannot quietly become the deadline, and name the
+  costs you are leaving to the headroom instead of pretending they do not
+  exist.
 - Settle a session-started unit before a suite starts it explicitly, and read
-  `ActiveState` *and* `SubState`: `activating (start)` is a healthy run in
-  flight to be waited out (bounded), while `activating (auto-restart)` holds a
-  queued restart that `reset-failed` does not cancel and must be `stop`ped.
-  Log `LoadState`/`ConditionResult` for settled `inactive`/`active` states so a
-  missing or `Condition*`-skipped unit cannot pass for a clean slate.
+  `ActiveState` *and* `SubState` in **one** `systemctl show`: `activating
+  (start)` is a healthy run in flight to be waited out (bounded, with periodic
+  progress in the log), while `activating (auto-restart)` holds a queued
+  restart that `reset-failed` does not cancel and must be `stop`ped. Two
+  separate reads can pair states the unit never held, and `--value` on a
+  multi-property read answers in systemd's order rather than the requested one,
+  so parse the `key=value` form. Log `LoadState`, `ConditionResult` *and*
+  `ConditionTimestamp` for settled `inactive`/`active` states — an empty
+  timestamp means the conditions were never evaluated (including a not-found
+  unit), a populated one with `ConditionResult=no` means a genuinely skipped
+  start — so neither can pass for a clean slate. If the `stop` fails, re-read
+  the state before warning: a still-running install is a different and worse
+  hazard than a queued restart, because the suite's start then runs
+  concurrently with it.
 - Delete the owner-referenced target from a `cleanup_target` function trapped on
   `EXIT`, `TERM`, **and** `INT` — deadline expiry and `argo terminate` arrive as
   signals, and an untrapped SIGTERM kills bash before the EXIT trap runs, so the

--- a/docs/skills/test-authoring/systemd-container-tests.md
+++ b/docs/skills/test-authoring/systemd-container-tests.md
@@ -45,6 +45,53 @@ suites remain under investigation.
 5. **Pip bootstrapping:** Minimal bootc target images do not always include
    `pip`. Bootstrap it with `python3 -m ensurepip --default-pip`, then install
    qecore, dogtail, and Behave inside the disposable target.
+6. **Both suite allowlists:** `SUITE` is validated twice — once in the runner
+   script before the target Pod is touched, and again inside the heredoc that
+   writes `/workspace/run-behave.sh`. A suite added to only the first passes
+   validation, boots the target, and then exits 2 from inside it. Add every new
+   suite to both `case` statements.
+7. **Per-suite provisioning stays behind a suite guard:** anything one suite
+   needs and the others do not (Homebrew, a systemd user manager) belongs
+   inside `if [[ "${SUITE}" == "<suite>" ]]`, so no other suite pays the boot
+   or setup cost. The `TARGET_SETUP` heredoc is quoted, so it inherits nothing
+   — pass `SUITE` into it explicitly via `env`.
+8. **One session, two lookups:** `systemctl --user` reaches the user manager
+   over local transport at `${XDG_RUNTIME_DIR}/systemd/private` and ignores
+   `DBUS_SESSION_BUS_ADDRESS`; qecore/dogtail reach the session and a11y bus
+   through the absolute `DBUS_SESSION_BUS_ADDRESS`/`AT_SPI_BUS_ADDRESS` and
+   ignore `XDG_RUNTIME_DIR`. Derive all three from one directory. Moving one
+   without the other gives either an unreachable manager or a dead a11y bus.
+
+#### The `homebrew` lane
+
+`suite=homebrew` is the only suite that needs a provisioned Homebrew prefix and
+a real systemd **user** manager (`brew-preinstall.service` is a user unit). The
+runner adds both in `TARGET_SETUP`, guarded on the suite:
+
+```bash
+systemctl unmask --runtime brew-setup.service
+systemctl start brew-setup.service
+test -x /var/home/linuxbrew/.linuxbrew/bin/brew   # the real gate
+
+loginctl enable-linger bluefin-test               # creates the user object …
+systemctl start user@1000.service                 # … and its manager
+RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value)
+runuser -u bluefin-test -- env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
+  systemctl --user start dbus.socket
+test -S "${RUNTIME_DIR}/systemd/private"          # manager reachable
+test -S "${RUNTIME_DIR}/bus"                      # session bus live
+```
+
+The runner then reads that same `RuntimePath` back and exports
+`XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, and `AT_SPI_BUS_ADDRESS` from it
+for this suite only. Do not hard-code `/run/user/1000`: logind owns that path,
+and pinning it while leaving the bus addresses under `/home/bluefin-test/run`
+is exactly the split rule 8 forbids. Every other suite keeps the
+runner-created `/home/bluefin-test/run` triple unchanged.
+
+The suite itself verifies this contract in `before_all` and fails the run — it
+never skips. See `projectbluefin/testsuite`'s `tests/homebrew/README.md`.
+Submission contract: [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.md).
 
 #### Verified session findings
 
@@ -62,4 +109,24 @@ suites remain under investigation.
   its spawned user script. Persist any inputs the suite needs (image references,
   branch names, secrets paths) in a file the target can read, and have the test
   runner or environment read that file instead of relying on env propagation.
+- The reason for that: `qecore-headless` reads `gnome-session`'s
+  `/proc/<pid>/environ` after starting GDM and **replaces its own environment
+  with it** (keeping only a short list — `PYTHONPATH`, `TERM`, `LOGGING`,
+  `GNOME_ACCESSIBILITY`, …), then launches the user script with that
+  environment. So `runuser … env …` values shape qecore's pre-session run, not
+  behave's. Keep the runner's `XDG_RUNTIME_DIR` equal to the runtime directory
+  logind assigned, so the pre-session and in-session values are identical
+  instead of silently diverging.
+- `brew-setup.service` ships **enabled** in the bootc image and carries
+  `ConditionPathExists=!/etc/.linuxbrew`, so it normally runs at target boot and
+  a later `systemctl start` is *skipped* while still exiting 0. Assert
+  `/var/home/linuxbrew/.linuxbrew/bin/brew`, never the unit's return code.
+- `systemctl unmask --runtime <unit>` exits 0 when the unit is not masked — and
+  even when it does not exist — so it is safe under `set -euo pipefail`. It only
+  clears runtime masks, which is what `systemd.mask=` on the kernel cmdline
+  creates in the QEMU lane.
+- `loginctl show-user <user>` fails with `No such process` until that user has a
+  session or lingering enabled. Run `loginctl enable-linger` first, then read
+  `--property=RuntimePath`; `runuser` alone opens no PAM/logind session, so
+  without it there is no user manager and no `/run/user/<uid>` at all.
 

--- a/docs/skills/test-authoring/systemd-container-tests.md
+++ b/docs/skills/test-authoring/systemd-container-tests.md
@@ -21,9 +21,12 @@ The `homebrew` lane below is the one deliberate, targeted exception: it needs a
 real session (Ptyxis typing, two `@chairlift_ui` scenarios), so it is a probe of
 that unproven boundary rather than a claim that the boundary is solved. Its
 provisioning — Homebrew, the systemd user manager, the reconciled runtime
-directory — is validated statically and by mocked branch runs, and it has never
-been executed against the cluster. Read a session-handoff failure there as the
-known desktop limitation, not as a regression in that provisioning.
+directory — is validated statically (`argo lint`, unit assertions, `bash -n`
+over every extracted runner/heredoc block) and by running the
+`brew-preinstall` settle block against a stub `systemctl`. That covers the
+lane's own branch logic and nothing else: no real systemd, logind, Homebrew, or
+cluster has executed it. Read a session-handoff failure there as the known
+desktop limitation, not as a regression in that provisioning.
 
 #### Core Containerized Testing Rules:
 1. **Native systemd boundary:** Create the target with an Argo `resource`
@@ -78,21 +81,34 @@ known desktop limitation, not as a regression in that provisioning.
    friendly diagnostic instead of killing the shell.
 10. **Settle a session unit's state before a suite starts it:** units pulled in
     by `graphical-session.target` with `Restart=on-failure` and
-    `StartLimitBurst` may already have run by the time Behave starts them
-    explicitly. `failed` is only half of it: between attempts the unit sits in
-    `activating (auto-restart)`, where `is-failed` reports nothing and
-    `reset-failed` clears nothing, and the queued restart then races the
-    suite's own start; with `RemainAfterExit=true` a *successful* prior run
-    leaves it `active`, so the suite's start is a no-op that proves nothing.
-    In `run-behave.sh`, immediately before behave and with the lane's
-    reconciled `XDG_RUNTIME_DIR` (not a guess): read `ActiveState` via
-    `systemctl --user show <unit> --property=ActiveState --value`, dump
-    `systemctl --user status` for anything that is not a settled
-    `inactive`/`active`, `stop` the unit — which cancels a queued auto-restart
-    and clears a stale `active` — and only then `reset-failed` to clear the
-    start-limit counter. Capture both exit codes and warn by name; `|| true`
-    throws away the reason the next failure will be blamed on. Never reset
-    *after* the suite's start: that would hide real failures.
+    `StartLimitBurst` may already have run — or still be running — by the time
+    Behave starts them explicitly. `ActiveState` alone cannot tell those apart,
+    so read `SubState` too, immediately before behave and with the lane's
+    reconciled `XDG_RUNTIME_DIR` (not a guess):
+    - `activating` + `start`: a **healthy run in flight**. Wait for it, capped
+      (`BREW_PREINSTALL_WAIT_SECONDS`), polling `ActiveState`/`SubState`.
+      Killing it discards work the deadline already budgets for and hands the
+      suite a half-applied result.
+    - `activating` + `auto-restart` (`auto-restart-queued` on systemd ≥ 254):
+      the `RestartSec` gap after a failure. `is-failed` reports nothing and
+      `reset-failed` cancels nothing here, and the queued restart would race
+      the suite's own start — do not wait it out, diagnose and clear it.
+    - `failed`, or a run that outlasts the wait: dump `systemctl --user
+      status` before anything clears it.
+    - `inactive`/`active` are the settled states, but `inactive` is also what
+      a unit that is not installed, or that systemd skipped on a failed
+      `Condition*`, looks like — and starting either exits 0. Log `LoadState`
+      and `ConditionResult` so that case is visible instead of passing for a
+      clean slate.
+
+    Then `stop` the unit — which cancels a queued auto-restart and clears a
+    latched `RemainAfterExit=true` success — and only then `reset-failed` to
+    clear the start-limit counter. Capture both exit codes and warn by name;
+    `|| true` throws away the reason the next failure will be blamed on. Never
+    reset *after* the suite's start: that would hide real failures. Be honest
+    about what the suite's start then re-covers: it re-runs the unit, but if
+    the unit is idempotent or content-addressed that re-run may legitimately do
+    nothing, so it proves the start path, not the work.
 11. **Trap TERM and INT, not just EXIT:** `activeDeadlineSeconds` expiry and
     `argo terminate` reach the runner as signals, and an untrapped SIGTERM
     kills bash without running the EXIT trap — the privileged target Pod then
@@ -114,18 +130,38 @@ runner adds both in `TARGET_SETUP`, guarded on the suite:
 ```bash
 systemctl unmask --runtime brew-setup.service
 BREW_SETUP_RC=0
-systemctl start brew-setup.service || BREW_SETUP_RC=$?  # never fatal on its own
-test -x /var/home/linuxbrew/.linuxbrew/bin/brew          # the real gate
+systemctl start brew-setup.service || BREW_SETUP_RC=$?   # never fatal on its own
+if [[ ! -x /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then          # the real gate
+  echo "brew-setup.service left no brew at … (start exit ${BREW_SETUP_RC})" >&2
+  systemctl status --no-pager --full brew-setup.service >&2 || true
+  exit 1
+fi
 
-loginctl enable-linger bluefin-test               # creates the user object …
-systemctl start user@1000.service                 # … and its manager
+LINGER_RC=0
+loginctl enable-linger bluefin-test || LINGER_RC=$?      # creates the user object …
+USER_MANAGER_RC=0
+systemctl start user@1000.service || USER_MANAGER_RC=$?  # … and its manager
 RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value 2>/dev/null || true)
+if [[ -z "${RUNTIME_DIR}" ]]; then
+  report_user_manager_failure "logind assigned no runtime directory to bluefin-test \
+(enable-linger exit ${LINGER_RC}, user@1000.service start exit ${USER_MANAGER_RC})"
+  exit 1
+fi
+DBUS_SOCKET_RC=0
 runuser -u bluefin-test -- env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
-  systemctl --user start dbus.socket
-# each socket check is a guard, not a bare `test`, so it can name the failure:
-#   if [[ ! -S "${RUNTIME_DIR}/systemd/private" ]]; then …; exit 1; fi
-[[ -S "${RUNTIME_DIR}/systemd/private" ]]         # manager reachable
-[[ -S "${RUNTIME_DIR}/bus" ]]                     # session bus live
+  systemctl --user start dbus.socket || DBUS_SOCKET_RC=$?
+# Both sockets are named guards, never a bare `[[ -S … ]]`: under `set -e` a
+# bare check aborts the script with no line saying which socket was missing.
+if [[ ! -S "${RUNTIME_DIR}/systemd/private" ]]; then                 # manager reachable
+  report_user_manager_failure "user@1000.service exposed no control socket at \
+${RUNTIME_DIR}/systemd/private (start exit ${USER_MANAGER_RC})"
+  exit 1
+fi
+if [[ ! -S "${RUNTIME_DIR}/bus" ]]; then                             # session bus live
+  report_user_manager_failure "the bluefin-test user manager exposed no session bus at \
+${RUNTIME_DIR}/bus (dbus.socket start exit ${DBUS_SOCKET_RC})"
+  exit 1
+fi
 printf '%s\n' "${RUNTIME_DIR}" >/workspace/qa-runtime-dir
 ```
 
@@ -148,13 +184,23 @@ triple unchanged.
 
 `run-behave.sh` also settles `brew-preinstall.service` immediately before
 Behave's explicit start, with the same reconciled `XDG_RUNTIME_DIR` (rule 10):
-read `ActiveState`, dump `status` for anything that is not a settled
-`inactive`/`active`, `stop` — cancelling a queued auto-restart and any latched
-`RemainAfterExit=true` success — then `reset-failed`, warning by name if either
-step fails. The runner deletes the target Pod from a `cleanup_target` function
-trapped on `EXIT`, `TERM`, and `INT` (rule 11). The wall-clock budget for this
-lane is documented on `activeDeadlineSeconds` (7200s) in the template and in
-[`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.md).
+read `ActiveState` *and* `SubState`, wait out an in-flight `activating (start)`
+run for up to `BREW_PREINSTALL_WAIT_SECONDS` (900s, polled every 10s), dump
+`status` for `failed`, the `auto-restart` gap, or a run that outlasts that
+wait, log `LoadState`/`ConditionResult` for a settled `inactive`/`active`, then
+`stop` — cancelling a queued auto-restart and any latched `RemainAfterExit=true`
+success — and `reset-failed`, warning by name if either step fails. Behave's
+start then executes the unit rather than returning from the latch, but because
+`brew-preinstall` is content-addressed that re-run is a fast no-op after a
+successful install (unchanged Brewfile hash); it re-covers the unit's start
+path, not the install. After a *failed* run nothing was recorded, so the re-run
+does the real work and reports the real error. The runner deletes the target
+Pod from a `cleanup_target` function trapped on `EXIT`, `TERM`, and `INT`
+(rule 11). The wall-clock budget for this lane is documented on
+`activeDeadlineSeconds` (7200s) in the template and in
+[`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.md); it pays for the
+network cask install once, and the in-flight wait cap is deliberately that same
+900s.
 
 The suite itself verifies this contract in `before_all` and fails the run — it
 never skips. See `projectbluefin/testsuite`'s `tests/homebrew/README.md`.
@@ -198,17 +244,31 @@ Submission contract: [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.m
   without it there is no user manager and no `/run/user/<uid>` at all.
 - `brew-preinstall.service` is `Type=oneshot` with `RemainAfterExit=true`,
   `WantedBy=graphical-session.target`, `Restart=on-failure`, `RestartSec=30`,
-  `StartLimitIntervalSec=600`, and `StartLimitBurst=3`. The session qecore
-  starts pulls it in on its own, so by the time the suite starts it explicitly
-  it may be `failed` (suite reports the start-limit, not the cause),
-  `activating (auto-restart)` during the 30s `RestartSec` gap (a queued restart
-  job that `reset-failed` does not cancel and that then races the suite's
-  start), or `active` from a successful run that `RemainAfterExit` keeps
-  latched (the suite's start becomes a no-op). Read `ActiveState`, stop, then
-  `reset-failed` — see rule 10.
+  `StartLimitIntervalSec=600`, `StartLimitBurst=3`, `ConditionUser=!@system`,
+  and `ConditionPathExists=/var/home/linuxbrew/.linuxbrew/bin/brew`. The
+  session qecore starts pulls it in on its own, so by the time the suite starts
+  it explicitly it may be `failed` (suite reports the start-limit, not the
+  cause), `activating (auto-restart)` during the 30s `RestartSec` gap (a queued
+  restart job that `reset-failed` does not cancel and that then races the
+  suite's start), `activating (start)` with the install still running, or
+  `active` from a successful run that `RemainAfterExit` keeps latched (the
+  suite's start becomes a no-op). `inactive` is ambiguous too: a skipped
+  `Condition*` or an uninstalled unit looks identical to "never ran", and both
+  start with exit 0. Read `ActiveState` *and* `SubState`, wait out an in-flight
+  run, stop the rest, then `reset-failed` — see rule 10.
+- `/usr/libexec/brew-preinstall` is **content-addressed**: it hashes
+  `/usr/share/ublue-os/homebrew/preinstall.d/*.Brewfile` and compares that with
+  `~/.local/share/ublue-os/brew-preinstall-state.json` before touching brew, so
+  a second run after a successful one exits immediately on the unchanged hash.
+  Restarting the unit therefore costs one network cask install per *lane*, not
+  per start — which is why the wait cap and the deadline budget both spend 900s
+  on it exactly once, and why a post-stop re-run proves the unit starts, not
+  that the install happened.
 - Wall clock: `run-tests` carries `activeDeadlineSeconds: 7200`. The homebrew
-  lane's own budget (pull + boot + pip + brew prefix + session + network cask
-  install + 15 Ptyxis/dogtail scenarios) is ~89 minutes with no contention;
-  every other suite finishes far inside that, and the deadline is a hang guard
-  rather than an expectation.
+  lane's own budget (pull + boot + pip + brew prefix + session + one network
+  cask install + 15 Ptyxis/dogtail scenarios) is ~88 minutes with no
+  contention; the only path that pays for the install twice is an in-flight run
+  that fails after being waited out, which still lands ~17 minutes inside the
+  deadline. Every other suite finishes far inside that, and the deadline is a
+  hang guard rather than an expectation.
 

--- a/docs/skills/test-authoring/systemd-container-tests.md
+++ b/docs/skills/test-authoring/systemd-container-tests.md
@@ -17,6 +17,14 @@ container target, so do not claim that all desktop suites pass there. System-lev
 and headless-qecore suites are the current working target; desktop GNOME Shell
 suites remain under investigation.
 
+The `homebrew` lane below is the one deliberate, targeted exception: it needs a
+real session (Ptyxis typing, two `@chairlift_ui` scenarios), so it is a probe of
+that unproven boundary rather than a claim that the boundary is solved. Its
+provisioning — Homebrew, the systemd user manager, the reconciled runtime
+directory — is validated statically and by mocked branch runs, and it has never
+been executed against the cluster. Read a session-handoff failure there as the
+known desktop limitation, not as a regression in that provisioning.
+
 #### Core Containerized Testing Rules:
 1. **Native systemd boundary:** Create the target with an Argo `resource`
    template and set its owner reference to the Workflow. The runner waits for
@@ -61,6 +69,22 @@ suites remain under investigation.
    through the absolute `DBUS_SESSION_BUS_ADDRESS`/`AT_SPI_BUS_ADDRESS` and
    ignore `XDG_RUNTIME_DIR`. Derive all three from one directory. Moving one
    without the other gives either an unreachable manager or a dead a11y bus.
+9. **Provisioning steps capture, checks decide:** under `set -euo pipefail` a
+   bare `systemctl start` aborts the script before the check that would explain
+   it. Capture the exit code (`|| RC=$?`), let the binary/socket check be
+   authoritative, and print a named error plus `systemctl status` and `loginctl
+   show-user <user>` before `exit 1`. The same applies to command substitution:
+   `RUNTIME_DIR=$(loginctl show-user … || true)` so an empty value reaches the
+   friendly diagnostic instead of killing the shell.
+10. **Reset failed/start-limit state before a suite starts a session unit:**
+    units pulled in by `graphical-session.target` with `Restart=on-failure` and
+    `StartLimitBurst` can already be failed and rate-limited by the time Behave
+    starts them explicitly, and the suite then sees "start request repeated too
+    quickly" instead of the real error. Report the pre-existing failure, then
+    `systemctl --user reset-failed <unit> || true` in `run-behave.sh` — with the
+    lane's reconciled `XDG_RUNTIME_DIR`, not a guess — immediately before
+    behave. Never reset *after* the suite's start: that would hide real
+    failures.
 
 #### The `homebrew` lane
 
@@ -70,24 +94,42 @@ runner adds both in `TARGET_SETUP`, guarded on the suite:
 
 ```bash
 systemctl unmask --runtime brew-setup.service
-systemctl start brew-setup.service
-test -x /var/home/linuxbrew/.linuxbrew/bin/brew   # the real gate
+BREW_SETUP_RC=0
+systemctl start brew-setup.service || BREW_SETUP_RC=$?  # never fatal on its own
+test -x /var/home/linuxbrew/.linuxbrew/bin/brew          # the real gate
 
 loginctl enable-linger bluefin-test               # creates the user object …
 systemctl start user@1000.service                 # … and its manager
-RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value)
+RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value 2>/dev/null || true)
 runuser -u bluefin-test -- env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
   systemctl --user start dbus.socket
 test -S "${RUNTIME_DIR}/systemd/private"          # manager reachable
 test -S "${RUNTIME_DIR}/bus"                      # session bus live
+printf '%s\n' "${RUNTIME_DIR}" >/workspace/qa-runtime-dir
 ```
 
-The runner then reads that same `RuntimePath` back and exports
-`XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, and `AT_SPI_BUS_ADDRESS` from it
-for this suite only. Do not hard-code `/run/user/1000`: logind owns that path,
-and pinning it while leaving the bus addresses under `/home/bluefin-test/run`
-is exactly the split rule 8 forbids. Every other suite keeps the
-runner-created `/home/bluefin-test/run` triple unchanged.
+Every capture above exists so the *authoritative* check gets to run and report.
+`systemctl start` under bare `set -e` aborts the script before the binary or
+socket check can say anything, which turns a legible "no brew at …" into an
+unexplained exit. Each real check therefore prints a named error plus
+`systemctl status` (`brew-setup.service` or `user@1000.service`) and `loginctl
+show-user bluefin-test` before exiting 1.
+
+The runner then reads `/workspace/qa-runtime-dir` — the directory that was
+already proven to carry both sockets — and exports `XDG_RUNTIME_DIR`,
+`DBUS_SESSION_BUS_ADDRESS`, and `AT_SPI_BUS_ADDRESS` from it for this suite
+only. Do not query `RuntimePath` a second time from the runner: a second answer
+is unvalidated and can differ from the one that was asserted. Do not hard-code
+`/run/user/1000` either: logind owns that path, and pinning it while leaving the
+bus addresses under `/home/bluefin-test/run` is exactly the split rule 8
+forbids. Every other suite keeps the runner-created `/home/bluefin-test/run`
+triple unchanged.
+
+`run-behave.sh` also clears `brew-preinstall.service`'s failed/start-limit state
+with the same reconciled `XDG_RUNTIME_DIR`, immediately before Behave's explicit
+start (rule 9). The wall-clock budget for this lane is documented on
+`activeDeadlineSeconds` (7200s) in the template and in
+[`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.md).
 
 The suite itself verifies this contract in `before_all` and fails the run — it
 never skips. See `projectbluefin/testsuite`'s `tests/homebrew/README.md`.
@@ -129,4 +171,14 @@ Submission contract: [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.m
   session or lingering enabled. Run `loginctl enable-linger` first, then read
   `--property=RuntimePath`; `runuser` alone opens no PAM/logind session, so
   without it there is no user manager and no `/run/user/<uid>` at all.
+- `brew-preinstall.service` is `WantedBy=graphical-session.target` with
+  `Restart=on-failure`, `RestartSec=30`, `StartLimitIntervalSec=600`, and
+  `StartLimitBurst=3`. The session qecore starts pulls it in on its own, so by
+  the time the suite starts it explicitly it may already be `failed` and
+  rate-limited — and the suite would report the start-limit, not the cause.
+- Wall clock: `run-tests` carries `activeDeadlineSeconds: 7200`. The homebrew
+  lane's own budget (pull + boot + pip + brew prefix + session + network cask
+  install + 15 Ptyxis/dogtail scenarios) is ~89 minutes with no contention;
+  every other suite finishes far inside that, and the deadline is a hang guard
+  rather than an expectation.
 

--- a/docs/skills/test-authoring/systemd-container-tests.md
+++ b/docs/skills/test-authoring/systemd-container-tests.md
@@ -84,11 +84,18 @@ desktop limitation, not as a regression in that provisioning.
     `StartLimitBurst` may already have run — or still be running — by the time
     Behave starts them explicitly. `ActiveState` alone cannot tell those apart,
     so read `SubState` too, immediately before behave and with the lane's
-    reconciled `XDG_RUNTIME_DIR` (not a guess):
+    reconciled `XDG_RUNTIME_DIR` (not a guess). Read the pair in **one**
+    `systemctl show --property=ActiveState --property=SubState` call: two calls
+    can straddle a transition and hand the branch a pair the unit never held.
+    Use the `key=value` output, not `--value` — a multi-property `--value` read
+    prints in systemd's own property order, not the requested one, so parsing
+    it positionally is a silent mis-assignment waiting to happen.
     - `activating` + `start`: a **healthy run in flight**. Wait for it, capped
-      (`BREW_PREINSTALL_WAIT_SECONDS`), polling `ActiveState`/`SubState`.
-      Killing it discards work the deadline already budgets for and hands the
-      suite a half-applied result.
+      (`BREW_PREINSTALL_WAIT_SECONDS`), polling `ActiveState`/`SubState`, and
+      log progress on an interval — a bounded wait that prints nothing for a
+      quarter of an hour is indistinguishable from a dead runner in the Argo
+      log view. Killing it discards work the deadline already budgets for and
+      hands the suite a half-applied result.
     - `activating` + `auto-restart` (`auto-restart-queued` on systemd ≥ 254):
       the `RestartSec` gap after a failure. `is-failed` reports nothing and
       `reset-failed` cancels nothing here, and the queued restart would race
@@ -97,18 +104,29 @@ desktop limitation, not as a regression in that provisioning.
       status` before anything clears it.
     - `inactive`/`active` are the settled states, but `inactive` is also what
       a unit that is not installed, or that systemd skipped on a failed
-      `Condition*`, looks like — and starting either exits 0. Log `LoadState`
-      and `ConditionResult` so that case is visible instead of passing for a
-      clean slate.
+      `Condition*`, looks like — and starting either exits 0. Log `LoadState`,
+      `ConditionResult` **and `ConditionTimestamp`**: `ConditionResult=no` on
+      its own means either of two opposite things, and only an empty
+      `ConditionTimestamp` marks the difference (see the verified finding
+      below). Print the verdict, not just the raw properties.
+    - Any property read can come back empty (unreachable manager, unknown
+      property). Default to a non-settled sentinel such as `unknown` so an
+      empty read falls through to the diagnostic branch instead of being
+      mistaken for a clean slate — and so `set -u` does not abort the lane.
 
     Then `stop` the unit — which cancels a queued auto-restart and clears a
     latched `RemainAfterExit=true` success — and only then `reset-failed` to
     clear the start-limit counter. Capture both exit codes and warn by name;
-    `|| true` throws away the reason the next failure will be blamed on. Never
-    reset *after* the suite's start: that would hide real failures. Be honest
-    about what the suite's start then re-covers: it re-runs the unit, but if
-    the unit is idempotent or content-addressed that re-run may legitimately do
-    nothing, so it proves the start path, not the work.
+    `|| true` throws away the reason the next failure will be blamed on. If the
+    `stop` fails, **re-read the state** before warning: the pre-stop sample
+    cannot say what survived, and the three survivors are not equally bad. A
+    still-`activating` run that is not in the auto-restart gap means a live
+    install is executing and the suite's start will run concurrently against
+    the same prefix — say that specifically, not just "a queued auto-restart
+    may race". Never reset *after* the suite's start: that would hide real
+    failures. Be honest about what the suite's start then re-covers: it re-runs
+    the unit, but if the unit is idempotent or content-addressed that re-run
+    may legitimately do nothing, so it proves the start path, not the work.
 11. **Trap TERM and INT, not just EXIT:** `activeDeadlineSeconds` expiry and
     `argo terminate` reach the runner as signals, and an untrapped SIGTERM
     kills bash without running the EXIT trap — the privileged target Pod then
@@ -184,23 +202,31 @@ triple unchanged.
 
 `run-behave.sh` also settles `brew-preinstall.service` immediately before
 Behave's explicit start, with the same reconciled `XDG_RUNTIME_DIR` (rule 10):
-read `ActiveState` *and* `SubState`, wait out an in-flight `activating (start)`
-run for up to `BREW_PREINSTALL_WAIT_SECONDS` (900s, polled every 10s), dump
-`status` for `failed`, the `auto-restart` gap, or a run that outlasts that
-wait, log `LoadState`/`ConditionResult` for a settled `inactive`/`active`, then
-`stop` — cancelling a queued auto-restart and any latched `RemainAfterExit=true`
-success — and `reset-failed`, warning by name if either step fails. Behave's
-start then executes the unit rather than returning from the latch, but because
-`brew-preinstall` is content-addressed that re-run is a fast no-op after a
-successful install (unchanged Brewfile hash); it re-covers the unit's start
-path, not the install. After a *failed* run nothing was recorded, so the re-run
-does the real work and reports the real error. The runner deletes the target
-Pod from a `cleanup_target` function trapped on `EXIT`, `TERM`, and `INT`
-(rule 11). The wall-clock budget for this lane is documented on
+sample `ActiveState` *and* `SubState` in one `systemctl show`, wait out an
+in-flight `activating (start)` run for up to `BREW_PREINSTALL_WAIT_SECONDS`
+(900s, polled every 10s, progress logged every 60s), dump `status` for
+`failed`, the `auto-restart` gap, or a run that outlasts that wait, report
+`LoadState` plus a `ConditionResult`/`ConditionTimestamp` verdict for a settled
+`inactive`/`active`, then `stop` — cancelling a queued auto-restart and any
+latched `RemainAfterExit=true` success — and `reset-failed`, warning by name if
+either step fails. A failed `stop` re-reads the unit and names what survived:
+a live install still running (the suite's start would then run brew
+concurrently against the same prefix), a queued auto-restart, or a latched
+`active`. Behave's start then executes the unit rather than returning from the
+latch, but because `brew-preinstall` is content-addressed that re-run is a fast
+no-op after a successful install (unchanged Brewfile hash); it re-covers the
+unit's start path, not the install. After a *failed* run nothing was recorded,
+so the re-run does the real work and reports the real error. The runner deletes
+the target Pod from a `cleanup_target` function trapped on `EXIT`, `TERM`, and
+`INT` (rule 11). The wall-clock budget for this lane is documented on
 `activeDeadlineSeconds` (7200s) in the template and in
 [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.md); it pays for the
-network cask install once, and the in-flight wait cap is deliberately that same
-900s.
+network cask install once, the in-flight wait cap is deliberately that same
+900s, and the restart attempts the session can burn before the lane ever
+samples the unit are absorbed by the headroom rather than by a budget line.
+The template's `phase:`/`headroom:` comment lines are parsed by
+`tests/unit/test_container_only_qa_workflows.py`, which re-derives the totals
+and the stated minutes — edit the numbers, not the prose.
 
 The suite itself verifies this contract in `before_all` and fails the run — it
 never skips. See `projectbluefin/testsuite`'s `tests/homebrew/README.md`.
@@ -256,6 +282,26 @@ Submission contract: [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.m
   `Condition*` or an uninstalled unit looks identical to "never ran", and both
   start with exit 0. Read `ActiveState` *and* `SubState`, wait out an in-flight
   run, stop the rest, then `reset-failed` — see rule 10.
+- **`ConditionResult=no` does not mean the condition failed.** Verified on
+  systemd 260.2: `systemctl show <unit> --property=ConditionResult
+  --property=ConditionTimestamp` reports `ConditionResult=no` with an **empty**
+  `ConditionTimestamp` for any unit whose conditions have never been evaluated
+  — every loaded-but-never-started unit on the host, and also every
+  `LoadState=not-found` unit, for which `systemctl show` still exits 0 and
+  answers `inactive`/`dead`/`no`. A unit that really was condition-skipped
+  carries a **populated** `ConditionTimestamp` (e.g. `brew-setup.service` on a
+  host whose prefix already exists). So `ConditionTimestamp`, not
+  `ConditionResult`, is what separates "never evaluated" from "evaluated and
+  failed"; log both and print the verdict.
+- **`systemctl show --property=A --property=B --value` does not answer in the
+  order asked.** Verified on systemd 260.2: requesting
+  `ConditionResult,ConditionTimestamp,LoadState` with `--value` prints the
+  `LoadState` value first, because systemctl uses its own property order.
+  Positional parsing of a multi-property `--value` read therefore assigns the
+  wrong variables silently. Read the `key=value` form and match on the key —
+  which is also the only way to sample two properties **atomically**, and
+  sampling `ActiveState` and `SubState` in separate calls can pair states the
+  unit never simultaneously held.
 - `/usr/libexec/brew-preinstall` is **content-addressed**: it hashes
   `/usr/share/ublue-os/homebrew/preinstall.d/*.Brewfile` and compares that with
   `~/.local/share/ublue-os/brew-preinstall-state.json` before touching brew, so
@@ -267,8 +313,14 @@ Submission contract: [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.m
 - Wall clock: `run-tests` carries `activeDeadlineSeconds: 7200`. The homebrew
   lane's own budget (pull + boot + pip + brew prefix + session + one network
   cask install + 15 Ptyxis/dogtail scenarios) is ~88 minutes with no
-  contention; the only path that pays for the install twice is an in-flight run
-  that fails after being waited out, which still lands ~17 minutes inside the
-  deadline. Every other suite finishes far inside that, and the deadline is a
-  hang guard rather than an expectation.
+  contention, leaving ~32 minutes of headroom. Two costs sit in that headroom
+  rather than in a budget line: an in-flight run that fails after being waited
+  out and is then redone by the suite (a second 900s install), and the
+  `Restart=on-failure` attempts the session burns *before* `run-behave.sh` ever
+  samples the unit — bounded by `StartLimitBurst=3` within
+  `StartLimitIntervalSec=600`, and overlapping the lane's earlier phases
+  anyway. Even a run that pays both lands ~7 minutes inside the deadline. Every
+  other suite finishes far inside that, and the deadline is a hang guard rather
+  than an expectation. The template writes those numbers as machine-checked
+  `phase:`/`headroom:` comment lines.
 

--- a/docs/skills/test-authoring/systemd-container-tests.md
+++ b/docs/skills/test-authoring/systemd-container-tests.md
@@ -76,15 +76,34 @@ known desktop limitation, not as a regression in that provisioning.
    show-user <user>` before `exit 1`. The same applies to command substitution:
    `RUNTIME_DIR=$(loginctl show-user … || true)` so an empty value reaches the
    friendly diagnostic instead of killing the shell.
-10. **Reset failed/start-limit state before a suite starts a session unit:**
-    units pulled in by `graphical-session.target` with `Restart=on-failure` and
-    `StartLimitBurst` can already be failed and rate-limited by the time Behave
-    starts them explicitly, and the suite then sees "start request repeated too
-    quickly" instead of the real error. Report the pre-existing failure, then
-    `systemctl --user reset-failed <unit> || true` in `run-behave.sh` — with the
-    lane's reconciled `XDG_RUNTIME_DIR`, not a guess — immediately before
-    behave. Never reset *after* the suite's start: that would hide real
-    failures.
+10. **Settle a session unit's state before a suite starts it:** units pulled in
+    by `graphical-session.target` with `Restart=on-failure` and
+    `StartLimitBurst` may already have run by the time Behave starts them
+    explicitly. `failed` is only half of it: between attempts the unit sits in
+    `activating (auto-restart)`, where `is-failed` reports nothing and
+    `reset-failed` clears nothing, and the queued restart then races the
+    suite's own start; with `RemainAfterExit=true` a *successful* prior run
+    leaves it `active`, so the suite's start is a no-op that proves nothing.
+    In `run-behave.sh`, immediately before behave and with the lane's
+    reconciled `XDG_RUNTIME_DIR` (not a guess): read `ActiveState` via
+    `systemctl --user show <unit> --property=ActiveState --value`, dump
+    `systemctl --user status` for anything that is not a settled
+    `inactive`/`active`, `stop` the unit — which cancels a queued auto-restart
+    and clears a stale `active` — and only then `reset-failed` to clear the
+    start-limit counter. Capture both exit codes and warn by name; `|| true`
+    throws away the reason the next failure will be blamed on. Never reset
+    *after* the suite's start: that would hide real failures.
+11. **Trap TERM and INT, not just EXIT:** `activeDeadlineSeconds` expiry and
+    `argo terminate` reach the runner as signals, and an untrapped SIGTERM
+    kills bash without running the EXIT trap — the privileged target Pod then
+    waits for owner-reference GC while holding its whole CPU/memory
+    reservation. Put the delete in a function, `trap` it on `EXIT`, and add
+    `trap 'cleanup; exit 143' TERM` / `trap 'cleanup; exit 130' INT` so the
+    handler exits instead of resuming. `kubectl delete --ignore-not-found`
+    makes the double delete harmless. A trapped signal is handled once the
+    current foreground command returns, so the deletion is immediate when the
+    signal reaches the runner's process group (which also ends the in-flight
+    `kubectl exec`) and otherwise happens as soon as that exec returns.
 
 #### The `homebrew` lane
 
@@ -103,8 +122,10 @@ systemctl start user@1000.service                 # … and its manager
 RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath --value 2>/dev/null || true)
 runuser -u bluefin-test -- env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \
   systemctl --user start dbus.socket
-test -S "${RUNTIME_DIR}/systemd/private"          # manager reachable
-test -S "${RUNTIME_DIR}/bus"                      # session bus live
+# each socket check is a guard, not a bare `test`, so it can name the failure:
+#   if [[ ! -S "${RUNTIME_DIR}/systemd/private" ]]; then …; exit 1; fi
+[[ -S "${RUNTIME_DIR}/systemd/private" ]]         # manager reachable
+[[ -S "${RUNTIME_DIR}/bus" ]]                     # session bus live
 printf '%s\n' "${RUNTIME_DIR}" >/workspace/qa-runtime-dir
 ```
 
@@ -125,10 +146,14 @@ bus addresses under `/home/bluefin-test/run` is exactly the split rule 8
 forbids. Every other suite keeps the runner-created `/home/bluefin-test/run`
 triple unchanged.
 
-`run-behave.sh` also clears `brew-preinstall.service`'s failed/start-limit state
-with the same reconciled `XDG_RUNTIME_DIR`, immediately before Behave's explicit
-start (rule 9). The wall-clock budget for this lane is documented on
-`activeDeadlineSeconds` (7200s) in the template and in
+`run-behave.sh` also settles `brew-preinstall.service` immediately before
+Behave's explicit start, with the same reconciled `XDG_RUNTIME_DIR` (rule 10):
+read `ActiveState`, dump `status` for anything that is not a settled
+`inactive`/`active`, `stop` — cancelling a queued auto-restart and any latched
+`RemainAfterExit=true` success — then `reset-failed`, warning by name if either
+step fails. The runner deletes the target Pod from a `cleanup_target` function
+trapped on `EXIT`, `TERM`, and `INT` (rule 11). The wall-clock budget for this
+lane is documented on `activeDeadlineSeconds` (7200s) in the template and in
 [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.md).
 
 The suite itself verifies this contract in `before_all` and fails the run — it
@@ -171,11 +196,16 @@ Submission contract: [`docs/reference/WORKFLOWS.md`](../../reference/WORKFLOWS.m
   session or lingering enabled. Run `loginctl enable-linger` first, then read
   `--property=RuntimePath`; `runuser` alone opens no PAM/logind session, so
   without it there is no user manager and no `/run/user/<uid>` at all.
-- `brew-preinstall.service` is `WantedBy=graphical-session.target` with
-  `Restart=on-failure`, `RestartSec=30`, `StartLimitIntervalSec=600`, and
-  `StartLimitBurst=3`. The session qecore starts pulls it in on its own, so by
-  the time the suite starts it explicitly it may already be `failed` and
-  rate-limited — and the suite would report the start-limit, not the cause.
+- `brew-preinstall.service` is `Type=oneshot` with `RemainAfterExit=true`,
+  `WantedBy=graphical-session.target`, `Restart=on-failure`, `RestartSec=30`,
+  `StartLimitIntervalSec=600`, and `StartLimitBurst=3`. The session qecore
+  starts pulls it in on its own, so by the time the suite starts it explicitly
+  it may be `failed` (suite reports the start-limit, not the cause),
+  `activating (auto-restart)` during the 30s `RestartSec` gap (a queued restart
+  job that `reset-failed` does not cancel and that then races the suite's
+  start), or `active` from a successful run that `RemainAfterExit` keeps
+  latched (the suite's start becomes a no-op). Read `ActiveState`, stop, then
+  `reset-failed` — see rule 10.
 - Wall clock: `run-tests` carries `activeDeadlineSeconds: 7200`. The homebrew
   lane's own budget (pull + boot + pip + brew prefix + session + network cask
   install + 15 Ptyxis/dogtail scenarios) is ~89 minutes with no contention;

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+import json
+import os
 import re
 import shutil
 import subprocess
+import tempfile
 
 import pytest
 
@@ -32,8 +35,13 @@ def _systemd_run_tests_template():
 
 
 def _heredoc(name, text):
-    """The body of a quoted `<<'NAME'` heredoc, without its delimiters."""
-    match = re.search(r"<<'%s'\n(.*?)\n\s*%s\n" % (name, name), text, re.S)
+    """The body of a quoted `<<'NAME'` heredoc, without its delimiters.
+
+    The redirect may carry trailing tokens (`<<'PY' || RC=$?`), which bash
+    applies to the command, not the heredoc — so match to end of line rather
+    than demanding the newline immediately after the delimiter.
+    """
+    match = re.search(r"<<'%s'[^\n]*\n(.*?)\n\s*%s\n" % (name, name), text, re.S)
     assert match is not None, f"{name} heredoc not found"
     return match.group(1)
 
@@ -219,6 +227,111 @@ def _run_settle_block(
         ]
     )
     return _bash(["bash"], script)
+
+
+def _behave_summary_block():
+    """The runner's scenario-tally python heredoc, ready to execute.
+
+    Extracted from the parsed template, so this is the source that really
+    runs on the cluster — not a copy that can drift.
+    """
+    return _heredoc("PY", _systemd_run_tests_template()["script"]["source"])
+
+
+def _run_behave_summary(tmp_path, features, suite="homebrew", tags=""):
+    """Execute the tally block over a synthetic behave JSON report.
+
+    Only the hardcoded results path is rewritten, to a pytest tmp file; the
+    counting, the printed summary and the empty-run guard are the shipped
+    code. Returns the completed process.
+    """
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps(features), encoding="utf-8")
+    block = _behave_summary_block().replace(
+        '"/tmp/results/results.json"', repr(str(results))
+    )
+    assert str(results) in block, "results path substitution did not apply"
+
+    if shutil.which("python3") is None:  # pragma: no cover - python3 runs this
+        pytest.skip("python3 is required to check the runner's summary block")
+    return subprocess.run(
+        ["python3", "-c", block],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**os.environ, "SUITE": suite, "BEHAVE_TAGS": tags},
+    )
+
+
+def _feature(*statuses):
+    return {"elements": [{"status": status} for status in statuses]}
+
+
+def test_behave_summary_reports_the_tally_for_a_real_run():
+    # Guard rail for the guard rail: the empty-run check below is only
+    # meaningful if a populated report still counts and still passes.
+    with tempfile.TemporaryDirectory(dir=ROOT / "tests") as workdir:
+        result = _run_behave_summary(
+            Path(workdir), [_feature("passed", "passed"), _feature("passed")]
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert "3/3 scenarios passed" in result.stdout
+
+
+def test_behave_summary_counts_failures_without_failing_itself():
+    # behave's own exit code owns failure reporting; this block only tallies,
+    # so a failed scenario must not turn into a second, differently-worded
+    # error from the summary.
+    with tempfile.TemporaryDirectory(dir=ROOT / "tests") as workdir:
+        result = _run_behave_summary(
+            Path(workdir), [_feature("passed", "failed", "passed")]
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert "2/3 scenarios passed" in result.stdout
+
+
+def test_behave_summary_refuses_a_zero_scenario_run():
+    # behave exits 0 when --tags matches nothing, so a typo'd tag used to
+    # print "0/0 scenarios passed" and report a green lane that validated
+    # nothing. Targeted tag runs are the whole point of behave-tags, so this
+    # is exactly when the false green would happen.
+    with tempfile.TemporaryDirectory(dir=ROOT / "tests") as workdir:
+        result = _run_behave_summary(
+            Path(workdir), [], suite="homebrew", tags="--tags @chairlfit"
+        )
+
+    assert result.returncode != 0, result.stdout
+    assert "no scenarios ran" in result.stderr
+    # The diagnostic has to name the suite and the tags, or the operator is
+    # left rerunning the lane to find out which typo caused it.
+    assert "homebrew" in result.stderr
+    assert "@chairlfit" in result.stderr
+
+
+def test_behave_summary_refuses_a_report_whose_features_are_all_empty():
+    # A tag can match a feature file but none of its scenarios, which yields
+    # features with empty `elements` rather than an empty report.
+    with tempfile.TemporaryDirectory(dir=ROOT / "tests") as workdir:
+        result = _run_behave_summary(Path(workdir), [_feature(), _feature()])
+
+    assert result.returncode != 0, result.stdout
+    assert "no scenarios ran" in result.stderr
+
+
+def test_runner_fails_the_lane_when_the_summary_block_refuses():
+    # The block's exit code has to reach the runner's exit status, and it has
+    # to rank below qecore's and behave's so a real failure still reports its
+    # own cause rather than "no scenarios ran".
+    runner = _systemd_run_tests_template()["script"]["source"]
+    tail = runner[runner.index("BEHAVE_RC=$(cat /tmp/results/behave-rc.txt)"):]
+
+    assert "SUMMARY_RC=0" in tail
+    assert "<<'PY' || SUMMARY_RC=$?" in tail
+    assert 'exit "${SUMMARY_RC}"' in tail
+    assert tail.index('exit "${QECORE_RC}"') < tail.index('exit "${BEHAVE_RC}"')
+    assert tail.index('exit "${BEHAVE_RC}"') < tail.index('exit "${SUMMARY_RC}"')
 
 
 def test_bluefin_image_poll_qa_is_container_only():

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 import re
+import shutil
+import subprocess
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -44,6 +48,114 @@ def _systemd_runner_blocks():
         "TARGET_SUITE": target_suite,
         "RUN_BEHAVE": _heredoc("RUN_BEHAVE", target_suite),
     }
+
+
+def _normalize_argo_substitutions(shell):
+    """Argo `{{…}}` placeholders replaced by an inert word.
+
+    Argo expands them before bash ever sees the script. They are always
+    quoted here, so bash would parse them as literals anyway, but replacing
+    them keeps the syntax check honest about what actually runs.
+    """
+    return re.sub(r"\{\{[^{}]+\}\}", "argo-substitution", shell)
+
+
+def _bash(argv, stdin):
+    if shutil.which("bash") is None:
+        pytest.skip("bash is required to check the runner's shell blocks")
+    return subprocess.run(
+        argv, input=stdin, capture_output=True, text=True, timeout=120
+    )
+
+
+def _brew_preinstall_settle_block():
+    """The `suite=homebrew` settle block of run-behave.sh, on its own.
+
+    Sliced at the suite guard and its column-0 `fi`, so it can be executed
+    against stub `systemctl`/`sleep` without the surrounding behave run.
+    """
+    behave = _systemd_runner_blocks()["RUN_BEHAVE"]
+    guard = 'if [[ "${SUITE}" == "homebrew" ]]; then'
+    tail = behave[behave.index(guard):]
+    end = re.search(r"\nfi\n", tail)
+    assert end is not None, "the homebrew settle block has no column-0 `fi`"
+    return tail[: end.end()]
+
+
+# `systemctl` and `sleep` are shell functions so the block's own
+# `env XDG_RUNTIME_DIR=… systemctl …` calls resolve to them (`env` is stubbed
+# to drop leading assignments). `sleep` counts polls in the parent shell — the
+# property reads happen inside `$(…)` subshells, so only the stub's *input*
+# can cross that boundary, which is exactly how the state sequences advance.
+_SETTLE_STUBS = """
+set -euo pipefail
+SUITE=homebrew
+RUNTIME_DIR=/run/user/1000
+XDG_RUNTIME_DIR=/run/user/1000
+SLEEPS=0
+env() {
+  while [[ $# -gt 0 && "$1" == *=* ]]; do shift; done
+  "$@"
+}
+sleep() { SLEEPS=$((SLEEPS + 1)); }
+_seq() {
+  local -a values
+  read -r -a values <<< "$1"
+  local idx="${SLEEPS}"
+  (( idx >= ${#values[@]} )) && idx=$(( ${#values[@]} - 1 ))
+  echo "${values[idx]}"
+}
+systemctl() {
+  local verb="" property="" arg
+  for arg in "$@"; do
+    case "${arg}" in
+      --property=*) property="${arg#--property=}" ;;
+      show|status|stop|reset-failed|start) [[ -n "${verb}" ]] || verb="${arg}" ;;
+    esac
+  done
+  if [[ "${verb}" == show ]]; then
+    case "${property}" in
+      ActiveState) _seq "${ACTIVE_SEQ}" ;;
+      SubState) _seq "${SUB_SEQ}" ;;
+      LoadState) echo "${LOAD_STATE}" ;;
+      ConditionResult) echo "${CONDITION_RESULT}" ;;
+      *) echo "" ;;
+    esac
+    return 0
+  fi
+  echo "STUB systemctl ${verb}" >&2
+  return "${STUB_RC:-0}"
+}
+"""
+
+
+def _run_settle_block(
+    active_states,
+    sub_states,
+    load_state="loaded",
+    condition_result="yes",
+    stub_rc=0,
+):
+    """Run the homebrew settle block against a scripted unit state sequence.
+
+    Each entry is the state reported after that many stubbed `sleep` calls,
+    so `["activating", "active"]` is a run that is in flight on the first
+    look and settled one poll later. Returns the completed process; the
+    block's diagnostics and every non-`show` systemctl call land on stderr.
+    """
+    script = "".join(
+        [
+            _SETTLE_STUBS,
+            f'ACTIVE_SEQ="{" ".join(active_states)}"\n',
+            f'SUB_SEQ="{" ".join(sub_states)}"\n',
+            f'LOAD_STATE="{load_state}"\n',
+            f'CONDITION_RESULT="{condition_result}"\n',
+            f"STUB_RC={stub_rc}\n",
+            _brew_preinstall_settle_block(),
+            '\necho "SLEEPS=${SLEEPS}" >&2\n',
+        ]
+    )
+    return _bash(["bash"], script)
 
 
 def test_bluefin_image_poll_qa_is_container_only():
@@ -277,6 +389,34 @@ def test_native_systemd_runner_deadline_is_sized_for_the_homebrew_lane():
     assert "sized for the slowest lane (suite=homebrew)" in content
 
 
+def test_native_systemd_runner_budgets_one_cask_install_and_bounds_the_wait():
+    # brew-preinstall is content-addressed, so only one run pays the network
+    # cost: whichever of the session's in-flight run and the suite's explicit
+    # start goes first, the other exits early on the unchanged Brewfile hash.
+    # The budget must say that, and the in-flight wait must be capped at the
+    # same number the budget spends on that install — an uncapped wait would
+    # bound the lane by the deadline instead.
+    content = SYSTEMD_RUNNER.read_text(encoding="utf-8")
+    behave = _systemd_runner_blocks()["RUN_BEHAVE"]
+    budget = content.split("activeDeadlineSeconds:", 1)[0].rsplit("# 2h,", 1)[1]
+
+    assert "one network cask install ~900s" in budget
+    assert "content-addressed" in budget
+    assert "not once\n    # per restart attempt" in budget
+    assert "StartLimitBurst=3 ~900s" not in budget
+    assert "BREW_PREINSTALL_WAIT_SECONDS=900" in behave
+    assert "BREW_PREINSTALL_POLL_SECONDS=10" in behave
+    assert "BREW_PREINSTALL_WAIT_SECONDS (the same 900s)" in budget
+
+    # 600 + 120 + 300 + 300 + 360 + 900 + 2700 = 5280s, and the one path that
+    # repeats the install (an in-flight run that fails after being waited out)
+    # adds 900 more, which is still inside 7200.
+    assert 600 + 120 + 300 + 300 + 360 + 900 + 2700 == 5280
+    assert 5280 + 900 < _systemd_run_tests_template()["activeDeadlineSeconds"]
+    assert "~88min" in budget
+    assert "~17min inside this deadline" in budget
+
+
 def test_native_systemd_runner_asks_logind_for_the_runtime_path_exactly_once():
     # A second RuntimePath lookup would return an answer nothing has checked
     # against the two sockets asserted in TARGET_SETUP, and could differ.
@@ -347,26 +487,44 @@ def test_native_systemd_runner_socket_failures_carry_named_diagnostics():
 def test_native_systemd_runner_clears_the_brew_preinstall_restart_race():
     # brew-preinstall.service is Type=oneshot, RemainAfterExit=true,
     # Restart=on-failure, RestartSec=30, StartLimitBurst=3, and is pulled in by
-    # graphical-session.target. Between restart attempts it sits in
-    # `activating (auto-restart)`, where is-failed reports nothing and
-    # reset-failed clears nothing, and the queued restart then races the
-    # suite's explicit start. Inspect, diagnose, stop (which cancels the queued
-    # restart), then reset — all before behave, never after.
+    # graphical-session.target. ActiveState alone cannot tell a healthy run in
+    # flight from the auto-restart gap after a failure, so the lane reads
+    # SubState too: wait out `activating (start)`, cancel `auto-restart`.
+    # Then diagnose, stop (which cancels a queued restart and clears a latched
+    # `active`), and reset — all before behave, never after.
     behave = _systemd_runner_blocks()["RUN_BEHAVE"]
 
-    show = behave.index("--property=ActiveState --value")
+    show = behave.index("BREW_PREINSTALL_STATE=$(brew_preinstall_property ActiveState)")
+    substate = behave.index(
+        "BREW_PREINSTALL_SUBSTATE=$(brew_preinstall_property SubState)"
+    )
+    wait = behave.index("waiting up to ${BREW_PREINSTALL_WAIT_SECONDS}s")
     diagnose = behave.index("before behave started it")
     stop = behave.index("systemctl --user stop brew-preinstall.service")
     reset = behave.index("systemctl --user reset-failed brew-preinstall.service")
     run = behave.index("python3 -m behave")
 
-    assert show < diagnose < stop < reset < run
+    assert show < substate < wait < diagnose < stop < reset < run
     assert "BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}" in behave
+    assert "BREW_PREINSTALL_SUBSTATE=${BREW_PREINSTALL_SUBSTATE:-unknown}" in behave
     assert (
-        'if [[ "${BREW_PREINSTALL_STATE}" != "inactive" \\\n'
-        '    && "${BREW_PREINSTALL_STATE}" != "active" ]]; then' in behave
+        'if [[ "${BREW_PREINSTALL_STATE}" == "activating" \\\n'
+        '    && "${BREW_PREINSTALL_SUBSTATE}" != auto-restart* ]]; then' in behave
     )
+    assert (
+        'if [[ "${BREW_PREINSTALL_STATE}" == "inactive" \\\n'
+        '    || "${BREW_PREINSTALL_STATE}" == "active" ]]; then' in behave
+    )
+    # `auto-restart-queued` is the systemd >= 254 spelling; the prefix glob
+    # must match both, and neither may be waited out.
+    assert behave.count('"${BREW_PREINSTALL_SUBSTATE}" != auto-restart*') == 1
+    assert behave.count('"${BREW_PREINSTALL_SUBSTATE}" == auto-restart*') == 1
     assert "systemctl --user is-failed" not in behave
+
+    # inactive/active are settled, but they are also what a unit that systemd
+    # never ran looks like — LoadState/ConditionResult make that visible.
+    assert "LoadState=$(brew_preinstall_property LoadState)" in behave
+    assert "ConditionResult=$(brew_preinstall_property ConditionResult)" in behave
 
     # Both cleanup steps capture their exit code and report it by name instead
     # of discarding it with `|| true`.
@@ -384,18 +542,173 @@ def test_native_systemd_runner_clears_the_brew_preinstall_restart_race():
     assert "a queued auto-restart may still race the suite's explicit start" in behave
     assert "the suite may report a stale start limit instead of the real error" in behave
 
-    # The whole block is guarded on the lane and uses the validated directory,
-    # and a session that disagrees with it is called out rather than silently
-    # honoured.
+    # The whole block is guarded on the lane, every manager call goes through
+    # the validated runtime directory, and a session that disagrees with it is
+    # called out rather than silently honoured.
     guarded = behave.split('if [[ "${SUITE}" == "homebrew" ]]; then', 1)[1]
     assert guarded.index("systemctl --user stop brew-preinstall.service") < guarded.index(
         "\nfi\n"
     )
-    assert behave.count('env XDG_RUNTIME_DIR="${RUNTIME_DIR}"') >= 6
+    lines = behave.splitlines()
+    user_calls = [
+        (lines[index - 1].strip(), line.strip())
+        for index, line in enumerate(lines)
+        if line.strip().startswith("systemctl --user")
+    ]
+    assert {call.split()[2] for _, call in user_calls} == {
+        "show",
+        "status",
+        "stop",
+        "reset-failed",
+    }
+    assert all(
+        previous == 'env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \\'
+        for previous, _ in user_calls
+    )
     assert (
         "warning: session XDG_RUNTIME_DIR='${XDG_RUNTIME_DIR:-}' differs from"
         " the lane's '${RUNTIME_DIR}'" in behave
     )
+
+
+def test_native_systemd_runner_shell_blocks_parse_as_bash():
+    # These blocks only ever run inside the target, hours into a workflow, so a
+    # syntax error costs a full lane. `bash -n` every one of them here: the
+    # runner script, both heredocs it writes into the target, the run-behave.sh
+    # body nested inside the second, and the homebrew settle slice the mocked
+    # branch tests below execute.
+    blocks = dict(_systemd_runner_blocks())
+    blocks["brew-preinstall-settle"] = _brew_preinstall_settle_block()
+
+    for name, shell in blocks.items():
+        result = _bash(["bash", "-n"], _normalize_argo_substitutions(shell))
+        assert result.returncode == 0, f"{name} is not valid bash:\n{result.stderr}"
+
+    # The check is only worth anything if the extraction really produced the
+    # script — a silently empty block would pass `bash -n` too.
+    assert blocks["RUN_BEHAVE"].startswith("#!/bin/bash")
+    assert "python3 -m behave" in blocks["RUN_BEHAVE"]
+    assert blocks["brew-preinstall-settle"].rstrip().endswith("\nfi")
+    assert "{{" not in _normalize_argo_substitutions(blocks["runner"])
+
+
+def test_brew_preinstall_settle_waits_out_a_healthy_in_flight_run():
+    # ActiveState=activating with SubState=start is the session's own cask
+    # install still running. Killing it discards the work the deadline budgets
+    # for and leaves the suite a half-applied prefix, so the lane waits.
+    result = _run_settle_block(
+        active_states=["activating", "activating", "active"],
+        sub_states=["start", "start", "exited"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    stderr = result.stderr
+    assert "waiting up to 900s for the in-flight run instead of killing it" in stderr
+    assert "is active (exited) after waiting 20s" in stderr
+    assert "SLEEPS=2" in stderr
+    # It waited first and only then settled the unit for behave.
+    assert stderr.index("waiting up to 900s") < stderr.index("STUB systemctl stop")
+    assert stderr.index("STUB systemctl stop") < stderr.index(
+        "STUB systemctl reset-failed"
+    )
+
+
+def test_brew_preinstall_settle_cancels_a_queued_auto_restart_without_waiting():
+    # The auto-restart gap is not a healthy run: there is a queued restart job
+    # that reset-failed does not cancel. Diagnose and stop it immediately —
+    # waiting out the RestartSec gap would only line the restart up against
+    # the suite's own start.
+    for substate in ("auto-restart", "auto-restart-queued"):
+        result = _run_settle_block(
+            active_states=["activating"], sub_states=[substate]
+        )
+
+        assert result.returncode == 0, result.stderr
+        stderr = result.stderr
+        assert "SLEEPS=0" in stderr
+        assert "waiting up to" not in stderr
+        assert f"was activating ({substate}) before behave started it" in stderr
+        assert stderr.index("STUB systemctl status") < stderr.index(
+            "STUB systemctl stop"
+        )
+        assert stderr.index("STUB systemctl stop") < stderr.index(
+            "STUB systemctl reset-failed"
+        )
+
+
+def test_brew_preinstall_settle_diagnoses_a_failed_unit_then_clears_it():
+    result = _run_settle_block(active_states=["failed"], sub_states=["failed"])
+
+    assert result.returncode == 0, result.stderr
+    stderr = result.stderr
+    assert "SLEEPS=0" in stderr
+    assert "was failed (failed) before behave started it" in stderr
+    assert "STUB systemctl status" in stderr
+    assert stderr.index("STUB systemctl stop") < stderr.index(
+        "STUB systemctl reset-failed"
+    )
+
+
+def test_brew_preinstall_settle_bounds_the_wait_for_a_wedged_run():
+    # A run that never leaves `activating` must not hold the lane until the
+    # workflow deadline: the wait is capped at BREW_PREINSTALL_WAIT_SECONDS
+    # (900s / 10s polls = 90 iterations), then it is diagnosed and cleared
+    # like any other unsettled state.
+    result = _run_settle_block(
+        active_states=["activating"], sub_states=["start"]
+    )
+
+    assert result.returncode == 0, result.stderr
+    stderr = result.stderr
+    assert "SLEEPS=90" in stderr
+    assert "is activating (start) after waiting 900s" in stderr
+    assert "was activating (start) before behave started it" in stderr
+    assert "STUB systemctl status" in stderr
+    assert "STUB systemctl stop" in stderr
+
+
+def test_brew_preinstall_settle_reports_load_state_for_a_settled_unit():
+    # `inactive` is indistinguishable from "unit not installed" or "systemd
+    # skipped it on ConditionUser/ConditionPathExists" — and a start of either
+    # exits 0, so the suite would pass on nothing. Say which one it is.
+    missing = _run_settle_block(
+        active_states=["inactive"],
+        sub_states=["dead"],
+        load_state="not-found",
+    )
+    skipped = _run_settle_block(
+        active_states=["inactive"],
+        sub_states=["dead"],
+        condition_result="no",
+    )
+
+    assert missing.returncode == 0, missing.stderr
+    assert (
+        "is inactive (dead, LoadState=not-found, ConditionResult=yes)"
+        " before behave started it" in missing.stderr
+    )
+    assert "STUB systemctl status" not in missing.stderr  # settled: no dump
+    assert skipped.returncode == 0, skipped.stderr
+    assert (
+        "is inactive (dead, LoadState=loaded, ConditionResult=no)"
+        " before behave started it" in skipped.stderr
+    )
+
+
+def test_brew_preinstall_settle_survives_a_failing_stop_and_reset():
+    # Neither cleanup step is allowed to abort run-behave.sh under `set -e`,
+    # and neither may swallow its exit code: behave still has to run, with the
+    # reason the next failure will be blamed on printed by name.
+    result = _run_settle_block(
+        active_states=["failed"], sub_states=["failed"], stub_rc=1
+    )
+
+    assert result.returncode == 0, result.stderr
+    stderr = result.stderr
+    assert "warning: stopping brew-preinstall.service before behave exited 1" in stderr
+    assert "(state was failed/failed)" in stderr
+    assert "warning: reset-failed brew-preinstall.service exited 1" in stderr
+    assert "SLEEPS=0" in stderr
 
 
 def test_native_systemd_runner_deletes_the_target_pod_on_termination_signals():

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parents[2]
 PIPELINE = ROOT / "argo/workflow-templates/bluefin-qa-pipeline.yaml"
+SYSTEMD_RUNNER = ROOT / "argo/workflow-templates/run-systemd-container-tests.yaml"
 FORBIDDEN = (
     "assert-cd",
     "containerdisk-tag",
@@ -12,6 +14,36 @@ FORBIDDEN = (
     "qa-vm-fleet",
     "kubectl delete vm",
 )
+
+
+def _systemd_run_tests_template():
+    """The `run-tests` template of the native-systemd runner, parsed."""
+    import yaml
+
+    document = yaml.safe_load(SYSTEMD_RUNNER.read_text(encoding="utf-8"))
+    templates = {
+        template["name"]: template for template in document["spec"]["templates"]
+    }
+    return templates["run-tests"]
+
+
+def _heredoc(name, text):
+    """The body of a quoted `<<'NAME'` heredoc, without its delimiters."""
+    match = re.search(r"<<'%s'\n(.*?)\n\s*%s\n" % (name, name), text, re.S)
+    assert match is not None, f"{name} heredoc not found"
+    return match.group(1)
+
+
+def _systemd_runner_blocks():
+    """Runner source plus each nested heredoc, so assertions can be scoped."""
+    runner = _systemd_run_tests_template()["script"]["source"]
+    target_suite = _heredoc("TARGET_SUITE", runner)
+    return {
+        "runner": runner,
+        "TARGET_SETUP": _heredoc("TARGET_SETUP", runner),
+        "TARGET_SUITE": target_suite,
+        "RUN_BEHAVE": _heredoc("RUN_BEHAVE", target_suite),
+    }
 
 
 def test_bluefin_image_poll_qa_is_container_only():
@@ -218,6 +250,170 @@ def test_native_systemd_runner_uses_a_scheduler_managed_target_pod():
     assert "nodeSelector:" not in content
     assert "containerDisk" not in content
     assert "bootc install to-disk" not in content
+
+
+def test_native_systemd_runner_accepts_homebrew_in_both_suite_allowlists():
+    # The runner guards the suite twice: once before it touches the cluster and
+    # once inside the heredoc that writes /workspace/run-behave.sh. A suite that
+    # is added to only one of them either never provisions or dies inside the
+    # qecore session with an opaque exit 2.
+    blocks = _systemd_runner_blocks()
+    allow = "smoke|common|developer|software|system|homebrew) ;;"
+
+    assert allow in blocks["runner"]
+    assert allow in blocks["RUN_BEHAVE"]
+    assert blocks["runner"].count(allow) == 2  # runner + the nested RUN_BEHAVE
+    assert blocks["runner"].count("Unsupported container suite: ${SUITE}") == 2
+
+
+def test_native_systemd_runner_deadline_is_sized_for_the_homebrew_lane():
+    # The homebrew lane adds a network-bound cask install and 15 Ptyxis-driven
+    # scenarios on top of the shared pull/boot/session cost, so the shared 3600s
+    # hang guard no longer bounds the slowest suite this template can run.
+    template = _systemd_run_tests_template()
+    content = SYSTEMD_RUNNER.read_text(encoding="utf-8")
+
+    assert template["activeDeadlineSeconds"] == 7200
+    assert "sized for the slowest lane (suite=homebrew)" in content
+
+
+def test_native_systemd_runner_asks_logind_for_the_runtime_path_exactly_once():
+    # A second RuntimePath lookup would return an answer nothing has checked
+    # against the two sockets asserted in TARGET_SETUP, and could differ.
+    blocks = _systemd_runner_blocks()
+
+    assert blocks["runner"].count("--property=RuntimePath") == 1
+    assert "--property=RuntimePath" in blocks["TARGET_SETUP"]
+    assert "--property=RuntimePath" not in blocks["RUN_BEHAVE"]
+    assert (
+        "RUNTIME_DIR=$(loginctl show-user bluefin-test --property=RuntimePath"
+        " --value 2>/dev/null || true)" in blocks["TARGET_SETUP"]
+    )
+
+
+def test_native_systemd_runner_persists_the_validated_runtime_dir_for_readers():
+    # TARGET_SETUP proves the directory carries both sockets, then hands it to
+    # the runner and the suite through the same durable /workspace contract the
+    # suite inputs use.
+    blocks = _systemd_runner_blocks()
+    runner_after_setup = blocks["runner"].split("TARGET_SETUP\n", 2)[-1]
+
+    assert (
+        "printf '%s\\n' \"${RUNTIME_DIR}\" >/workspace/qa-runtime-dir"
+        in blocks["TARGET_SETUP"]
+    )
+    assert "cat /workspace/qa-runtime-dir" in runner_after_setup
+    assert (
+        "TARGET_SETUP persisted no user-manager runtime directory at"
+        " /workspace/qa-runtime-dir" in runner_after_setup
+    )
+    assert "loginctl" not in blocks["RUN_BEHAVE"]
+    assert "qa-runtime-dir" not in blocks["RUN_BEHAVE"]
+    assert 'RUNTIME_DIR=/home/bluefin-test/run' in runner_after_setup
+    assert 'RUNTIME_DIR=%q' in blocks["TARGET_SUITE"]
+    assert "source /workspace/qa-suite.env" in blocks["RUN_BEHAVE"]
+
+
+def test_native_systemd_runner_socket_failures_carry_named_diagnostics():
+    # Under `set -euo pipefail` a bare `test -S` or `systemctl start` aborts the
+    # script before anything can explain it. Every provisioning step captures
+    # its exit code; the binary and socket checks decide and report.
+    setup = _systemd_runner_blocks()["TARGET_SETUP"]
+
+    assert "report_user_manager_failure() {" in setup
+    assert "systemctl status --no-pager --full user@1000.service >&2 || true" in setup
+    assert "loginctl show-user bluefin-test >&2 || true" in setup
+    assert 'if [[ ! -S "${RUNTIME_DIR}/systemd/private" ]]; then' in setup
+    assert 'if [[ ! -S "${RUNTIME_DIR}/bus" ]]; then' in setup
+    assert "test -S" not in setup
+    assert setup.count("report_user_manager_failure ") == 3
+    assert setup.count("exit 1") == 4  # brew binary gate + the three above
+
+    for capture in (
+        "systemctl start brew-setup.service || BREW_SETUP_RC=$?",
+        "loginctl enable-linger bluefin-test || LINGER_RC=$?",
+        "systemctl start user@1000.service || USER_MANAGER_RC=$?",
+        "systemctl --user start dbus.socket || DBUS_SOCKET_RC=$?",
+    ):
+        assert capture in setup
+
+    assert "journalctl --no-pager --unit brew-setup.service >&2 || true" in setup
+    assert (
+        "exposed no control socket at ${RUNTIME_DIR}/systemd/private" in setup
+    )
+    assert "exposed no session bus at ${RUNTIME_DIR}/bus" in setup
+
+
+def test_native_systemd_runner_clears_the_brew_preinstall_restart_race():
+    # brew-preinstall.service is Type=oneshot, RemainAfterExit=true,
+    # Restart=on-failure, RestartSec=30, StartLimitBurst=3, and is pulled in by
+    # graphical-session.target. Between restart attempts it sits in
+    # `activating (auto-restart)`, where is-failed reports nothing and
+    # reset-failed clears nothing, and the queued restart then races the
+    # suite's explicit start. Inspect, diagnose, stop (which cancels the queued
+    # restart), then reset — all before behave, never after.
+    behave = _systemd_runner_blocks()["RUN_BEHAVE"]
+
+    show = behave.index("--property=ActiveState --value")
+    diagnose = behave.index("before behave started it")
+    stop = behave.index("systemctl --user stop brew-preinstall.service")
+    reset = behave.index("systemctl --user reset-failed brew-preinstall.service")
+    run = behave.index("python3 -m behave")
+
+    assert show < diagnose < stop < reset < run
+    assert "BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}" in behave
+    assert (
+        'if [[ "${BREW_PREINSTALL_STATE}" != "inactive" \\\n'
+        '    && "${BREW_PREINSTALL_STATE}" != "active" ]]; then' in behave
+    )
+    assert "systemctl --user is-failed" not in behave
+
+    # Both cleanup steps capture their exit code and report it by name instead
+    # of discarding it with `|| true`.
+    assert (
+        "systemctl --user stop brew-preinstall.service || BREW_PREINSTALL_STOP_RC=$?"
+        in behave
+    )
+    assert (
+        "systemctl --user reset-failed brew-preinstall.service"
+        " || BREW_PREINSTALL_RESET_RC=$?" in behave
+    )
+    assert "reset-failed brew-preinstall.service || true" not in behave
+    assert 'if [[ "${BREW_PREINSTALL_STOP_RC}" -ne 0 ]]; then' in behave
+    assert 'if [[ "${BREW_PREINSTALL_RESET_RC}" -ne 0 ]]; then' in behave
+    assert "a queued auto-restart may still race the suite's explicit start" in behave
+    assert "the suite may report a stale start limit instead of the real error" in behave
+
+    # The whole block is guarded on the lane and uses the validated directory,
+    # and a session that disagrees with it is called out rather than silently
+    # honoured.
+    guarded = behave.split('if [[ "${SUITE}" == "homebrew" ]]; then', 1)[1]
+    assert guarded.index("systemctl --user stop brew-preinstall.service") < guarded.index(
+        "\nfi\n"
+    )
+    assert behave.count('env XDG_RUNTIME_DIR="${RUNTIME_DIR}"') >= 6
+    assert (
+        "warning: session XDG_RUNTIME_DIR='${XDG_RUNTIME_DIR:-}' differs from"
+        " the lane's '${RUNTIME_DIR}'" in behave
+    )
+
+
+def test_native_systemd_runner_deletes_the_target_pod_on_termination_signals():
+    # activeDeadlineSeconds expiry and `argo terminate` arrive as signals, and
+    # an untrapped SIGTERM kills bash without running the EXIT trap — the
+    # privileged 8Gi/4CPU target Pod would then wait for owner-reference GC.
+    runner = _systemd_runner_blocks()["runner"]
+
+    assert "cleanup_target() {" in runner
+    assert (
+        'kubectl delete pod "${TARGET_POD}" -n "{{workflow.namespace}}" \\\n'
+        "    --ignore-not-found --wait=false || true" in runner
+    )
+    assert "trap cleanup_target EXIT" in runner
+    assert "trap 'cleanup_target; exit 143' TERM" in runner
+    assert "trap 'cleanup_target; exit 130' INT" in runner
+    assert runner.count("kubectl delete pod") == 1
+    assert runner.index("trap cleanup_target EXIT") < runner.index("kubectl wait")
 
 
 def test_pr_poller_uses_the_exact_testsuite_pr_source():

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -68,6 +68,34 @@ def _bash(argv, stdin):
     )
 
 
+def _run_tests_budget_comment():
+    """The YAML comment block directly above `activeDeadlineSeconds`.
+
+    Comments do not survive parsing, so this walks the raw file backwards from
+    the setting to the first non-comment line, which is the whole rationale and
+    nothing else.
+    """
+    lines = SYSTEMD_RUNNER.read_text(encoding="utf-8").splitlines()
+    index = next(
+        i for i, line in enumerate(lines) if line.strip().startswith("activeDeadlineSeconds:")
+    )
+    start = index
+    while start > 0 and lines[start - 1].strip().startswith("#"):
+        start -= 1
+    assert start < index, "activeDeadlineSeconds carries no explanatory comment"
+    return "\n".join(lines[start:index])
+
+
+def _budget_entries(comment, marker):
+    """Every `<marker>: <seconds> - <description>` entry in a budget comment."""
+    return [
+        (int(seconds), description.strip())
+        for seconds, description in re.findall(
+            rf"^\s*#\s*{marker}:\s*(\d+)\s*-\s*(.*)$", comment, re.M
+        )
+    ]
+
+
 def _brew_preinstall_settle_block():
     """The `suite=homebrew` settle block of run-behave.sh, on its own.
 
@@ -85,10 +113,19 @@ def _brew_preinstall_settle_block():
 # `systemctl` and `sleep` are shell functions so the block's own
 # `env XDG_RUNTIME_DIR=… systemctl …` calls resolve to them (`env` is stubbed
 # to drop leading assignments). `sleep` counts polls in the parent shell — the
-# property reads happen inside `$(…)` subshells, so only the stub's *input*
-# can cross that boundary, which is exactly how the state sequences advance.
+# property reads happen inside a process substitution, so only the stub's
+# *input* can cross that boundary, which is exactly how the state sequences
+# advance. `show` answers in the `key=value` form the block parses, honouring
+# systemd's real behaviour of printing one line per requested property; with
+# SHOW_EMPTY=1 it prints nothing at all, which is what an unreachable manager
+# or an unreadable property looks like.
 _SETTLE_STUBS = """
 set -euo pipefail
+# The block reads properties with `2>/dev/null`, so the stub announces each
+# `show` on fd 3 — a duplicate of the captured stderr that the block's own
+# redirect cannot swallow. That is how the tests see *how many* calls were
+# made and which properties each one asked for.
+exec 3>&2
 SUITE=homebrew
 RUNTIME_DIR=/run/user/1000
 XDG_RUNTIME_DIR=/run/user/1000
@@ -106,24 +143,38 @@ _seq() {
   echo "${values[idx]}"
 }
 systemctl() {
-  local verb="" property="" arg
+  local verb="" arg property
+  local -a properties=()
   for arg in "$@"; do
     case "${arg}" in
-      --property=*) property="${arg#--property=}" ;;
+      --property=*) properties+=("${arg#--property=}") ;;
       show|status|stop|reset-failed|start) [[ -n "${verb}" ]] || verb="${arg}" ;;
     esac
   done
   if [[ "${verb}" == show ]]; then
-    case "${property}" in
-      ActiveState) _seq "${ACTIVE_SEQ}" ;;
-      SubState) _seq "${SUB_SEQ}" ;;
-      LoadState) echo "${LOAD_STATE}" ;;
-      ConditionResult) echo "${CONDITION_RESULT}" ;;
-      *) echo "" ;;
-    esac
+    echo "STUB show: ${properties[*]}" >&3
+    if [[ "${SHOW_EMPTY:-0}" == 1 ]]; then
+      return 0
+    fi
+    for property in "${properties[@]}"; do
+      case "${property}" in
+        ActiveState) echo "ActiveState=$(_seq "${ACTIVE_SEQ}")" ;;
+        SubState) echo "SubState=$(_seq "${SUB_SEQ}")" ;;
+        LoadState) echo "LoadState=${LOAD_STATE}" ;;
+        ConditionResult) echo "ConditionResult=${CONDITION_RESULT}" ;;
+        ConditionTimestamp) echo "ConditionTimestamp=${CONDITION_TIMESTAMP}" ;;
+        *) echo "${property}=" ;;
+      esac
+    done
     return 0
   fi
   echo "STUB systemctl ${verb}" >&2
+  # A stop that fails leaves the unit in whatever state it was really in, and
+  # the block re-reads it to decide how bad that is. Let a test say which.
+  if [[ "${verb}" == stop && -n "${AFTER_STOP_ACTIVE:-}" ]]; then
+    ACTIVE_SEQ="${AFTER_STOP_ACTIVE}"
+    SUB_SEQ="${AFTER_STOP_SUB}"
+  fi
   return "${STUB_RC:-0}"
 }
 """
@@ -134,22 +185,34 @@ def _run_settle_block(
     sub_states,
     load_state="loaded",
     condition_result="yes",
+    condition_timestamp="Sun 2026-08-09 12:00:00 EDT",
+    show_empty=False,
     stub_rc=0,
+    after_stop=None,
 ):
     """Run the homebrew settle block against a scripted unit state sequence.
 
     Each entry is the state reported after that many stubbed `sleep` calls,
     so `["activating", "active"]` is a run that is in flight on the first
-    look and settled one poll later. Returns the completed process; the
-    block's diagnostics and every non-`show` systemctl call land on stderr.
+    look and settled one poll later. `show_empty` makes every property read
+    return nothing, the way an unreachable user manager would; `after_stop`
+    is an `(ActiveState, SubState)` pair the unit moves to once `stop` has
+    run, which is what the block re-reads when that stop fails. Returns the
+    completed process; the block's diagnostics and every systemctl call land
+    on stderr.
     """
+    after_stop_active, after_stop_sub = after_stop or ("", "")
     script = "".join(
         [
             _SETTLE_STUBS,
             f'ACTIVE_SEQ="{" ".join(active_states)}"\n',
             f'SUB_SEQ="{" ".join(sub_states)}"\n',
+            f'AFTER_STOP_ACTIVE="{after_stop_active}"\n',
+            f'AFTER_STOP_SUB="{after_stop_sub}"\n',
             f'LOAD_STATE="{load_state}"\n',
             f'CONDITION_RESULT="{condition_result}"\n',
+            f'CONDITION_TIMESTAMP="{condition_timestamp}"\n',
+            f"SHOW_EMPTY={1 if show_empty else 0}\n",
             f"STUB_RC={stub_rc}\n",
             _brew_preinstall_settle_block(),
             '\necho "SLEEPS=${SLEEPS}" >&2\n',
@@ -383,38 +446,70 @@ def test_native_systemd_runner_deadline_is_sized_for_the_homebrew_lane():
     # scenarios on top of the shared pull/boot/session cost, so the shared 3600s
     # hang guard no longer bounds the slowest suite this template can run.
     template = _systemd_run_tests_template()
-    content = SYSTEMD_RUNNER.read_text(encoding="utf-8")
 
     assert template["activeDeadlineSeconds"] == 7200
-    assert "sized for the slowest lane (suite=homebrew)" in content
+    assert "sized for the slowest lane (suite=homebrew)" in _run_tests_budget_comment()
 
 
 def test_native_systemd_runner_budgets_one_cask_install_and_bounds_the_wait():
-    # brew-preinstall is content-addressed, so only one run pays the network
-    # cost: whichever of the session's in-flight run and the suite's explicit
-    # start goes first, the other exits early on the unchanged Brewfile hash.
-    # The budget must say that, and the in-flight wait must be capped at the
-    # same number the budget spends on that install — an uncapped wait would
-    # bound the lane by the deadline instead.
-    content = SYSTEMD_RUNNER.read_text(encoding="utf-8")
+    # The budget comment is the only record of *why* the deadline is what it
+    # is, so check the arithmetic rather than the prose: pull the phase and
+    # headroom seconds straight out of the comment, add the in-flight wait cap
+    # read from run-behave.sh, and require the totals to fit. Asserting on
+    # sentences instead would only pin the line wrapping, and hard-coding the
+    # sum on both sides of an `==` would assert nothing at all.
+    comment = _run_tests_budget_comment()
     behave = _systemd_runner_blocks()["RUN_BEHAVE"]
-    budget = content.split("activeDeadlineSeconds:", 1)[0].rsplit("# 2h,", 1)[1]
+    deadline = _systemd_run_tests_template()["activeDeadlineSeconds"]
 
-    assert "one network cask install ~900s" in budget
-    assert "content-addressed" in budget
-    assert "not once\n    # per restart attempt" in budget
-    assert "StartLimitBurst=3 ~900s" not in budget
-    assert "BREW_PREINSTALL_WAIT_SECONDS=900" in behave
-    assert "BREW_PREINSTALL_POLL_SECONDS=10" in behave
-    assert "BREW_PREINSTALL_WAIT_SECONDS (the same 900s)" in budget
+    phases = _budget_entries(comment, "phase")
+    headroom = _budget_entries(comment, "headroom")
+    phase_total = sum(seconds for seconds, _ in phases)
+    headroom_total = sum(seconds for seconds, _ in headroom)
+    wait_cap = int(
+        re.search(r"^\s*BREW_PREINSTALL_WAIT_SECONDS=(\d+)$", behave, re.M).group(1)
+    )
+    poll = int(
+        re.search(r"^\s*BREW_PREINSTALL_POLL_SECONDS=(\d+)$", behave, re.M).group(1)
+    )
 
-    # 600 + 120 + 300 + 300 + 360 + 900 + 2700 = 5280s, and the one path that
-    # repeats the install (an in-flight run that fails after being waited out)
-    # adds 900 more, which is still inside 7200.
-    assert 600 + 120 + 300 + 300 + 360 + 900 + 2700 == 5280
-    assert 5280 + 900 < _systemd_run_tests_template()["activeDeadlineSeconds"]
-    assert "~88min" in budget
-    assert "~17min inside this deadline" in budget
+    assert len(phases) >= 5, f"the budget lists too few phases: {phases}"
+    assert headroom, "the budget names no cost it expects the headroom to absorb"
+
+    # The lane's own expected cost, then the worst case the reviewer has to
+    # believe: every headroom item paid on the same run.
+    assert phase_total + wait_cap <= deadline
+    assert phase_total + headroom_total <= deadline
+
+    # An in-flight run is waited out instead of killed, so the wait cap spends
+    # the same seconds the budget already allocates to that one install. A
+    # larger cap would let the wait alone outgrow its own budget line; a
+    # smaller one would abandon a run the budget says it can afford.
+    install = [seconds for seconds, text in phases if "cask install" in text]
+    assert install == [wait_cap], (
+        f"the in-flight wait cap ({wait_cap}s) must equal the single"
+        f" cask-install phase, found {install}"
+    )
+    assert wait_cap % poll == 0
+
+    # The comment states the minutes it derives from those numbers; recompute
+    # them so a phase edit that leaves the prose behind fails here.
+    assert f"~{round(phase_total / 60)}min" in comment
+    assert f"~{round((deadline - phase_total) / 60)}min of headroom" in comment
+    assert (
+        f"~{round((deadline - phase_total - headroom_total) / 60)}min inside the"
+        " deadline" in comment
+    )
+
+    # The restart attempts the session can burn before run-behave.sh ever
+    # samples the unit are real wall clock that no phase line covers; the
+    # budget has to say the headroom absorbs them, and say what bounds them.
+    assert any("Restart=on-failure" in text for _, text in headroom)
+    assert "StartLimitBurst=3 within StartLimitIntervalSec=600" in comment
+
+    # The claim the single install phase rests on.
+    assert "content-addressed" in comment
+    assert f"BREW_PREINSTALL_WAIT_SECONDS (the same {wait_cap}s)" in comment
 
 
 def test_native_systemd_runner_asks_logind_for_the_runtime_path_exactly_once():
@@ -494,37 +589,72 @@ def test_native_systemd_runner_clears_the_brew_preinstall_restart_race():
     # `active`), and reset — all before behave, never after.
     behave = _systemd_runner_blocks()["RUN_BEHAVE"]
 
-    show = behave.index("BREW_PREINSTALL_STATE=$(brew_preinstall_property ActiveState)")
-    substate = behave.index(
-        "BREW_PREINSTALL_SUBSTATE=$(brew_preinstall_property SubState)"
-    )
+    sample = behave.index("brew_preinstall_sample() {")
+    first_read = behave.index("\n  brew_preinstall_sample\n")
     wait = behave.index("waiting up to ${BREW_PREINSTALL_WAIT_SECONDS}s")
     diagnose = behave.index("before behave started it")
     stop = behave.index("systemctl --user stop brew-preinstall.service")
     reset = behave.index("systemctl --user reset-failed brew-preinstall.service")
     run = behave.index("python3 -m behave")
 
-    assert show < substate < wait < diagnose < stop < reset < run
-    assert "BREW_PREINSTALL_STATE=${BREW_PREINSTALL_STATE:-unknown}" in behave
-    assert "BREW_PREINSTALL_SUBSTATE=${BREW_PREINSTALL_SUBSTATE:-unknown}" in behave
-    assert (
-        'if [[ "${BREW_PREINSTALL_STATE}" == "activating" \\\n'
-        '    && "${BREW_PREINSTALL_SUBSTATE}" != auto-restart* ]]; then' in behave
+    assert sample < first_read < wait < diagnose < stop < reset < run
+    assert re.search(
+        r'if \[\[ "\$\{BREW_PREINSTALL_STATE\}" == "activating" \\\n'
+        r'\s*&& "\$\{BREW_PREINSTALL_SUBSTATE\}" != auto-restart\* \]\]; then',
+        behave,
     )
-    assert (
-        'if [[ "${BREW_PREINSTALL_STATE}" == "inactive" \\\n'
-        '    || "${BREW_PREINSTALL_STATE}" == "active" ]]; then' in behave
+    assert re.search(
+        r'if \[\[ "\$\{BREW_PREINSTALL_STATE\}" == "inactive" \\\n'
+        r'\s*\|\| "\$\{BREW_PREINSTALL_STATE\}" == "active" \]\]; then',
+        behave,
     )
     # `auto-restart-queued` is the systemd >= 254 spelling; the prefix glob
     # must match both, and neither may be waited out.
-    assert behave.count('"${BREW_PREINSTALL_SUBSTATE}" != auto-restart*') == 1
-    assert behave.count('"${BREW_PREINSTALL_SUBSTATE}" == auto-restart*') == 1
+    assert 'BREW_PREINSTALL_SUBSTATE}" != auto-restart*' in behave
+    assert 'BREW_PREINSTALL_SUBSTATE}" == auto-restart*' in behave
     assert "systemctl --user is-failed" not in behave
 
+    # One `systemctl show` per sample, setting both variables together: two
+    # reads can straddle a transition and pair states the unit never held.
+    # `--value` is unusable for that, since systemctl orders the output itself.
+    assert behave.count("brew_preinstall_sample() {") == 1
+    assert (
+        "--property=ActiveState --property=SubState 2>/dev/null || true" in behave
+    )
+    assert "brew_preinstall_property" not in behave
+    assert "--property=ActiveState --value" not in behave
+    assert 'BREW_PREINSTALL_STATE="${value:-unknown}"' in behave
+    assert 'BREW_PREINSTALL_SUBSTATE="${value:-unknown}"' in behave
+    # The parse loop must stay in the calling shell. Piping `systemctl show`
+    # into `while read` puts it in a subshell, where both assignments are
+    # discarded and every branch below silently sees `unknown`.
+    assert behave.count('done <<< "${sample}"') == 2
+    assert "systemctl --user show" in behave
+    assert "show brew-preinstall.service | while" not in behave
+
     # inactive/active are settled, but they are also what a unit that systemd
-    # never ran looks like — LoadState/ConditionResult make that visible.
-    assert "LoadState=$(brew_preinstall_property LoadState)" in behave
-    assert "ConditionResult=$(brew_preinstall_property ConditionResult)" in behave
+    # never ran looks like. ConditionResult=no alone cannot say which: only an
+    # empty ConditionTimestamp distinguishes "never evaluated" from
+    # "evaluated and failed", so both are read and a verdict is printed.
+    assert "brew_preinstall_condition_report() {" in behave
+    assert re.search(
+        r"--property=LoadState --property=ConditionResult \\\n"
+        r"\s*--property=ConditionTimestamp 2>/dev/null \|\| true",
+        behave,
+    )
+    assert 'if [[ -z "${stamp}" ]]; then' in behave
+    assert "conditions never evaluated" in behave
+    assert "conditions evaluated and failed" in behave
+    assert "conditions evaluated and passed" in behave
+    assert "$(brew_preinstall_condition_report)" in behave
+
+    # A wait that can last a quarter of an hour has to keep saying so, or the
+    # lane is indistinguishable from a runner that stopped producing output.
+    assert "BREW_PREINSTALL_PROGRESS_SECONDS=60" in behave
+    assert (
+        "is still activating (${BREW_PREINSTALL_SUBSTATE}) after"
+        " ${BREW_PREINSTALL_WAITED}s of ${BREW_PREINSTALL_WAIT_SECONDS}s" in behave
+    )
 
     # Both cleanup steps capture their exit code and report it by name instead
     # of discarding it with `|| true`.
@@ -539,8 +669,37 @@ def test_native_systemd_runner_clears_the_brew_preinstall_restart_race():
     assert "reset-failed brew-preinstall.service || true" not in behave
     assert 'if [[ "${BREW_PREINSTALL_STOP_RC}" -ne 0 ]]; then' in behave
     assert 'if [[ "${BREW_PREINSTALL_RESET_RC}" -ne 0 ]]; then' in behave
-    assert "a queued auto-restart may still race the suite's explicit start" in behave
     assert "the suite may report a stale start limit instead of the real error" in behave
+
+    # A failed stop is not one hazard but three, and the pre-stop sample cannot
+    # say which: re-read, then name the one that actually applies. A live
+    # install left running is the serious one — the suite's start would then
+    # run brew concurrently against the same prefix.
+    failed_stop = behave.split(
+        'if [[ "${BREW_PREINSTALL_STOP_RC}" -ne 0 ]]; then', 1
+    )[1]
+    assert failed_stop.index("brew_preinstall_sample") < failed_stop.index(
+        "warning: stopping brew-preinstall.service"
+    )
+    assert "BREW_PREINSTALL_STOPPED_FROM=" in failed_stop
+    assert (
+        "(state was ${BREW_PREINSTALL_STOPPED_FROM}, now"
+        " ${BREW_PREINSTALL_STATE}/${BREW_PREINSTALL_SUBSTATE})" in failed_stop
+    )
+    assert (
+        "warning: a live brew-preinstall.service install is still running; the"
+        " suite's explicit start will run brew concurrently against the same"
+        " Homebrew prefix" in failed_stop
+    )
+    assert (
+        "warning: brew-preinstall.service still holds a queued auto-restart"
+        " that may race the suite's explicit start" in failed_stop
+    )
+    assert (
+        "warning: brew-preinstall.service is still active, so RemainAfterExit"
+        " keeps it latched and the suite's explicit start may be a no-op"
+        in failed_stop
+    )
 
     # The whole block is guarded on the lane, every manager call goes through
     # the validated runtime directory, and a session that disagrees with it is
@@ -562,7 +721,7 @@ def test_native_systemd_runner_clears_the_brew_preinstall_restart_race():
         "reset-failed",
     }
     assert all(
-        previous == 'env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \\'
+        previous.endswith('env XDG_RUNTIME_DIR="${RUNTIME_DIR}" \\')
         for previous, _ in user_calls
     )
     assert (
@@ -667,31 +826,119 @@ def test_brew_preinstall_settle_bounds_the_wait_for_a_wedged_run():
     assert "STUB systemctl stop" in stderr
 
 
-def test_brew_preinstall_settle_reports_load_state_for_a_settled_unit():
+def test_brew_preinstall_settle_reports_the_condition_verdict_for_a_settled_unit():
     # `inactive` is indistinguishable from "unit not installed" or "systemd
     # skipped it on ConditionUser/ConditionPathExists" — and a start of either
-    # exits 0, so the suite would pass on nothing. Say which one it is.
+    # exits 0, so the suite would pass on nothing. ConditionResult alone cannot
+    # separate them either: systemd reports `no` both for a unit whose
+    # conditions were evaluated and failed *and* for one it has never tried to
+    # start (including not-found), and only the empty ConditionTimestamp marks
+    # the second. Read both and state which case it is.
     missing = _run_settle_block(
         active_states=["inactive"],
         sub_states=["dead"],
         load_state="not-found",
+        condition_result="no",
+        condition_timestamp="",
     )
     skipped = _run_settle_block(
         active_states=["inactive"],
         sub_states=["dead"],
         condition_result="no",
+        condition_timestamp="Sun 2026-08-09 12:00:00 EDT",
     )
+    clean = _run_settle_block(active_states=["inactive"], sub_states=["dead"])
 
     assert missing.returncode == 0, missing.stderr
     assert (
-        "is inactive (dead, LoadState=not-found, ConditionResult=yes)"
-        " before behave started it" in missing.stderr
+        "is inactive (dead, LoadState=not-found, ConditionResult=no,"
+        " ConditionTimestamp=<empty>, conditions never evaluated, so systemd"
+        " has not tried to start this unit) before behave started it"
+        in missing.stderr
     )
     assert "STUB systemctl status" not in missing.stderr  # settled: no dump
+
     assert skipped.returncode == 0, skipped.stderr
     assert (
-        "is inactive (dead, LoadState=loaded, ConditionResult=no)"
-        " before behave started it" in skipped.stderr
+        "is inactive (dead, LoadState=loaded, ConditionResult=no,"
+        " ConditionTimestamp=Sun 2026-08-09 12:00:00 EDT, conditions evaluated"
+        " and failed, so the start was skipped) before behave started it"
+        in skipped.stderr
+    )
+
+    assert clean.returncode == 0, clean.stderr
+    assert "conditions evaluated and passed) before behave started it" in clean.stderr
+    # The same ConditionResult=no is reported for both of the first two, so the
+    # verdict — not the raw property — is what tells them apart.
+    assert "ConditionResult=no" in missing.stderr
+    assert "ConditionResult=no" in skipped.stderr
+    assert "conditions never evaluated" not in skipped.stderr
+
+
+def test_brew_preinstall_settle_samples_active_state_and_sub_state_atomically():
+    # Two `systemctl show` calls can straddle a transition and hand the block
+    # an ActiveState/SubState pair the unit never actually held — for example
+    # `activating` from before a failure with `failed` from after it, which
+    # would send the lane down the wrong branch. One call, both properties.
+    result = _run_settle_block(
+        active_states=["activating", "active"], sub_states=["start", "exited"]
+    )
+
+    assert result.returncode == 0, result.stderr
+    shows = re.findall(r"^STUB show: (.*)$", result.stderr, re.M)
+    state_reads = [
+        request
+        for request in shows
+        if "ActiveState" in request or "SubState" in request
+    ]
+
+    assert state_reads, result.stderr
+    assert all(request == "ActiveState SubState" for request in state_reads)
+    # The condition properties are their own single read, and never mixed into
+    # the state sample: `--value` would order a mixed read by systemd's rules,
+    # not the requested ones.
+    assert "LoadState ConditionResult ConditionTimestamp" in shows
+
+
+def test_brew_preinstall_settle_reports_progress_while_it_waits():
+    # A wedged install can hold the lane here for 15 minutes. Silence for that
+    # long is indistinguishable from a runner that died, so the wait reports
+    # every BREW_PREINSTALL_PROGRESS_SECONDS against a known state.
+    wedged = _run_settle_block(active_states=["activating"], sub_states=["start"])
+    brief = _run_settle_block(
+        active_states=["activating", "activating", "active"],
+        sub_states=["start", "start", "exited"],
+    )
+
+    assert wedged.returncode == 0, wedged.stderr
+    progress = re.findall(
+        r"is still activating \(start\) after (\d+)s of 900s", wedged.stderr
+    )
+
+    assert [int(seconds) for seconds in progress] == list(range(60, 901, 60))
+
+    # A run that settles inside the first interval says nothing extra.
+    assert brief.returncode == 0, brief.stderr
+    assert "is still activating" not in brief.stderr
+
+
+def test_brew_preinstall_settle_degrades_when_property_reads_are_empty():
+    # An unreachable user manager, or a property systemctl cannot answer,
+    # prints nothing at all. That must not read as a settled state: `unknown`
+    # falls through to the diagnostic branch and is still stopped and reset,
+    # so behave starts from a known place instead of the lane aborting under
+    # `set -euo pipefail`.
+    result = _run_settle_block(
+        active_states=["activating"], sub_states=["start"], show_empty=True
+    )
+
+    assert result.returncode == 0, result.stderr
+    stderr = result.stderr
+    assert "SLEEPS=0" in stderr  # unknown is not activating: nothing to wait for
+    assert "was unknown (unknown) before behave started it" in stderr
+    assert "STUB systemctl status" in stderr
+    assert stderr.index("STUB systemctl stop") < stderr.index(
+        "STUB systemctl reset-failed"
     )
 
 
@@ -706,9 +953,65 @@ def test_brew_preinstall_settle_survives_a_failing_stop_and_reset():
     assert result.returncode == 0, result.stderr
     stderr = result.stderr
     assert "warning: stopping brew-preinstall.service before behave exited 1" in stderr
-    assert "(state was failed/failed)" in stderr
+    assert "(state was failed/failed, now failed/failed)" in stderr
     assert "warning: reset-failed brew-preinstall.service exited 1" in stderr
+    assert "(last observed state failed/failed)" in stderr
     assert "SLEEPS=0" in stderr
+    # Nothing survived the stop here, so none of the three specific hazards
+    # may be claimed.
+    assert "a live brew-preinstall.service install is still running" not in stderr
+    assert "still holds a queued auto-restart" not in stderr
+    assert "RemainAfterExit keeps it latched" not in stderr
+
+
+def test_brew_preinstall_settle_names_the_hazard_a_failed_stop_left_behind():
+    # A failed stop is three different problems and the pre-stop sample cannot
+    # say which, so the block re-reads the unit. A live install is the serious
+    # one: the suite's start would run a second brew against the same prefix.
+    live = _run_settle_block(
+        active_states=["failed"],
+        sub_states=["failed"],
+        stub_rc=1,
+        after_stop=("activating", "start"),
+    )
+    queued = _run_settle_block(
+        active_states=["failed"],
+        sub_states=["failed"],
+        stub_rc=1,
+        after_stop=("activating", "auto-restart-queued"),
+    )
+    latched = _run_settle_block(
+        active_states=["failed"],
+        sub_states=["failed"],
+        stub_rc=1,
+        after_stop=("active", "exited"),
+    )
+
+    assert live.returncode == 0, live.stderr
+    assert "(state was failed/failed, now activating/start)" in live.stderr
+    assert (
+        "warning: a live brew-preinstall.service install is still running; the"
+        " suite's explicit start will run brew concurrently against the same"
+        " Homebrew prefix" in live.stderr
+    )
+    assert "still holds a queued auto-restart" not in live.stderr
+
+    assert queued.returncode == 0, queued.stderr
+    assert "(state was failed/failed, now activating/auto-restart-queued)" in queued.stderr
+    assert (
+        "warning: brew-preinstall.service still holds a queued auto-restart"
+        " that may race the suite's explicit start" in queued.stderr
+    )
+    assert "a live brew-preinstall.service install is still running" not in queued.stderr
+
+    assert latched.returncode == 0, latched.stderr
+    assert "(state was failed/failed, now active/exited)" in latched.stderr
+    assert (
+        "warning: brew-preinstall.service is still active, so RemainAfterExit"
+        " keeps it latched and the suite's explicit start may be a no-op"
+        in latched.stderr
+    )
+    assert "a live brew-preinstall.service install is still running" not in latched.stderr
 
 
 def test_native_systemd_runner_deletes_the_target_pod_on_termination_signals():


### PR DESCRIPTION
## What

Adds a dedicated `homebrew` suite to the native-systemd container runner so
Homebrew, bctl, and ChairLift can be validated in the normal bootc OCI image
without KubeVirt. The lane provisions Homebrew only for this suite, reconciles
the systemd user manager with qecore's session bus, rejects zero-scenario
greens, and preserves existing suite behavior.

## Validation

- `just lint`
- `pytest -q tests/unit/test_container_only_qa_workflows.py` - 56 passed
- `python3 scripts/validate-docs.py`
- shell syntax and mocked state-transition coverage

## Scope

No VM, raw disk, host PID namespace, or direct cluster apply. ArgoCD remains
the owner of the WorkflowTemplate.

Assisted-by: GPT-5.6 Sol via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
