### PR TITLE
fix: distinguish LAN and WAN traffic in report

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -163,6 +163,25 @@ list-workflows:
 logs:
     argo logs -n {{ argo_ns }} @latest
 
+# Report rolling uplink, WAN-estimate, workload, and Zot cache traffic.
+# Usage: just traffic-report
+# Usage: just traffic-report window=1h interface=enp191s0 limit=10
+traffic-report *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    translated=()
+    for arg in {{ args }}; do
+        case "${arg}" in
+            window=*) translated+=(--window "${arg#window=}") ;;
+            prometheus-url=*) translated+=(--prometheus-url "${arg#prometheus-url=}") ;;
+            prometheus_url=*) translated+=(--prometheus-url "${arg#prometheus_url=}") ;;
+            interface=*) translated+=(--interface "${arg#interface=}") ;;
+            limit=*) translated+=(--limit "${arg#limit=}") ;;
+            *) translated+=("${arg}") ;;
+        esac
+    done
+    exec python3 scripts/traffic_report.py "${translated[@]}"
+
 # List VMs in all test namespaces
 list-vms:
     @echo "=== bluefin-test ===" && kubectl get vm -n bluefin-test 2>/dev/null || true

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -169,20 +169,39 @@ to zero.
 service. Keep it as a single `ClusterIP` deployment: do not add an ingress,
 Grafana, Prometheus Operator, or another cluster dashboard.
 
-### External traffic report
+### Uplink traffic report (LAN + WAN)
 
-For a rolling boundary-traffic view, port-forward Prometheus and run:
+For a rolling uplink view, port-forward Prometheus and run:
 
 ```bash
 kubectl -n kube-system port-forward svc/prometheus 9090:9090
 just traffic-report
 ```
 
-The report uses cAdvisor's node-root counters on the physical `enp191s0`
-uplink. It intentionally excludes pod interfaces, `cni0`, USB4, and Tailscale
-traffic. Zot pull counters are included as a ranked image-repository activity
-signal, but Zot does not expose per-repository byte totals; do not present
-those counts as bandwidth.
+The report calls cAdvisor's node-root counters on the physical `enp191s0`
+**uplink interface totals (LAN + WAN)**. `enp191s0` is the lab LAN NIC, not a
+clean internet boundary: its counters include node-to-node traffic, LAN
+clients, and in-cluster hairpin traffic. Do not present those totals as
+external bandwidth.
+
+The report includes a deliberately partial WAN estimate. Zot cache pod RX is
+shown as estimated upstream image-pull ingress, and a node's uplink TX minus
+the other visible node(s)' RX is shown as estimated non-node egress. These
+subtractions are assumptions, not flow data; a missing or negative component
+is rendered as unavailable. Other WAN/LAN traffic cannot be separated because
+cAdvisor has no remote-address or port labels. Destination-level telemetry
+would require a bounded eBPF/flow exporter, which this report does not invent.
+
+The report also compares Zot upstream RX with Zot TX (cache serving) and shows
+an approximate byte cache-hit ratio under the assumption that upstream RX is
+miss traffic. Its workload sections exclude the known
+`hostNetwork: true` `usb4-link-monitor-*` node mirrors, which otherwise just
+duplicate node counters. Treat any remaining cAdvisor workload rows as
+attribution only, not destination-level internet flow data.
+
+Zot pull counters are included as a ranked image-repository activity signal,
+but Zot does not expose per-repository byte totals; do not present those
+counts as bandwidth.
 
 **Zot on-demand sync pulls blobs on tag reads.** Any `skopeo inspect` or pull
 of a *tag* through the cache (`192.168.1.102:30501/...`) copies the manifest

--- a/scripts/traffic_report.py
+++ b/scripts/traffic_report.py
@@ -11,6 +11,9 @@ from collections.abc import Iterable
 from typing import Any
 
 
+HOST_NETWORK_POD_REGEX = "usb4-link-monitor-.*"
+
+
 def query_prometheus(
     base_url: str, expression: str, timeout: float = 10
 ) -> list[dict[str, Any]]:
@@ -43,17 +46,45 @@ def rows(
     )
 
 
