### PR TITLE
fix(argo): suspend stable image pollers by default

### DIFF
--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -36,6 +36,30 @@ their QA trigger is disabled. Daily testing-lane coverage comes from
 `nightly-smoke` at 02:00 UTC, `nightly-smoke-lts` at 02:30 UTC, and
 `nightly-dakota` at 03:00 UTC.
 
+### Poller operating policy
+
+The testing and Dakota pollers stay enabled at their staggered ten-minute
+cadence because those lanes are actively used and the check is a cheap,
+manifest-only upstream digest lookup. Their manifests set `run-qa: "false"`,
+so a poll does not fan out a full QA run; the nightly workflows provide the
+daily suite coverage and are not duplicate triggers.
+
+The stable pollers (`image-poll-bluefin-stable` and
+`image-poll-lts-stable`) are suspended in git by default. Stable images change
+roughly weekly, and the active bluefin-stable poller was measured repeating a
+failing full-suite run about hourly. To validate a stable lane once, submit it
+directly:
+
+```bash
+argo submit --from cronworkflow/image-poll-bluefin-stable -n argo --wait --log
+argo submit --from cronworkflow/image-poll-lts-stable -n argo --wait --log
+```
+
+For a scheduled validation window, change that manifest's `spec.suspend` to
+`false`, commit and push, then restore `true` afterward. Direct `kubectl patch`
+or `argo resume` changes are temporary because ArgoCD reconciles the
+git-tracked value.
+
 ## Cluster topology
 
 | Host | Role | IP | Notes |

--- a/manifests/image-poll-bluefin-stable.yaml
+++ b/manifests/image-poll-bluefin-stable.yaml
@@ -1,5 +1,9 @@
-# CronWorkflow: polls ghcr.io/projectbluefin/bluefin:stable every 10 minutes.
-# Triggers bluefin-qa-pipeline only when OCI digest changes vs ConfigMap state.
+# CronWorkflow: polls ghcr.io/projectbluefin/bluefin:stable every 10 minutes
+# when deliberately enabled.
+# Stable images change roughly weekly; keep this off by default because an
+# active poller previously repeated a failing full-suite run about hourly.
+# Run once with `argo submit --from cronworkflow/image-poll-bluefin-stable -n argo`
+# or set `suspend: false` in git for a reviewed scheduled validation window.
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
@@ -9,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  suspend: true
   schedules:
     - "4/10 * * * *"
   timezone: "UTC"

--- a/manifests/image-poll-bluefin-testing.yaml
+++ b/manifests/image-poll-bluefin-testing.yaml
@@ -1,6 +1,7 @@
 # CronWorkflow: polls ghcr.io/projectbluefin/bluefin:testing every 10 minutes.
-# Tracks OCI digest changes without launching frequent QA; daily QA is scheduled
-# by nightly-smoke.
+# This remains enabled for the actively used testing lane: the direct registry
+# digest check is manifest-only, and run-qa=false prevents a QA fan-out here.
+# Daily QA is scheduled by nightly-smoke.
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:

--- a/manifests/image-poll-dakota.yaml
+++ b/manifests/image-poll-dakota.yaml
@@ -1,6 +1,7 @@
 # CronWorkflow: polls ghcr.io/projectbluefin/dakota:testing every 10 minutes.
-# Tracks OCI digest changes without launching frequent QA; daily QA is scheduled
-# by nightly-dakota.
+# This remains enabled for the actively used testing lane: the direct registry
+# digest check is manifest-only, and run-qa=false prevents a QA fan-out here.
+# Daily QA is scheduled by nightly-dakota.
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:

--- a/manifests/image-poll-lts-stable.yaml
+++ b/manifests/image-poll-lts-stable.yaml
@@ -1,5 +1,9 @@
-# CronWorkflow: polls ghcr.io/projectbluefin/bluefin-lts:stable every 10 minutes.
-# Triggers bluefin-qa-pipeline only when OCI digest changes vs ConfigMap state.
+# CronWorkflow: polls ghcr.io/projectbluefin/bluefin-lts:stable every 10 minutes
+# when deliberately enabled.
+# Stable images change roughly weekly; keep this off by default so an active
+# poller cannot repeat a failing full-suite run without an explicit decision.
+# Run once with `argo submit --from cronworkflow/image-poll-lts-stable -n argo`
+# or set `suspend: false` in git for a reviewed scheduled validation window.
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
@@ -9,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: lab
     bluefin.io/trigger: digest-poll
 spec:
-  suspend: false
+  suspend: true
   schedules:
     - "6/10 * * * *"
   timezone: "UTC"

--- a/manifests/image-poll-lts-testing.yaml
+++ b/manifests/image-poll-lts-testing.yaml
@@ -1,6 +1,7 @@
 # CronWorkflow: polls ghcr.io/projectbluefin/bluefin-lts:testing every 10 minutes.
-# Tracks OCI digest changes without launching frequent QA; daily QA is scheduled
-# by nightly-smoke-lts.
+# This remains enabled for the actively used testing lane: the direct registry
+# digest check is manifest-only, and run-qa=false prevents a QA fan-out here.
+# Daily QA is scheduled by nightly-smoke-lts.
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:

--- a/tests/unit/test_poller_cadence.py
+++ b/tests/unit/test_poller_cadence.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_manifest(name: str) -> dict:
+    return yaml.safe_load((ROOT / "manifests" / name).read_text(encoding="utf-8"))
+
+
+def test_stable_image_pollers_are_suspended_by_default():
+    for name, schedule in (
+        ("image-poll-bluefin-stable.yaml", "4/10 * * * *"),
+        ("image-poll-lts-stable.yaml", "6/10 * * * *"),
+    ):
+        spec = load_manifest(name)["spec"]
+        assert spec["suspend"] is True
+        assert spec["schedules"] == [schedule]
+
+
+def test_active_testing_and_dakota_pollers_keep_staggered_freshness_checks():
+    expected = {
+        "image-poll-bluefin-testing.yaml": "0/10 * * * *",
+        "image-poll-lts-testing.yaml": "2/10 * * * *",
+        "image-poll-dakota.yaml": "8/10 * * * *",
+    }
+
+    for name, schedule in expected.items():
+        manifest = load_manifest(name)
+        spec = manifest["spec"]
+        parameters = {
+            parameter["name"]: parameter.get("value")
+            for parameter in spec["workflowSpec"]["arguments"]["parameters"]
+        }
+
+        assert spec["suspend"] is False
+        assert spec["schedules"] == [schedule]
+        assert parameters["run-qa"] == "false"
+
+
+def test_testing_nightly_workflows_remain_the_daily_qa_path():
+    expected = {
+        "nightly-smoke.yaml": ("0 2 * * *", "bluefin"),
+        "nightly-smoke-lts.yaml": ("30 2 * * *", "bluefin-lts"),
+        "nightly-dakota.yaml": ("0 3 * * *", "dakota"),
+    }
+
+    for name, (schedule, variant) in expected.items():
+        spec = load_manifest(name)["spec"]
+        parameters = {
+            parameter["name"]: parameter.get("value")
+            for parameter in spec["workflowSpec"]["arguments"]["parameters"]
+        }
+
+        assert spec["suspend"] is False
+        assert spec["schedules"] == [schedule]
+        assert parameters["variant"] == variant


### PR DESCRIPTION
## Summary

- Suspend `image-poll-bluefin-stable` and `image-poll-lts-stable` in git by default.
- Keep the actively used testing and Dakota digest pollers enabled at staggered 10-minute intervals; their manifest-only checks retain freshness without QA fan-out (`run-qa: "false"`).
- Keep `nightly-smoke`, `nightly-smoke-lts`, and `nightly-dakota` as the separate daily QA path.
- Document one-off and scheduled stable-lane enablement, plus add cadence contract tests.

## Rationale

The egress audit measured the stable bluefin lane spawning about seven `run-container-tests` pods across the full suite roughly hourly, with all observed generations exiting 1. Stable tags change only about weekly, so leaving a 10-minute full-suite poller active creates repeated failing work with no freshness benefit. The owner preference is off-by-default, so stable polling now requires an explicit one-off submission or a deliberate git change to `spec.suspend: false`.

The testing/Dakota pollers remain enabled because those lanes are used for QA. Their direct upstream digest checks are cheap manifest-only requests, and the existing nightly workflows are not duplicate triggers because the pollers explicitly skip QA.

## Validation

- `just lint` ✅
- `pytest -q tests/unit/test_poller_cadence.py tests/unit/test_image_poll_bandwidth.py` ✅ (9 passed)
- `pytest -q tests/unit` ⚠️ 385 passed, 7 unrelated baseline failures in existing metrics, dashboard, RECC, and Zot tests.

Full unit-suite failures do not touch the owned poller manifests, runbook, or cadence test.