### PR TITLE
fix(qa): curb reconciler clone churn

### DIFF
--- a/manifests/qa-run-reconciler.yaml
+++ b/manifests/qa-run-reconciler.yaml
@@ -1,4 +1,888 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qa-run-publisher
+  namespace: argo
+  labels:
+    app.kubernetes.io/part-of: lab
+data:
+  publish_qa_run.py: |
+    #!/usr/bin/env python3
+    """Normalize and append public-safe QA workflow evidence snapshots."""
+
+    from __future__ import annotations
+
+    import argparse
+    import hashlib
+    import json
+    import os
+    import re
+    import shutil
+    import subprocess
+    import sys
+    from datetime import datetime, timezone
+    from pathlib import Path
+    from urllib.parse import urlsplit
+    import ipaddress
+
+
+    HISTORY_PATH = Path("docs/data/history/qa-runs.ndjson")
+    REPO_URL = "https://github.com/projectbluefin/lab.git"
+    SCHEMA_VERSION = "1.0"
+    PUBLICATION_STATE_VERSION = 1
+    PUBLIC_HISTORY_URL = (
+        "https://github.com/projectbluefin/lab/blob/main/docs/data/history/qa-runs.ndjson"
+    )
+    SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/+@=-]{0,511}$")
+    DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+    SCENARIO_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 .,:;()/_+-]{0,159}$")
+    RESULT_SUMMARY = re.compile(r"^(?P<passed>[0-9]+)/(?P<total>[0-9]+) scenarios passed$")
+    TERMINAL_PHASES = {"Succeeded", "Failed", "Error", "Terminated"}
+    PUBLIC_EVIDENCE_HOSTS = {
+        "github.com",
+        "raw.githubusercontent.com",
+        "factory.projectbluefin.io",
+        "projectbluefin.github.io",
+    }
+    PUBLIC_REGISTRY_HOSTS = {
+        "cgr.dev",
+        "docker.io",
+        "ghcr.io",
+        "quay.io",
+        "registry.fedoraproject.org",
+    }
+
+
+    class RecordError(ValueError):
+        """A QA evidence record is malformed or unsafe to publish."""
+
+
+    def utc_now() -> str:
+        return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+    def timestamp(value: object, field: str, *, required: bool = False) -> str | None:
+        if value is None:
+            if required:
+                raise RecordError(f"{field} is required")
+            return None
+        if not isinstance(value, str) or not value:
+            raise RecordError(f"{field} must be an ISO8601 timestamp or null")
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise RecordError(f"{field} must be ISO8601") from exc
+        if parsed.tzinfo is None:
+            raise RecordError(f"{field} must include a timezone")
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+    def safe_text(value: object, field: str, *, required: bool = False, limit: int = 512) -> str | None:
+        if value is None and not required:
+            return None
+        if not isinstance(value, str) or not value or len(value) > limit or not SAFE_TEXT.fullmatch(value):
+            raise RecordError(f"{field} must be a safe single-line identifier")
+        if any(secret in value.lower() for secret in ("token", "password", "secret", "authorization")):
+            raise RecordError(f"{field} contains a sensitive-looking value")
+        return value
+
+
+    def public_value(value: object) -> str | None:
+        """Return a workflow parameter only when it is safe for public evidence."""
+        if not isinstance(value, str) or not value or len(value) > 512:
+            return None
+        if any(ord(character) < 32 for character in value):
+            return None
+        lowered = value.lower()
+        if any(secret in lowered for secret in ("token", "password", "secret", "authorization", "x-access-token")):
+            return None
+        try:
+            ipaddress.ip_address(value)
+        except ValueError:
+            pass
+        else:
+            return None
+        if numeric_ipv4_like(value):
+            return None
+        if lowered == "localhost" or lowered.endswith((".cluster.local", ".svc", ".local")):
+            return None
+        if "/" not in value:
+            try:
+                hostname = urlsplit(f"//{value}").hostname
+            except ValueError:
+                hostname = None
+            if hostname == "localhost":
+                return None
+            if hostname:
+                if numeric_ipv4_like(hostname):
+                    return None
+                try:
+                    ipaddress.ip_address(hostname)
+                except ValueError:
+                    pass
+                else:
+                    return None
+        if "://" in value:
+            try:
+                parsed = urlsplit(value)
+                port = parsed.port
+            except ValueError:
+                return None
+            if (
+                parsed.scheme != "https"
+                or not parsed.hostname
+                or parsed.username
+                or parsed.password
+                or port not in (None, 443)
+                or not public_host(parsed.hostname, PUBLIC_EVIDENCE_HOSTS)
+            ):
+                return None
+            return value
+
+        registry = value.split("/", 1)[0]
+        if "/" in value and (
+            registry == "localhost" or "." in registry or ":" in registry or registry.startswith("[")
+        ):
+            try:
+                parsed = urlsplit(f"//{registry}")
+                port = parsed.port
+            except ValueError:
+                return None
+            if (
+                not parsed.hostname
+                or parsed.username
+                or parsed.password
+                or port is not None and not 1 <= port <= 65535
+                or not public_host(parsed.hostname, PUBLIC_REGISTRY_HOSTS)
+            ):
+                return None
+        return value
+
+
+    def numeric_ipv4_like(hostname: str) -> bool:
+        """Identify IPv4 spellings accepted by legacy URL/IP parsers.
+
+        ``ipaddress`` deliberately accepts only canonical dotted-quad syntax.
+        Browser and libc parsers also accept one-to-four numeric components, with
+        decimal, octal, and hexadecimal components. Those spellings must never be
+        published as host identifiers because they can resolve to private hosts.
+        """
+        hostname = hostname.rstrip(".").lower()
+        parts = hostname.split(".")
+        if not 1 <= len(parts) <= 4:
+            return False
+
+        values = []
+        for part in parts:
+            if not part:
+                return False
+            if part.startswith("0x"):
+                digits, base = part[2:], 16
+                if not digits or not re.fullmatch(r"[0-9a-f]+", digits):
+                    return False
+            elif re.fullmatch(r"[0-9]+", part):
+                # Leading-zero components are legacy octal. Treat invalid octal
+                # digits as numeric-looking too, rather than accepting ambiguity.
+                digits, base = part, 8 if len(part) > 1 and part.startswith("0") else 10
+                if base == 8 and not re.fullmatch(r"[0-7]+", digits):
+                    return True
+            else:
+                return False
+            values.append(int(digits, base))
+
+        limits = ((0xFFFFFFFF,), (0xFF, 0xFFFFFF), (0xFF, 0xFF, 0xFFFF), (0xFF,) * 4)
+        return all(value <= limit for value, limit in zip(values, limits[len(parts) - 1]))
+
+
+    def public_host(hostname: str, allowed_hosts: set[str]) -> bool:
+        """Accept an explicitly approved public hostname, never an IP literal."""
+        hostname = hostname.rstrip(".").lower()
+        if numeric_ipv4_like(hostname):
+            return False
+        try:
+            address = ipaddress.ip_address(hostname)
+        except ValueError:
+            address = None
+        if address is not None:
+            return False
+        return hostname in allowed_hosts
+
+
+    def parameters(workflow: dict) -> dict[str, str]:
+        values: dict[str, str] = {}
+        for item in workflow.get("spec", {}).get("arguments", {}).get("parameters", []) or []:
+            if isinstance(item, dict) and isinstance(item.get("name"), str) and isinstance(item.get("value"), str):
+                values[item["name"]] = item["value"]
+        return values
+
+
+    def node_templates(nodes: list[dict]) -> set[str]:
+        templates = set()
+        for node in nodes:
+            if isinstance(node, dict):
+                for key in ("templateName", "displayName"):
+                    value = node.get(key)
+                    if isinstance(value, str):
+                        templates.add(value)
+        return templates
+
+
+    def failed_scenarios(nodes: list[dict]) -> list[str] | None:
+        """Read bounded scenario names from a runner's explicit result artifact."""
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            output_parameters = {
+                parameter.get("name"): parameter.get("value")
+                for parameter in node.get("outputs", {}).get("parameters", []) or []
+                if isinstance(parameter, dict)
+            }
+            if "failed-scenarios" not in output_parameters:
+                continue
+            try:
+                values = json.loads(output_parameters["failed-scenarios"])
+            except (TypeError, json.JSONDecodeError):
+                return None
+            if not isinstance(values, list) or len(values) > 20:
+                return None
+            if not all(
+                isinstance(scenario, str)
+                and SCENARIO_NAME.fullmatch(scenario)
+                and not any(
+                    secret in scenario.lower()
+                    for secret in ("token", "password", "secret", "authorization")
+                )
+                for scenario in values
+            ):
+                return None
+            if len(values) != len(set(values)):
+                return None
+            return values
+        return None
+
+
+    def has_result_summary(nodes: list[dict]) -> bool:
+        """Return whether a runner published a syntactically valid test summary."""
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            for parameter in node.get("outputs", {}).get("parameters", []) or []:
+                if not isinstance(parameter, dict) or parameter.get("name") != "result":
+                    continue
+                value = parameter.get("value")
+                if not isinstance(value, str):
+                    continue
+                match = RESULT_SUMMARY.fullmatch(value)
+                if match and int(match["passed"]) <= int(match["total"]):
+                    return True
+        return False
+
+
+    def artifact_state(nodes: list[dict], phase: str, templates: set[str]) -> dict[str, dict[str, object]]:
+        has_results = has_result_summary(nodes)
+        is_kde = "run-kde-tests" in templates
+        if phase not in TERMINAL_PHASES:
+            results = {
+                "state": "unavailable",
+                "state_reason": "Workflow is not terminal; result artifact availability is not final.",
+                "provenance": "Argo Workflow status node outputs",
+            }
+        elif has_results:
+            results = {
+                "state": "available",
+                "state_reason": None,
+                "provenance": "Argo Workflow status node output parameter",
+            }
+            scenarios = failed_scenarios(nodes)
+            if scenarios is not None:
+                results["failed_scenarios"] = scenarios
+        elif (scenarios := failed_scenarios(nodes)):
+            results = {
+                "state": "available",
+                "state_reason": None,
+                "provenance": "Argo Workflow status failed-scenarios output parameter",
+                "failed_scenarios": scenarios,
+            }
+        else:
+            results = {
+                "state": "unavailable",
+                "state_reason": "No trustworthy result or non-empty failed-scenarios output is present in the terminal Workflow status.",
+                "provenance": "Argo Workflow status node outputs",
+            }
+        if not is_kde:
+            screenshot = {
+                "state": "not_applicable",
+                "state_reason": "This QA workflow did not invoke the KDE screenshot-producing runner.",
+                "provenance": "Argo Workflow status template names",
+            }
+        elif phase not in TERMINAL_PHASES:
+            screenshot = {
+                "state": "unavailable",
+                "state_reason": "Workflow is not terminal; screenshot availability is not final.",
+                "provenance": "Argo Workflow status template names",
+            }
+        elif phase == "Succeeded":
+            screenshot = {
+                "state": "available",
+                "state_reason": None,
+                "provenance": "run-kde-tests requires screenshot publication before succeeding",
+            }
+        else:
+            screenshot = {
+                "state": "unavailable",
+                "state_reason": "The KDE runner did not complete successfully; screenshot availability is unverified.",
+                "provenance": "Argo Workflow terminal phase",
+            }
+        return {"results": results, "screenshot": screenshot}
+
+
+    def lane_data(workflow: dict, values: dict[str, str]) -> dict[str, str | None]:
+        template = workflow.get("spec", {}).get("workflowTemplateRef", {}).get("name", "")
+        variant = public_value(values.get("variant"))
+        if not variant:
+            variant = {
+                "aurora-qa-pipeline": "aurora",
+                "knuckle-qa-pipeline": "knuckle",
+            }.get(template)
+        # Image pollers carry branch=main as a testsuite/source ref. Their image tag
+        # is the published matrix lane (testing or stable), so it must win here.
+        branch = public_value(values.get("image-tag")) or public_value(values.get("branch"))
+        suite = public_value(values.get("suite")) or public_value(values.get("suites"))
+        if not variant or not branch:
+            return {
+                "name": None,
+                "variant": variant,
+                "branch": branch,
+                "suite": suite,
+                "state": "unavailable",
+                "state_reason": "Workflow parameters do not provide both variant and branch/image tag.",
+            }
+        if not suite:
+            return {
+                "name": f"{variant}-{branch}",
+                "variant": variant,
+                "branch": branch,
+                "suite": None,
+                "state": "unavailable",
+                "state_reason": "Workflow parameters do not provide a selected suite.",
+            }
+        return {
+            "name": f"{variant}-{branch}",
+            "variant": variant,
+            "branch": branch,
+            "suite": suite,
+            "state": "available",
+            "state_reason": None,
+        }
+
+
+    def image_data(values: dict[str, str]) -> dict[str, str | None]:
+        image = public_value(values.get("image"))
+        tag = public_value(values.get("image-tag"))
+        digest = public_value(values.get("image-digest"))
+        if digest and not DIGEST.fullmatch(digest):
+            digest = None
+        reference = f"{image}:{tag}" if image and tag else image
+        if reference and digest:
+            return {
+                "reference": reference,
+                "digest": digest,
+                "state": "available",
+                "state_reason": None,
+            }
+        return {
+            "reference": reference,
+            "digest": digest,
+            "state": "unavailable",
+            "state_reason": "No safe exact image reference and digest are available in the Workflow parameters.",
+        }
+
+
+    def suite_node_contexts(workflow: dict, selected_suites: set[str]) -> list[tuple[str, dict]]:
+        """Return the latest observable test node for each selected suite."""
+        by_suite: dict[str, dict] = {}
+        for node in (workflow.get("status", {}).get("nodes") or {}).values():
+            if not isinstance(node, dict) or node.get("phase") in {"Skipped", "Omitted"}:
+                continue
+            suite = next(
+                (
+                    item.get("value")
+                    for item in node.get("inputs", {}).get("parameters", []) or []
+                    if isinstance(item, dict) and item.get("name") == "suite"
+                    and isinstance(item.get("value"), str)
+                ),
+                None,
+            )
+            if suite not in selected_suites:
+                continue
+            previous = by_suite.get(suite)
+            priority = (
+                1 if node.get("phase") in TERMINAL_PHASES else 0,
+                node.get("finishedAt") or node.get("startedAt") or "",
+            )
+            previous_priority = (
+                1 if previous and previous.get("phase") in TERMINAL_PHASES else 0,
+                (previous or {}).get("finishedAt") or (previous or {}).get("startedAt") or "",
+            )
+            if previous is None or priority > previous_priority:
+                by_suite[suite] = node
+        return sorted(by_suite.items())
+
+
+    def normalize_record(
+        workflow: dict,
+        observed_at: str,
+        *,
+        suite: str | None = None,
+        node: dict | None = None,
+    ) -> dict[str, object]:
+        if not isinstance(workflow, dict):
+            raise RecordError("workflow must be an object")
+        metadata = workflow.get("metadata") or {}
+        status = workflow.get("status") or {}
+        name = safe_text(metadata.get("name"), "workflow_name", required=True, limit=253)
+        uid = safe_text(metadata.get("uid"), "workflow_uid", required=True, limit=253)
+        phase = safe_text((node or status).get("phase") or "Pending", "phase", limit=64)
+        created_at = timestamp(metadata.get("creationTimestamp"), "created_at", required=True)
+        started_at = timestamp((node or status).get("startedAt"), "started_at")
+        finished_at = timestamp((node or status).get("finishedAt"), "finished_at")
+        if started_at and started_at < created_at:
+            raise RecordError("started_at cannot precede created_at")
+        if finished_at and (not started_at or finished_at < started_at):
+            raise RecordError("finished_at must not precede started_at")
+        lifecycle_state = "terminal" if phase in TERMINAL_PHASES else "running"
+        values = parameters(workflow)
+        if suite:
+            values["suite"] = suite
+        nodes = [node] if node else [
+            item for item in (status.get("nodes") or {}).values() if isinstance(item, dict)
+        ]
+        templates = node_templates(nodes)
+        failure_state = "none" if phase == "Succeeded" else ("failed" if phase in TERMINAL_PHASES else "unavailable")
+        record: dict[str, object] = {
+            "schema_version": SCHEMA_VERSION,
+            "plane": "lab",
+            "record_type": "qa-run",
+            "workflow_uid": uid,
+            "workflow_name": name,
+            "observed_at": timestamp(observed_at, "observed_at", required=True),
+            "lifecycle": {
+                "state": lifecycle_state,
+                "phase": phase,
+                "created_at": created_at,
+                "started_at": started_at,
+                "finished_at": finished_at,
+            },
+            "lane": lane_data(workflow, values),
+            "image": image_data(values),
+            "artifacts": artifact_state(nodes, phase, templates),
+            "failure": {
+                "state": failure_state,
+                "phase": phase if failure_state == "failed" else None,
+            },
+            "provenance": {
+                "source_kind": "argoproj.io/Workflow",
+                "source_namespace": "argo",
+                "source_name": name,
+                "source_uid": uid,
+                "source_url": PUBLIC_HISTORY_URL,
+                "workflow_url": None,
+                "workflow_url_state": "unavailable",
+                "workflow_url_reason": "The Argo workflow endpoint is cluster-private and is never exported to Pages.",
+            },
+        }
+        fingerprint = dict(record)
+        fingerprint.pop("observed_at")
+        record["snapshot_id"] = hashlib.sha256(
+            json.dumps(fingerprint, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        return validate_record(record)
+
+
+    def normalize_workflows(workflow: object, observed_at: str) -> list[dict[str, object]]:
+        """Emit one exact-suite snapshot per observable QA task node.
+
+        A parent workflow with a comma-separated suite selection has no truthful
+        single suite of its own. It is therefore excluded unless its task nodes
+        identify the suites they executed.
+        """
+        if not isinstance(workflow, dict):
+            raise RecordError("workflow must be an object")
+        values = parameters(workflow)
+        selected = [
+            value.strip()
+            for value in (values.get("suites") or values.get("suite") or "").split(",")
+            if value.strip()
+        ]
+        if len(selected) > 1:
+            contexts = suite_node_contexts(workflow, set(selected))
+            return [
+                normalize_record(workflow, observed_at, suite=suite, node=node)
+                for suite, node in contexts
+            ]
+        return [normalize_record(workflow, observed_at)]
+
+
+    def normalize_workflow(workflow: object, observed_at: str) -> dict[str, object]:
+        """Normalize a workflow as one snapshot for direct callers.
+
+        Reconciliation uses ``normalize_workflows`` so it never assigns a
+        multi-suite parent to an arbitrary task-node suite.
+        """
+        if not isinstance(workflow, dict):
+            raise RecordError("workflow must be an object")
+        return normalize_record(workflow, observed_at)
+
+
+    def validate_record(record: object) -> dict[str, object]:
+        if not isinstance(record, dict):
+            raise RecordError("record must be an object")
+        required = {
+            "schema_version", "plane", "record_type", "snapshot_id", "workflow_uid", "workflow_name",
+            "observed_at", "lifecycle", "lane", "image", "artifacts", "failure", "provenance",
+        }
+        if set(record) != required:
+            raise RecordError("record fields do not match the QA-run schema")
+        if record["schema_version"] != SCHEMA_VERSION or record["plane"] != "lab" or record["record_type"] != "qa-run":
+            raise RecordError("record has an unsupported schema, plane, or type")
+        for key in ("snapshot_id", "workflow_uid", "workflow_name"):
+            safe_text(record[key], key, required=True)
+        if not re.fullmatch(r"[0-9a-f]{64}", str(record["snapshot_id"])):
+            raise RecordError("snapshot_id must be a sha256 hex digest")
+        timestamp(record["observed_at"], "observed_at", required=True)
+        lifecycle = record["lifecycle"]
+        if not isinstance(lifecycle, dict) or set(lifecycle) != {
+            "state", "phase", "created_at", "started_at", "finished_at"
+        }:
+            raise RecordError("lifecycle fields do not match the QA-run schema")
+        if lifecycle["state"] not in {"running", "terminal"}:
+            raise RecordError("lifecycle state must be running or terminal")
+        safe_text(lifecycle["phase"], "phase", required=True, limit=64)
+        created_at = timestamp(lifecycle["created_at"], "created_at", required=True)
+        started_at = timestamp(lifecycle["started_at"], "started_at")
+        finished_at = timestamp(lifecycle["finished_at"], "finished_at")
+        if started_at and started_at < created_at or finished_at and (not started_at or finished_at < started_at):
+            raise RecordError("lifecycle timestamps are not ordered")
+        if (lifecycle["state"] == "terminal") != (lifecycle["phase"] in TERMINAL_PHASES):
+            raise RecordError("lifecycle state and phase disagree")
+        if lifecycle["state"] == "running" and finished_at is not None:
+            raise RecordError("running lifecycle cannot have finished_at")
+        if lifecycle["state"] == "terminal" and (started_at is None or finished_at is None):
+            raise RecordError("terminal lifecycle requires start and finish timestamps")
+        lane = record["lane"]
+        if not isinstance(lane, dict) or set(lane) != {
+            "name", "variant", "branch", "suite", "state", "state_reason"
+        }:
+            raise RecordError("lane fields do not match the QA-run schema")
+        if lane.get("state") not in {"available", "unavailable"}:
+            raise RecordError("lane state must be explicit")
+        for key in ("name", "variant", "branch", "suite"):
+            value = lane.get(key)
+            if value is not None:
+                if public_value(value) != value:
+                    raise RecordError(f"lane.{key} is not safe for public evidence")
+                if key == "suite":
+                    for suite in str(value).split(","):
+                        safe_text(suite, "lane.suite", required=True)
+                else:
+                    safe_text(value, f"lane.{key}", required=True)
+        if lane["state"] == "available":
+            if not all(isinstance(lane.get(key), str) and lane[key] for key in ("name", "variant", "branch", "suite")):
+                raise RecordError("available lane requires name, variant, branch, and suite")
+            if lane.get("state_reason") is not None:
+                raise RecordError("available lane cannot have a state reason")
+        image = record["image"]
+        if not isinstance(image, dict) or set(image) != {"reference", "digest", "state", "state_reason"}:
+            raise RecordError("image fields do not match the QA-run schema")
+        if image.get("state") not in {"available", "unavailable"}:
+            raise RecordError("image state must be explicit")
+        if image.get("reference") is not None:
+            if public_value(image["reference"]) != image["reference"]:
+                raise RecordError("image reference is not safe for public evidence")
+            safe_text(image["reference"], "image.reference", required=True)
+        if image.get("digest") is not None and not DIGEST.fullmatch(str(image["digest"])):
+            raise RecordError("image digest must be a sha256 digest or null")
+        if image["state"] == "available" and (
+            not image.get("reference") or not image.get("digest") or image.get("state_reason") is not None
+        ):
+            raise RecordError("available image requires reference and digest without a state reason")
+        artifacts = record["artifacts"]
+        if not isinstance(artifacts, dict) or set(artifacts) != {"results", "screenshot"}:
+            raise RecordError("artifact fields do not match the QA-run schema")
+        for name, artifact in artifacts.items():
+            if not isinstance(artifact, dict) or artifact.get("state") not in {
+                "available", "unavailable", "not_applicable"
+            }:
+                raise RecordError("artifact availability must be explicit")
+            if not isinstance(artifact.get("provenance"), str) or not artifact["provenance"]:
+                raise RecordError("artifact provenance is required")
+            if artifact["state"] == "available" and artifact.get("state_reason") is not None:
+                raise RecordError("available artifact cannot have a state reason")
+            if artifact["state"] != "available" and not artifact.get("state_reason"):
+                raise RecordError("unavailable artifact requires a state reason")
+            scenarios = artifact.get("failed_scenarios")
+            if scenarios is not None:
+                if name != "results" or artifact["state"] != "available":
+                    raise RecordError("failed scenarios require an available result artifact")
+                if (
+                    not isinstance(scenarios, list)
+                    or len(scenarios) > 20
+                    or len(scenarios) != len(set(scenarios))
+                    or not all(
+                        isinstance(scenario, str)
+                        and SCENARIO_NAME.fullmatch(scenario)
+                        and not any(
+                            secret in scenario.lower()
+                            for secret in ("token", "password", "secret", "authorization")
+                        )
+                        for scenario in scenarios
+                    )
+                ):
+                    raise RecordError("failed scenarios must be safe, unique scenario names")
+        failure = record["failure"]
+        if not isinstance(failure, dict) or set(failure) != {"state", "phase"}:
+            raise RecordError("failure fields do not match the QA-run schema")
+        if failure.get("state") not in {"none", "failed", "unavailable"}:
+            raise RecordError("failure state must be explicit")
+        if failure["state"] == "failed" and failure.get("phase") not in {"Failed", "Error", "Terminated"}:
+            raise RecordError("failed evidence requires a failing terminal phase")
+        if failure["state"] != "failed" and failure.get("phase") is not None:
+            raise RecordError("non-failed evidence cannot have a failure phase")
+        provenance = record["provenance"]
+        if not isinstance(provenance, dict) or provenance.get("workflow_url") is not None:
+            raise RecordError("private workflow URLs must not be exported")
+        if provenance.get("source_url") != PUBLIC_HISTORY_URL or provenance.get("workflow_url_state") != "unavailable":
+            raise RecordError("provenance must use the public history location and hide the private workflow URL")
+        serialized = json.dumps(record)
+        if "192.168." in serialized or "x-access-token:" in serialized:
+            raise RecordError("record contains a private endpoint or credential")
+        return record
+
+
+    def read_history(path: Path) -> list[dict[str, object]]:
+        if not path.exists():
+            return []
+        records = []
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise RecordError(f"{path}:{number}: invalid JSON") from exc
+        return records
+
+
+    def append_records(path: Path, records: list[dict[str, object]]) -> int:
+        existing = {str(item.get("snapshot_id")): item for item in read_history(path)}
+        additions = []
+        for record in records:
+            validate_record(record)
+            previous = existing.get(str(record["snapshot_id"]))
+            if previous is None:
+                additions.append(record)
+                existing[str(record["snapshot_id"])] = record
+            elif {
+                key: value for key, value in previous.items() if key != "observed_at"
+            } != {
+                key: value for key, value in record.items() if key != "observed_at"
+            }:
+                raise RecordError("snapshot_id already exists with different evidence")
+        if additions:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                for record in additions:
+                    handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+        return len(additions)
+
+
+    def publication_key(record: dict[str, object]) -> str:
+        lane = record.get("lane")
+        suite = lane.get("suite") if isinstance(lane, dict) else None
+        return f"{record['workflow_uid']}::{suite or '<none>'}"
+
+
+    def publication_state(records: list[dict[str, object]]) -> dict[str, object]:
+        """Return the latest published snapshot for each current workflow lane."""
+        published: dict[str, str] = {}
+        for record in records:
+            validate_record(record)
+            key = publication_key(record)
+            snapshot_id = str(record["snapshot_id"])
+            previous = published.get(key)
+            if previous is not None and previous != snapshot_id:
+                raise RecordError("workflow lane has conflicting current snapshots")
+            published[key] = snapshot_id
+        return {"version": PUBLICATION_STATE_VERSION, "records": published}
+
+
+    def read_publication_state(path: Path) -> dict[str, str] | None:
+        """Read a valid state cache, treating missing or malformed state as unknown."""
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if (
+            not isinstance(document, dict)
+            or set(document) != {"version", "records"}
+            or document["version"] != PUBLICATION_STATE_VERSION
+            or not isinstance(document["records"], dict)
+        ):
+            return None
+        records = document["records"]
+        if not all(isinstance(key, str) and isinstance(value, str) for key, value in records.items()):
+            return None
+        if not all(re.fullmatch(r"[0-9a-f]{64}", value) for value in records.values()):
+            return None
+        return records
+
+
+    def write_publication_state(path: Path, records: list[dict[str, object]]) -> None:
+        """Persist state atomically after the corresponding history is published."""
+        document = publication_state(records)
+        temporary = path.with_name(f".{path.name}.new")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            temporary.write_text(
+                json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+                encoding="utf-8",
+            )
+            temporary.replace(path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+    def state_covers(records: list[dict[str, object]], state: dict[str, str] | None) -> bool:
+        """Return whether every current candidate is known to be published."""
+        if state is None:
+            return False
+        expected = publication_state(records)["records"]
+        return all(state.get(key) == snapshot_id for key, snapshot_id in expected.items())
+
+
+    def git_env(auth_dir: Path) -> dict[str, str]:
+        askpass = auth_dir / "git-askpass"
+        askpass.write_text(
+            '#!/bin/sh\ncase "$1" in\n*Username*) printf "%s\\n" "x-access-token" ;;\n'
+            '*) printf "%s\\n" "$GITHUB_TOKEN" ;;\nesac\n',
+            encoding="utf-8",
+        )
+        askpass.chmod(0o700)
+        env = os.environ.copy()
+        env.update({"GIT_ASKPASS": str(askpass), "GIT_TERMINAL_PROMPT": "0"})
+        return env
+
+
+    def run_git(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args], cwd=cwd, env=env, text=True,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        )
+
+
+    def publish(
+        records: list[dict[str, object]],
+        work_dir: Path,
+        *,
+        state_file: Path | None = None,
+    ) -> int:
+        if not os.environ.get("GITHUB_TOKEN"):
+            raise RecordError("GITHUB_TOKEN is required for authorized publication")
+        if not records:
+            return 0
+        if state_file is not None and state_covers(records, read_publication_state(state_file)):
+            return 0
+        auth_dir = work_dir / ".qa-run-auth"
+        clone_dir = work_dir / ".qa-run-history"
+        shutil.rmtree(auth_dir, ignore_errors=True)
+        shutil.rmtree(clone_dir, ignore_errors=True)
+        auth_dir.mkdir(parents=True)
+        env = git_env(auth_dir)
+        if run_git(
+            [
+                "clone",
+                "--depth",
+                "1",
+                "--filter=blob:none",
+                "--sparse",
+                REPO_URL,
+                str(clone_dir),
+            ],
+            cwd=work_dir,
+            env=env,
+        ).returncode:
+            raise RecordError("git clone failed")
+        if run_git(
+            ["sparse-checkout", "set", str(HISTORY_PATH.parent)],
+            cwd=clone_dir,
+            env=env,
+        ).returncode:
+            raise RecordError("git sparse checkout failed")
+        for attempt in range(2):
+            added = append_records(clone_dir / HISTORY_PATH, records)
+            if not added:
+                if state_file is not None:
+                    write_publication_state(state_file, records)
+                return 0
+            run_git(["config", "user.name", "github-actions[bot]"], cwd=clone_dir, env=env)
+            run_git(["config", "user.email", "github-actions[bot]@users.noreply.github.com"], cwd=clone_dir, env=env)
+            if run_git(["add", str(HISTORY_PATH)], cwd=clone_dir, env=env).returncode:
+                raise RecordError("git add failed")
+            if run_git(["commit", "-m", "chore(qa): append workflow evidence"], cwd=clone_dir, env=env).returncode:
+                raise RecordError("git commit failed")
+            if run_git(["push", "origin", "HEAD:main"], cwd=clone_dir, env=env).returncode == 0:
+                if state_file is not None:
+                    write_publication_state(state_file, records)
+                return added
+            if attempt == 0:
+                if run_git(["fetch", "origin", "main"], cwd=clone_dir, env=env).returncode:
+                    raise RecordError("git fetch after push race failed")
+                if run_git(["reset", "--hard", "origin/main"], cwd=clone_dir, env=env).returncode:
+                    raise RecordError("git reset after push race failed")
+        raise RecordError("git push failed after retry")
+
+
+    def reconcile(path: Path, observed_at: str) -> list[dict[str, object]]:
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RecordError(f"cannot read workflow list: {exc}") from exc
+        items = document.get("items") if isinstance(document, dict) else None
+        if not isinstance(items, list):
+            raise RecordError("workflow list must contain items")
+        records = []
+        for item in items:
+            records.extend(normalize_workflows(item, observed_at))
+        return records
+
+
+    def main(argv: list[str] | None = None) -> int:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("workflow_list")
+        parser.add_argument("--observed-at", default=utc_now())
+        parser.add_argument("--publish", action="store_true")
+        parser.add_argument("--work-dir", type=Path, default=Path("."))
+        parser.add_argument("--state-file", type=Path)
+        args = parser.parse_args(argv)
+        try:
+            records = reconcile(Path(args.workflow_list), args.observed_at)
+            if args.publish:
+                print(
+                    f"published {publish(records, args.work_dir, state_file=args.state_file)} "
+                    "QA evidence snapshots"
+                )
+            else:
+                print(json.dumps(records, sort_keys=True))
+        except RecordError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        return 0
+
+
+    if __name__ == "__main__":
+        raise SystemExit(main())
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: qa-run-reconciler
@@ -16,6 +900,9 @@ rules:
   - apiGroups: ["argoproj.io"]
     resources: ["workflowtaskresults"]
     verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -42,7 +929,7 @@ metadata:
       public-safe QA-run evidence contract.
 spec:
   schedules:
-    - "*/10 * * * *"
+    - "0 * * * *"
   timezone: UTC
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 120
@@ -58,6 +945,12 @@ spec:
     volumes:
       - name: workspace
         emptyDir: {}
+      - name: publisher
+        configMap:
+          name: qa-run-publisher
+          items:
+            - key: publish_qa_run.py
+              path: publish_qa_run.py
     templates:
       - name: reconcile
         script:
@@ -66,6 +959,9 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
+            - name: publisher
+              mountPath: /opt/qa-run
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -89,8 +985,18 @@ spec:
               echo "QA evidence export unavailable: github-token is not configured." >&2
               exit 1
             fi
-            curl --fail --silent --show-error --location \
-              https://raw.githubusercontent.com/projectbluefin/lab/main/scripts/publish_qa_run.py \
-              -o /workspace/publish_qa_run.py
-            python3 /workspace/publish_qa_run.py /workspace/workflows.json \
-              --publish --work-dir /workspace
+            if ! kubectl get configmap qa-run-reconciler-state -n argo \
+              -o jsonpath='{.data.state\.json}' > /workspace/published-state.json 2>/dev/null; then
+              rm -f /workspace/published-state.json
+            fi
+            python3 /opt/qa-run/publish_qa_run.py /workspace/workflows.json \
+              --publish --work-dir /workspace \
+              --state-file /workspace/published-state.json
+            if [[ -s /workspace/published-state.json ]]; then
+              jq -Rs '{data: {"state.json": .}}' /workspace/published-state.json \
+                > /workspace/state-patch.json
+              kubectl patch configmap qa-run-reconciler-state -n argo \
+                --type merge --patch-file /workspace/state-patch.json \
+                || kubectl create configmap qa-run-reconciler-state -n argo \
+                  --from-file=state.json=/workspace/published-state.json
+            fi

--- a/scripts/publish_qa_run.py
+++ b/scripts/publish_qa_run.py
@@ -20,6 +20,7 @@ import ipaddress
 HISTORY_PATH = Path("docs/data/history/qa-runs.ndjson")
 REPO_URL = "https://github.com/projectbluefin/lab.git"
 SCHEMA_VERSION = "1.0"
+PUBLICATION_STATE_VERSION = 1
 PUBLIC_HISTORY_URL = (
     "https://github.com/projectbluefin/lab/blob/main/docs/data/history/qa-runs.ndjson"
 )
@@ -686,6 +687,70 @@ def append_records(path: Path, records: list[dict[str, object]]) -> int:
     return len(additions)
 
 
+def publication_key(record: dict[str, object]) -> str:
+    lane = record.get("lane")
+    suite = lane.get("suite") if isinstance(lane, dict) else None
+    return f"{record['workflow_uid']}::{suite or '<none>'}"
+
+
+def publication_state(records: list[dict[str, object]]) -> dict[str, object]:
+    """Return the latest published snapshot for each current workflow lane."""
+    published: dict[str, str] = {}
+    for record in records:
+        validate_record(record)
+        key = publication_key(record)
+        snapshot_id = str(record["snapshot_id"])
+        previous = published.get(key)
+        if previous is not None and previous != snapshot_id:
+            raise RecordError("workflow lane has conflicting current snapshots")
+        published[key] = snapshot_id
+    return {"version": PUBLICATION_STATE_VERSION, "records": published}
+
+
+def read_publication_state(path: Path) -> dict[str, str] | None:
+    """Read a valid state cache, treating missing or malformed state as unknown."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if (
+        not isinstance(document, dict)
+        or set(document) != {"version", "records"}
+        or document["version"] != PUBLICATION_STATE_VERSION
+        or not isinstance(document["records"], dict)
+    ):
+        return None
+    records = document["records"]
+    if not all(isinstance(key, str) and isinstance(value, str) for key, value in records.items()):
+        return None
+    if not all(re.fullmatch(r"[0-9a-f]{64}", value) for value in records.values()):
+        return None
+    return records
+
+
+def write_publication_state(path: Path, records: list[dict[str, object]]) -> None:
+    """Persist state atomically after the corresponding history is published."""
+    document = publication_state(records)
+    temporary = path.with_name(f".{path.name}.new")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        temporary.write_text(
+            json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def state_covers(records: list[dict[str, object]], state: dict[str, str] | None) -> bool:
+    """Return whether every current candidate is known to be published."""
+    if state is None:
+        return False
+    expected = publication_state(records)["records"]
+    return all(state.get(key) == snapshot_id for key, snapshot_id in expected.items())
+
+
 def git_env(auth_dir: Path) -> dict[str, str]:
     askpass = auth_dir / "git-askpass"
     askpass.write_text(
@@ -706,20 +771,49 @@ def run_git(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.Co
     )
 
 
-def publish(records: list[dict[str, object]], work_dir: Path) -> int:
+def publish(
+    records: list[dict[str, object]],
+    work_dir: Path,
+    *,
+    state_file: Path | None = None,
+) -> int:
     if not os.environ.get("GITHUB_TOKEN"):
         raise RecordError("GITHUB_TOKEN is required for authorized publication")
+    if not records:
+        return 0
+    if state_file is not None and state_covers(records, read_publication_state(state_file)):
+        return 0
     auth_dir = work_dir / ".qa-run-auth"
     clone_dir = work_dir / ".qa-run-history"
     shutil.rmtree(auth_dir, ignore_errors=True)
     shutil.rmtree(clone_dir, ignore_errors=True)
     auth_dir.mkdir(parents=True)
     env = git_env(auth_dir)
-    if run_git(["clone", "--depth", "1", REPO_URL, str(clone_dir)], cwd=work_dir, env=env).returncode:
+    if run_git(
+        [
+            "clone",
+            "--depth",
+            "1",
+            "--filter=blob:none",
+            "--sparse",
+            REPO_URL,
+            str(clone_dir),
+        ],
+        cwd=work_dir,
+        env=env,
+    ).returncode:
         raise RecordError("git clone failed")
+    if run_git(
+        ["sparse-checkout", "set", str(HISTORY_PATH.parent)],
+        cwd=clone_dir,
+        env=env,
+    ).returncode:
+        raise RecordError("git sparse checkout failed")
     for attempt in range(2):
         added = append_records(clone_dir / HISTORY_PATH, records)
         if not added:
+            if state_file is not None:
+                write_publication_state(state_file, records)
             return 0
         run_git(["config", "user.name", "github-actions[bot]"], cwd=clone_dir, env=env)
         run_git(["config", "user.email", "github-actions[bot]@users.noreply.github.com"], cwd=clone_dir, env=env)
@@ -728,6 +822,8 @@ def publish(records: list[dict[str, object]], work_dir: Path) -> int:
         if run_git(["commit", "-m", "chore(qa): append workflow evidence"], cwd=clone_dir, env=env).returncode:
             raise RecordError("git commit failed")
         if run_git(["push", "origin", "HEAD:main"], cwd=clone_dir, env=env).returncode == 0:
+            if state_file is not None:
+                write_publication_state(state_file, records)
             return added
         if attempt == 0:
             if run_git(["fetch", "origin", "main"], cwd=clone_dir, env=env).returncode:
@@ -757,11 +853,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--observed-at", default=utc_now())
     parser.add_argument("--publish", action="store_true")
     parser.add_argument("--work-dir", type=Path, default=Path("."))
+    parser.add_argument("--state-file", type=Path)
     args = parser.parse_args(argv)
     try:
         records = reconcile(Path(args.workflow_list), args.observed_at)
         if args.publish:
-            print(f"published {publish(records, args.work_dir)} QA evidence snapshots")
+            print(
+                f"published {publish(records, args.work_dir, state_file=args.state_file)} "
+                "QA evidence snapshots"
+            )
         else:
             print(json.dumps(records, sort_keys=True))
     except RecordError as exc:

--- a/tests/unit/test_qa_run_reconciler_churn.py
+++ b/tests/unit/test_qa_run_reconciler_churn.py
@@ -1,0 +1,142 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "publish_qa_run.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("publish_qa_run", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def workflow():
+    return {
+        "metadata": {
+            "name": "bluefin-qa-abcde",
+            "uid": "12345678-1234-1234-1234-123456789abc",
+            "creationTimestamp": "2026-08-01T14:00:00Z",
+        },
+        "spec": {
+            "workflowTemplateRef": {"name": "bluefin-qa-pipeline"},
+            "arguments": {
+                "parameters": [
+                    {"name": "variant", "value": "bluefin"},
+                    {"name": "image", "value": "ghcr.io/projectbluefin/bluefin"},
+                    {"name": "image-tag", "value": "testing"},
+                    {"name": "image-digest", "value": "sha256:" + "a" * 64},
+                    {"name": "suites", "value": "smoke"},
+                ]
+            },
+        },
+        "status": {
+            "phase": "Running",
+            "startedAt": "2026-08-01T14:01:00Z",
+            "nodes": {
+                "node": {
+                    "displayName": "run-container-tests",
+                    "outputs": {},
+                }
+            },
+        },
+    }
+
+
+def test_published_state_short_circuits_before_clone(monkeypatch, tmp_path):
+    module = load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    record = module.normalize_workflow(workflow(), "2026-08-01T14:02:00Z")
+    state_file = tmp_path / "published-state.json"
+    state_file.write_text(
+        json.dumps(module.publication_state([record])),
+        encoding="utf-8",
+    )
+
+    def unexpected_git(*args, **kwargs):
+        raise AssertionError("clone must not run for a covered candidate")
+
+    monkeypatch.setattr(module, "run_git", unexpected_git)
+
+    assert module.publish([record], tmp_path, state_file=state_file) == 0
+    assert not (tmp_path / ".qa-run-history").exists()
+
+
+def test_missing_or_malformed_state_falls_back_to_clone(monkeypatch, tmp_path):
+    module = load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    record = module.normalize_workflow(workflow(), "2026-08-01T14:02:00Z")
+    state_file = tmp_path / "published-state.json"
+    state_file.write_text("{not-json", encoding="utf-8")
+    calls = []
+
+    def fake_git(args, *, cwd, env):
+        calls.append(args)
+        if args[0] == "clone":
+            history = Path(args[-1]) / module.HISTORY_PATH
+            history.parent.mkdir(parents=True)
+            history.write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(module, "run_git", fake_git)
+
+    assert module.publish([record], tmp_path, state_file=state_file) == 1
+    assert calls[0] == [
+        "clone",
+        "--depth",
+        "1",
+        "--filter=blob:none",
+        "--sparse",
+        module.REPO_URL,
+        str(tmp_path / ".qa-run-history"),
+    ]
+    assert module.read_publication_state(state_file) == module.publication_state([record])["records"]
+
+
+def test_missing_github_token_remains_an_explicit_error(monkeypatch, tmp_path):
+    module = load_module()
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    with pytest.raises(module.RecordError, match="GITHUB_TOKEN is required"):
+        module.publish([], tmp_path)
+
+
+def test_reconciler_uses_hourly_schedule_and_configmap_publisher():
+    documents = list(
+        yaml.safe_load_all(
+            (ROOT / "manifests" / "qa-run-reconciler.yaml").read_text(encoding="utf-8")
+        )
+    )
+    configmap = next(
+        document
+        for document in documents
+        if document["kind"] == "ConfigMap"
+        and document["metadata"]["name"] == "qa-run-publisher"
+    )
+    cron = next(
+        document
+        for document in documents
+        if document["kind"] == "CronWorkflow"
+        and document["metadata"]["name"] == "qa-run-reconciler"
+    )
+    source = cron["spec"]["workflowSpec"]["templates"][0]["script"]["source"]
+
+    assert cron["spec"]["schedules"] == ["0 * * * *"]
+    assert "raw.githubusercontent.com" not in source
+    assert "python3 /opt/qa-run/publish_qa_run.py" in source
+    assert "--state-file /workspace/published-state.json" in source
+    assert configmap["data"]["publish_qa_run.py"] == SCRIPT.read_text(encoding="utf-8")
+    assert {
+        "name": "publisher",
+        "configMap": {
+            "name": "qa-run-publisher",
+            "items": [{"key": "publish_qa_run.py", "path": "publish_qa_run.py"}],
+        },
+    } in cron["spec"]["workflowSpec"]["volumes"]


### PR DESCRIPTION
## Summary

- Compute candidate evidence before publication and short-circuit when the runtime ConfigMap state cache covers every current workflow/lane snapshot, so no-op runs do not clone or push.
- Bundle `publish_qa_run.py` in a GitOps-managed ConfigMap because the checked `ghcr.io/projectbluefin/lab-runner:latest` image does not contain it; remove the per-run raw GitHub download.
- Reconcile hourly instead of every 10 minutes and keep the new-record path on a sparse, blob-filtered shallow clone.

## Traffic impact

The measured baseline is 144 shallow clones/day at 9.9 MiB each, or about 1.4 GiB/day inbound, plus 144 raw publisher downloads. In the common no-op case this becomes zero clones and zero raw downloads (only 24 small state reads per day). If every hourly run has new evidence, the upper bound is 24 × 9.9 MiB, about 238 MiB/day (0.23 GiB), before push traffic.

## Safety

State is written only after a successful push; missing or malformed state falls back to the authoritative clone/dedup path. `append_records()` remains authoritative, push rejection retry is preserved, and missing `GITHUB_TOKEN` remains an explicit error.

## Validation

- `just lint` ✅
- `pytest -q tests/unit/test_qa_run_reconciler_churn.py tests/unit/test_qa_run_contract.py` — 20 passed ✅
- `pytest -q tests/unit` — 386 passed, 7 unrelated existing failures in build-metrics, page-dataset, RECC seam, and Zot policy tests ⚠️