+def node_name(metric: dict[str, str]) -> str:
+    return metric.get("node") or metric.get("instance", "<unknown>")
+
+
+def pod_name(metric: dict[str, str]) -> str:
+    return metric.get("pod") or metric.get(
+        "container_label_io_kubernetes_pod_name", ""
+    )
+
+
+def is_host_network_mirror(metric: dict[str, str]) -> bool:
+    """Identify host-network counters that mirror node traffic."""
+    host_network_labels = (
+        "hostNetwork",
+        "host_network",
+        "container_label_io_kubernetes_pod_hostnetwork",
+        "container_label_io_kubernetes_pod_host_network",
+    )
+    return any(
+        metric.get(label, "").lower() in {"1", "true", "yes"}
+        for label in host_network_labels
+    ) or pod_name(metric).startswith("usb4-link-monitor-")
+
+
 def bounded_rows(
     base_url: str, expression: str, limit: int
 ) -> list[tuple[float, dict[str, str]]]:
     return rows(query_prometheus(base_url, f"topk({limit}, {expression})"))
 
 
+def promql_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def identity(metric: dict[str, str]) -> str:
     namespace = metric.get(
         "namespace", metric.get("container_label_io_kubernetes_pod_namespace", "")
     )
-    pod = metric.get("pod", metric.get("container_label_io_kubernetes_pod_name", ""))
+    pod = pod_name(metric)
     container = metric.get(
         "container", metric.get("container_label_io_kubernetes_container_name", "")
     )
@@ -66,13 +97,69 @@ def print_workload_section(
 ) -> None:
     print(title)
     samples = [
-        (value, metric) for value, metric in samples if identity(metric) != "<unknown>"
+        (value, metric)
+        for value, metric in samples
+        if identity(metric) != "<unknown>" and not is_host_network_mirror(metric)
     ]
     if not samples:
-        print("  unavailable (cAdvisor exposed no workload labels)")
+        print("  unavailable (cAdvisor exposed no non-hostNetwork workload labels)")
         return
     for value, metric in samples:
         print(f"  {bytes_value(value):>14}  {identity(metric)}")
+
+
+def total_bytes(samples: Iterable[tuple[float, dict[str, str]]]) -> float:
+    return sum(value for value, _ in samples)
+
+
+def node_totals(
+    samples: Iterable[tuple[float, dict[str, str]]],
+) -> dict[str, float]:
+    totals: dict[str, float] = {}
+    for value, metric in samples:
+        node = node_name(metric)
+        totals[node] = totals.get(node, 0.0) + value
+    return totals
+
+
+def estimate_non_node_egress(
+    tx_samples: Iterable[tuple[float, dict[str, str]]],
+    rx_samples: Iterable[tuple[float, dict[str, str]]],
+) -> dict[str, float | None]:
+    """Estimate per-node non-peer egress from paired node-root counters.
+
+    For each node, subtract the receive total of every other visible node from
+    its transmit total. A negative or incomplete subtraction is unavailable
+    rather than being clamped into a fabricated WAN value.
+    """
+    tx_by_node = node_totals(tx_samples)
+    rx_by_node = node_totals(rx_samples)
+    nodes = set(tx_by_node) | set(rx_by_node)
+    estimates: dict[str, float | None] = {}
+    if len(nodes) < 2:
+        return {node: None for node in nodes}
+
+    for node in nodes:
+        tx_value = tx_by_node.get(node)
+        peer_nodes = nodes - {node}
+        if tx_value is None or not peer_nodes.issubset(rx_by_node):
+            estimates[node] = None
+            continue
+        estimate = tx_value - sum(rx_by_node[peer] for peer in peer_nodes)
+        estimates[node] = estimate if estimate >= 0 else None
+    return estimates
+
+
+def cache_hit_ratio(
+    upstream_rx_samples: Iterable[tuple[float, dict[str, str]]],
+    cache_tx_samples: Iterable[tuple[float, dict[str, str]]],
+) -> float | None:
+    """Estimate byte hit ratio from Zot upstream receive and cache transmit."""
+    upstream_rx = total_bytes(upstream_rx_samples)
+    cache_tx = total_bytes(cache_tx_samples)
+    if cache_tx <= 0 or upstream_rx < 0 or upstream_rx > cache_tx:
+        return None
+    return (cache_tx - upstream_rx) / cache_tx
 
 
 def main() -> None:
