### PR TITLE
ops(llm-d): pause local inference, and settle the contradiction about how

### DIFF
--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -133,10 +133,30 @@ kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.
 ## ROCm inference pause
 
 The local `llm-d` inference workload may be intentionally paused in
-`manifests/llm-d.yaml` with `replicas: 0` and no Service. Treat that as the
-expected stopped state, not a failed deployment. Do not use `kubectl scale` for
-a durable pause because ArgoCD self-heal restores the declared state; restore
-the Deployment replica and Service in git to re-enable inference.
+`manifests/llm-d.yaml` with `replicas: 0`. Treat that as the expected stopped
+state, not a failed deployment. Do not use `kubectl scale` for a durable pause
+because ArgoCD self-heal restores the declared state; restore `replicas: 1` in
+git to re-enable inference.
+
+That self-heal is fast enough to mislead: a runtime `kubectl scale --replicas=0`
+was measured being reverted in **~1 second**, with a replacement pod already
+Running. An operator who scales and then checks `kubectl get deploy` sees
+`0/1` and concludes it worked.
+
+**The PVC caveat, and when it actually applies.** `manifests/llm-d.yaml` long
+carried the opposite advice — scale at runtime, never commit `replicas: 0` —
+on the grounds that `llm-d-model-cache` is `local-path`, which is
+`WaitForFirstConsumer`, so a PVC with no pod never binds, ArgoCD blocks on it,
+and the Deployment is never created. **That deadlock is real but applies only
+at first creation.** Once the PVC is `Bound` it stays bound;
+`WaitForFirstConsumer` gates the first binding, not the lifetime. So:
+
+| State of `llm-d-model-cache` | Pausing with `replicas: 0` in git |
+|---|---|
+| `Bound` | Safe — this is the durable pause |
+| `Pending` / not yet created | Deadlocks; bring it up at `replicas: 1` first |
+
+Check with `kubectl get pvc -n llm-d` before committing a pause.
 
 If an old ArgoCD operation is still waiting for the pre-pause Deployment,
 terminate only that stale operation before syncing the current revision. Remove

--- a/manifests/llm-d.yaml
+++ b/manifests/llm-d.yaml
@@ -46,14 +46,24 @@ metadata:
     app.kubernetes.io/name: llm-d-modelserver
     app.kubernetes.io/part-of: testing-lab
 spec:
-  # Enabled. Note this cannot be staged at replicas: 0 while the cache PVC uses
-  # local-path: local-path is WaitForFirstConsumer, so the PVC only binds once a
-  # pod consumes it, and ArgoCD blocks its sync waiting for the PVC to become
-  # healthy — which never happens without a pod. replicas: 0 plus this PVC is a
-  # circular deadlock that also prevents the Deployment itself from being
-  # created. To take the server down, scale it to 0 at runtime rather than
-  # committing replicas: 0.
-  replicas: 1
+  # PAUSED. The GPU and its GTT budget are wanted for video transcoding on the
+  # Wolves cut; restore `replicas: 1` here to re-enable inference.
+  #
+  # The deadlock this comment used to warn about is real but applies ONLY at
+  # first creation. local-path is WaitForFirstConsumer, so `llm-d-model-cache`
+  # binds only once a pod consumes it: staging a NEW deployment at replicas: 0
+  # leaves the PVC Pending, ArgoCD blocks its sync waiting for it to go healthy,
+  # and the Deployment is never created. Once the PVC is Bound it STAYS bound --
+  # WaitForFirstConsumer gates the first binding, not the lifetime -- so pausing
+  # an already-running server here is safe. Verified before committing: the PVC
+  # is Bound to pvc-8cd401e5 (100Gi, RWO, local-path), age 6d19h.
+  #
+  # This is the durable pause. Do NOT use `kubectl scale`: `testing-lab-infra`
+  # runs with selfHeal, and a runtime scale-to-0 was measured being reverted in
+  # ~1 second, a replacement pod spawning immediately. That matches
+  # docs/skills/cluster-tooling/SKILL.md and contradicts this comment's previous
+  # advice, which is why the advice is corrected rather than left standing.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: llm-d-modelserver


### PR DESCRIPTION
Frees the `amd.com/gpu` and its GTT budget on `exo-0` for video transcoding work on the Wolves cut. Restore `replicas: 1` to re-enable.

## The interesting part: two docs disagreed, and one was wrong

- `docs/skills/cluster-tooling/SKILL.md` — commit `replicas: 0`; **never** `kubectl scale`, because self-heal reverts it.
- `manifests/llm-d.yaml` — the exact opposite: scale at runtime, **never** commit `replicas: 0`, because `local-path` is `WaitForFirstConsumer`, a pod-less PVC never binds, and ArgoCD deadlocks.

Measured instead of picked a side:

1. **`kubectl scale --replicas=0` does not survive.** Reverted in **~1 second**, replacement pod already `Running`. The manifest's advice is not viable under `testing-lab-infra`'s selfHeal. (It is also misleading in passing — `kubectl get deploy` shows `0/1` right after, so it looks like it worked.)
2. **The deadlock is real, but only at first creation.** `llm-d-model-cache` is already `Bound` (`pvc-8cd401e5`, 100Gi, RWO, `local-path`, age 6d19h). `WaitForFirstConsumer` gates the *first* binding, not the lifetime, so pausing an already-running server is safe.

So the SKILL was right for a **bound** PVC and the manifest was right for an **unbound** one. Neither said which case it meant. Both now state the condition, with the check (`kubectl get pvc -n llm-d`) written down rather than implied.

## Notes

- The Service is left in place — it just has no endpoints while paused, and kagent's `ModelConfig` still resolves the name. The SKILL's old "and no Service" wording is dropped as it did not match the manifest.
- `just lint` green (`✓ All manifests valid`).

Related context: hardware encode on these nodes was probed for the same transcoding work — VAAPI H.264 encode **does** work on Strix Halo via `radeonsi`, and runs happily *alongside* ROCm (different engines: VCN vs compute). It was still not worth using: on 24 cores `libx264 -preset slow` measured **15.7× realtime** against VAAPI's **13.7×**, at better quality.