@@ -85,8 +172,8 @@ def main() -> None:
     if args.limit < 1:
         parser.error("--limit must be positive")
 
-    interface = urllib.parse.quote(args.interface, safe="")
-    window = urllib.parse.quote(args.window, safe="")
+    interface = promql_escape(args.interface)
+    window = args.window
     rx = query_prometheus(
         args.prometheus_url,
         f'sum by (instance,interface) (increase(container_network_receive_bytes_total{{id="/",interface="{interface}"}}[{window}]))',
@@ -99,15 +186,40 @@ def main() -> None:
         args.prometheus_url,
         f'sum by (service,repo) (increase(zot_repo_downloads_total[{window}]))',
     )
+    workload_selector = (
+        f'interface="{interface}",id!="/",'
+        f'pod!~"{HOST_NETWORK_POD_REGEX}",'
+        f'container_label_io_kubernetes_pod_name!~"{HOST_NETWORK_POD_REGEX}"'
+    )
+    workload_group = (
+        "namespace,pod,container,"
+        "container_label_io_kubernetes_pod_namespace,"
+        "container_label_io_kubernetes_pod_name,"
+        "container_label_io_kubernetes_container_name,"
+        "hostNetwork,host_network,"
+        "container_label_io_kubernetes_pod_hostnetwork,"
+        "container_label_io_kubernetes_pod_host_network"
+    )
     workload_rx = bounded_rows(
         args.prometheus_url,
-        f'sum by (namespace,pod,container,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_name,container_label_io_kubernetes_container_name) (increase(container_network_receive_bytes_total{{interface="{interface}",id!="/"}}[{window}]))',
+        f"sum by ({workload_group}) (increase(container_network_receive_bytes_total{{{workload_selector}}}[{window}]))",
         args.limit,
     )
     workload_tx = bounded_rows(
         args.prometheus_url,
-        f'sum by (namespace,pod,container,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_name,container_label_io_kubernetes_container_name) (increase(container_network_transmit_bytes_total{{interface="{interface}",id!="/"}}[{window}]))',
+        f"sum by ({workload_group}) (increase(container_network_transmit_bytes_total{{{workload_selector}}}[{window}]))",
         args.limit,
+    )
+    zot_selector = (
+        'id!="/",namespace="local-registry",pod=~"zot-cache-.*",interface!="lo"'
+    )
+    zot_upstream_rx = query_prometheus(
+        args.prometheus_url,
+        f'sum by (node,instance) (increase(container_network_receive_bytes_total{{{zot_selector}}}[{window}]))',
+    )
+    zot_cache_tx = query_prometheus(
+        args.prometheus_url,
+        f'sum by (node,instance) (increase(container_network_transmit_bytes_total{{{zot_selector}}}[{window}]))',
     )
     github_requests = bounded_rows(
         args.prometheus_url,
@@ -120,16 +232,64 @@ def main() -> None:
         args.limit,
     )
 
-    print(f"External traffic on {args.interface} ({args.window} rolling window)")
+    print(
+        f"Uplink interface totals on {args.interface} "
+        f"(LAN + WAN; {args.window} rolling window)"
+    )
     print("Incoming:")
     for value, metric in rows(rx):
-        print(f"  {bytes_value(value):>14}  {metric.get('instance', '<unknown>')}")
+        print(f"  {bytes_value(value):>14}  {node_name(metric)}")
     print("Outgoing:")
     for value, metric in rows(tx):
-        print(f"  {bytes_value(value):>14}  {metric.get('instance', '<unknown>')}")
+        print(f"  {bytes_value(value):>14}  {node_name(metric)}")
     print()
-    print_workload_section("Workload incoming (cAdvisor counters):", workload_rx)
-    print_workload_section("Workload outgoing (cAdvisor counters):", workload_tx)
+    print("WAN estimate (partial; not a flow measurement):")
+    print("  Image-pull WAN ingress (Zot upstream RX estimate):")
+    if zot_upstream_rx:
+        for value, metric in rows(zot_upstream_rx):
+            print(f"    {bytes_value(value):>14}  {node_name(metric)}")
+    else:
+        print("    unavailable (no zot-cache cAdvisor receive series)")
+    print("  Non-node uplink egress (uplink TX minus peer-node RX):")
+    egress_estimates = estimate_non_node_egress(rows(tx), rows(rx))
+    if not egress_estimates:
+        print("    unavailable (fewer than two node-root series)")
+    else:
+        for node in sorted(egress_estimates):
+            estimate = egress_estimates[node]
+            if estimate is None:
+                print(f"    unavailable  {node}")
+            else:
+                print(f"    {bytes_value(estimate):>14}  {node}")
+    print("  Other WAN/LAN components: unavailable (no remote-address labels)")
+    print()
+    print("Zot cache signals (cAdvisor pod counters; estimated):")
+    print("  Upstream RX (image-pull WAN ingress):")
+    if zot_upstream_rx:
+        for value, metric in rows(zot_upstream_rx):
+            print(f"    {bytes_value(value):>14}  {node_name(metric)}")
+    else:
+        print("    unavailable (no zot-cache cAdvisor receive series)")
+    print("  TX (LAN cache serving):")
+    if zot_cache_tx:
+        for value, metric in rows(zot_cache_tx):
+            print(f"    {bytes_value(value):>14}  {node_name(metric)}")
+    else:
+        print("    unavailable (no zot-cache cAdvisor transmit series)")
+    ratio = cache_hit_ratio(rows(zot_upstream_rx), rows(zot_cache_tx))
+    if ratio is None:
+        print("  Approximate byte cache hit ratio: unavailable")
+    else:
+        print(f"  Approximate byte cache hit ratio: {ratio:.1%}")
+    print()
+    print_workload_section(
+        "Workload incoming (cAdvisor counters; host-network mirrors excluded):",
+        workload_rx,
+    )
+    print_workload_section(
+        "Workload outgoing (cAdvisor counters; host-network mirrors excluded):",
+        workload_tx,
+    )
     print()
     print("Registry pulls (count, not bytes):")
     for value, metric in rows(pulls)[: args.limit]:
@@ -156,11 +316,18 @@ def main() -> None:
         print("  unavailable (no github_api_throttled_total series)")
     print()
     print(
-        "Notes: uplink bytes are boundary traffic. Workload bytes are grouped "
-        "only when cAdvisor provides Kubernetes labels. Zot metrics rank pull "
-        "activity but do not expose per-repository byte totals. cAdvisor has no "
-        "remote address/port labels, so destination-level flow telemetry needs "
-        "a bounded eBPF/flow exporter; this report does not invent it."
+        "Notes: uplink bytes are interface totals, not external traffic; "
+        "enp191s0 carries LAN, node-to-node, and hairpin traffic. The WAN "
+        "estimate treats zot-cache RX as upstream image-pull bytes and subtracts "
+        "visible peer-node RX from each node's uplink TX; missing or negative "
+        "components stay unavailable. Workload bytes are grouped only when "
+        "cAdvisor provides Kubernetes labels, and known hostNetwork "
+        "usb4-link-monitor-* node mirrors are excluded. The cache-hit ratio is "
+        "(Zot TX - upstream RX) / Zot TX under the same miss-traffic assumption. "
+        "Zot pull metrics rank activity but do not expose per-repository byte "
+        "totals. cAdvisor has no remote address/port labels, so destination-level "
+        "flow telemetry needs a bounded eBPF/flow exporter; this report does not "
+        "invent it."
     )
 
 

--- a/tests/unit/test_traffic_report.py
+++ b/tests/unit/test_traffic_report.py
@@ -1,4 +1,12 @@
-from scripts.traffic_report import bytes_value, identity, rows
+from scripts.traffic_report import (
+    bytes_value,
+    cache_hit_ratio,
+    estimate_non_node_egress,
+    identity,
+    is_host_network_mirror,
+    print_workload_section,
+    rows,
+)
 
 
 def test_bytes_value_uses_binary_units():
@@ -25,3 +33,49 @@ def test_identity_supports_cadvisor_kubernetes_labels():
 
 def test_identity_never_prints_unlabelled_payload_data():
     assert identity({"instance": "node-1", "token": "must-not-be-used"}) == "node-1"
+
+
+def test_estimate_non_node_egress_subtracts_peer_receive_totals():
+    tx = [
+        (10.0, {"node": "ghost"}),
+        (4.0, {"node": "exo-0"}),
+    ]
+    rx = [
+        (6.0, {"node": "ghost"}),
+        (3.0, {"node": "exo-0"}),
+    ]
+
+    assert estimate_non_node_egress(tx, rx) == {"ghost": 7.0, "exo-0": None}
+
+
+def test_estimate_non_node_egress_is_unavailable_without_peer_data():
+    assert estimate_non_node_egress([(10.0, {"node": "ghost"})], []) == {
+        "ghost": None
+    }
+
+
+def test_cache_hit_ratio_uses_upstream_bytes_as_misses():
+    upstream_rx = [(2.0, {"node": "ghost"})]
+    cache_tx = [(10.0, {"node": "ghost"})]
+
+    assert cache_hit_ratio(upstream_rx, cache_tx) == 0.8
+
+
+def test_host_network_mirror_is_detected_by_label_or_known_pod_name():
+    assert is_host_network_mirror({"host_network": "true"}) is True
+    assert is_host_network_mirror({"pod": "usb4-link-monitor-abc12"}) is True
+    assert is_host_network_mirror({"pod": "zot-cache-abc12"}) is False
+
+
+def test_workload_section_excludes_host_network_mirrors(capsys):
+    print_workload_section(
+        "Workload incoming:",
+        [
+            (10.0, {"namespace": "kube-system", "pod": "usb4-link-monitor-abc12"}),
+            (5.0, {"namespace": "argo", "pod": "worker-abc12"}),
+        ],
+    )
+
+    output = capsys.readouterr().out
+    assert "usb4-link-monitor" not in output
+    assert "argo/worker-abc12" in output


### PR DESCRIPTION
## Summary

- Relabel cAdvisor `enp191s0` node-root counters as **uplink interface totals (LAN + WAN)** instead of external traffic.
- Add a deliberately partial WAN estimate: Zot cache upstream RX for image-pull ingress and node TX minus visible peer-node RX for non-node egress; unavailable components stay explicit.
- Add Zot upstream RX vs cache-serving TX and an approximate byte cache-hit ratio.
- Exclude known `hostNetwork: true` `usb4-link-monitor-*` node mirrors from workload attribution, including bounded host-network label handling.
- Add the documented `just traffic-report` recipe with both `name=value` and existing CLI-flag passthrough.
- Correct the cluster-tooling guidance and extend unit coverage.

## Before / after live evidence

The previous report advertised these 24h uplink totals as external traffic:

```text
Incoming: 55.27 GiB exo-0 / 27.49 GiB ghost
Outgoing: 34.38 GiB ghost / 3.35 GiB exo-0
Workload: kube-system/usb4-link-monitor-* (node-level mirrors)
```

With this change, a final live 24h run reported:

```text
Uplink interface totals (LAN + WAN)
Incoming: 55.59 GiB exo-0 / 28.56 GiB ghost
Outgoing: 34.85 GiB ghost / 3.43 GiB exo-0
Image-pull WAN ingress estimate (Zot upstream RX): 13.91 GiB ghost
Zot TX (LAN cache serving): 984.90 GiB ghost
Approximate byte cache hit ratio: 98.6%
Non-node egress estimate: unavailable (peer subtraction was negative)
Workload attribution: unavailable (host-network mirrors excluded)
```

The order-of-magnitude correction is that ~55/34 GiB is no longer presented as internet traffic: the physical NIC also carries LAN, node-to-node, and API/cache hairpin traffic. cAdvisor has no remote-address labels, so total WAN ingress/egress cannot be recovered; the report now shows only the defensible image-pull signal and explicit unavailable states rather than fabricating flow data.

## Validation

- `pytest -q tests/unit/test_traffic_report.py` — 9 passed
- `just lint` — passed
- Live validation via `just traffic-report window=24h prometheus-url=http://127.0.0.1:9090 interface=enp191s0 limit=10`