### PR TITLE
fix: reduce PR poller GitHub API volume

### DIFF
--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -101,14 +101,14 @@ spec:
           # since #612 each QA pipeline template carries `parallelism: 2`, so one
           # workflow holds at most 2 of the 6 `ghost-container-qa` slots and the
           # runner executes 6 / 2 = 3 workflows concurrently. Admitting more than
-          # that per 5-minute poll cannot make anything finish sooner; it only
+          # that per poll cannot make anything finish sooner; it only
           # deepens the queue. Keep this <= ghost-container-qa / pipeline
           # parallelism (asserted in tests/unit/test_pr_poller_reaper.py).
           MAX_DISPATCH=3
           DISPATCHED=0
 
           # Open PRs seen this run, keyed "<product>/<number>". Populated from
-          # the GitHub search results and used by the reaper below.
+          # the GitHub pull listing and used by the reaper below.
           declare -A OPEN_PRS=()
           # Products whose open-PR enumeration completed with zero API errors.
           # The reaper only acts on these, so a transient GitHub outage can
@@ -234,6 +234,10 @@ spec:
            "projectbluefin/bluefin-lts"
            "projectbluefin/dakota"
           )
+          declare -A AUTO_REPO_SET=()
+          for AUTO_REPO in "${AUTO_REPOS[@]}"; do
+            AUTO_REPO_SET["${AUTO_REPO}"]=1
+          done
 
           dispatch_pr() {
            local PR="$1"
@@ -643,7 +647,6 @@ spec:
 
           # --- Pass 1: every open PR in auto-test repos ---
           for REPO in "${AUTO_REPOS[@]}"; do
-           REPO_QUERY=$(jq -rn --arg q "repo:${REPO} is:pr is:open" '$q|@uri')
            REPO_PRODUCT="${REPO##*/}"
            PAGE=1
            # Every GitHub call for this repo must succeed before the reaper is
@@ -654,34 +657,25 @@ spec:
              RESULTS=$(curl -sf \
                -H "Authorization: token ${GITHUB_TOKEN}" \
                -H "Accept: application/vnd.github+json" \
-               "${API}/search/issues?q=${REPO_QUERY}&per_page=30&page=${PAGE}") || {
-                 echo "Repo ${REPO}: open-PR search failed on page ${PAGE}; skipping reap this run" >&2
+               "${API}/repos/${REPO}/pulls?state=open&per_page=100&page=${PAGE}") || {
+                 echo "Repo ${REPO}: open-PR pull listing failed on page ${PAGE}; skipping reap this run" >&2
                  SCAN_OK=0
                  break
                }
-             COUNT=$(echo "$RESULTS" | jq '.total_count // 0')
-             ITEMS=$(echo "$RESULTS" | jq '.items | length')
+             if ! ITEMS=$(echo "$RESULTS" | jq -e 'if type == "array" then length else error("expected pull array") end'); then
+               echo "Repo ${REPO}: invalid open-PR pull response on page ${PAGE}; skipping reap this run" >&2
+               SCAN_OK=0
+               break
+             fi
              [[ "$ITEMS" -eq 0 ]] && break
-             echo "Repo ${REPO}: ${COUNT} open PR(s), page ${PAGE}, ${ITEMS} items" >&2
-             # Record the open set from the search payload itself, so a failed
-             # per-PR detail fetch can never make a live PR look closed.
-             while read -r open_num; do
-               OPEN_PRS["${REPO_PRODUCT}/${open_num}"]=1
+             echo "Repo ${REPO}: ${ITEMS} open PR(s) on page ${PAGE}" >&2
+             while read -r PR; do
+               PR_NUM=$(echo "$PR" | jq -r '.number')
+               OPEN_PRS["${REPO_PRODUCT}/${PR_NUM}"]=1
                SEEN_OPEN=1
-             done < <(echo "$RESULTS" | jq -r '.items[].number')
-             while read -r item; do
-               PR_URL=$(echo "$item" | jq -r '.pull_request.url')
-               PR=$(curl -sf \
-                 -H "Authorization: token ${GITHUB_TOKEN}" \
-                 -H "Accept: application/vnd.github+json" \
-                 "$PR_URL") || {
-                   echo "Repo ${REPO}: PR detail fetch failed for ${PR_URL}; skipping reap this run" >&2
-                   SCAN_OK=0
-                   continue
-                 }
                dispatch_pr "$PR"
-             done < <(echo "$RESULTS" | jq -c '.items[]')
-             [[ "$ITEMS" -lt 30 ]] && break
+             done < <(echo "$RESULTS" | jq -c '.[]')
+             [[ "$ITEMS" -lt 100 ]] && break
              (( PAGE++ ))
            done
            # Require at least one observed open PR. A repo that suddenly reports
@@ -693,23 +687,54 @@ spec:
           done
 
           # --- Pass 2: label-based catch-all for projectbluefin repos ---
+          # Search only discovers the repositories. Pull listings provide the
+          # complete PR objects, including labels, without one detail request
+          # per matching PR.
           LABEL_QUERY=$(jq -rn --arg q "org:projectbluefin is:pr is:open label:test-on-lab" '$q|@uri')
           LABEL_RESULTS=$(curl -sf \
            -H "Authorization: token ${GITHUB_TOKEN}" \
            -H "Accept: application/vnd.github+json" \
-           "${API}/search/issues?q=${LABEL_QUERY}")
+           "${API}/search/issues?q=${LABEL_QUERY}&per_page=100&page=1") || {
+             echo "Label search failed; skipping label-based dispatch this run" >&2
+             LABEL_RESULTS='{"total_count":0,"items":[]}'
+           }
           LABEL_COUNT=$(echo "$LABEL_RESULTS" | jq '.total_count // 0')
           echo "Found ${LABEL_COUNT} PR(s) with test-on-lab label" >&2
-          if [[ "$LABEL_COUNT" -gt 0 ]]; then
-           while read -r item; do
-             PR_URL=$(echo "$item" | jq -r '.pull_request.url')
-             PR=$(curl -sf \
+          declare -A LABEL_REPOS=()
+          while read -r LABEL_REPO; do
+           [[ -z "${LABEL_REPO}" ]] && continue
+           LABEL_REPOS["${LABEL_REPO}"]=1
+          done < <(
+           echo "$LABEL_RESULTS" \
+             | jq -r '.items[]?.repository_url // empty
+                 | sub("^https://api.github.com/repos/"; "")'
+          )
+          for REPO in "${!LABEL_REPOS[@]}"; do
+           # Pass 1 already handled every open PR in these repositories.
+           [[ -n "${AUTO_REPO_SET[${REPO}]:-}" ]] && continue
+           PAGE=1
+           while true; do
+             LABEL_PRS=$(curl -sf \
                -H "Authorization: token ${GITHUB_TOKEN}" \
                -H "Accept: application/vnd.github+json" \
-               "$PR_URL")
-             dispatch_pr "$PR"
-           done < <(echo "$LABEL_RESULTS" | jq -c '.items[]')
-          fi
+               "${API}/repos/${REPO}/pulls?state=open&per_page=100&page=${PAGE}") || {
+                 echo "Label repo ${REPO}: open-PR pull listing failed on page ${PAGE}; skipping label dispatch this run" >&2
+                 break
+               }
+             if ! ITEMS=$(echo "$LABEL_PRS" | jq -e 'if type == "array" then length else error("expected pull array") end'); then
+               echo "Label repo ${REPO}: invalid open-PR pull response on page ${PAGE}; skipping label dispatch this run" >&2
+               break
+             fi
+             [[ "$ITEMS" -eq 0 ]] && break
+             while read -r PR; do
+               if echo "$PR" | jq -e '([.labels[]?.name] | index("test-on-lab")) != null' >/dev/null; then
+                 dispatch_pr "$PR"
+               fi
+             done < <(echo "$LABEL_PRS" | jq -c '.[]')
+             [[ "$ITEMS" -lt 100 ]] && break
+             (( PAGE++ ))
+           done
+          done
 
           # --- Pass 3: reap workflows whose PR is no longer open ---
           # A merged or closed PR keeps its workflow running for the full ~20
@@ -720,7 +745,7 @@ spec:
           # Safety: only products whose open-PR enumeration completed with zero
           # API errors AND returned at least one open PR are eligible, and only
           # workflows carrying a bluefin.io/repository label are considered.
-          # Re-running this every 5 minutes is a no-op once a workflow has
+          # Re-running this every 15 minutes is a no-op once a workflow has
           # spec.shutdown set.
           for REPO in "${AUTO_REPOS[@]}"; do
            REPO_PRODUCT="${REPO##*/}"

--- a/manifests/pr-label-poller.yaml
+++ b/manifests/pr-label-poller.yaml
@@ -1,4 +1,4 @@
-# CronWorkflow: polls configured projectbluefin repositories every five minutes.
+# CronWorkflow: polls configured projectbluefin repositories every fifteen minutes.
 # Dispatches at most one workflow per PR head SHA through the matching template.
 # Requires: github-token secret in argo namespace (already present).
 apiVersion: argoproj.io/v1alpha1
@@ -12,7 +12,7 @@ metadata:
 spec:
   suspend: false
   schedules:
-    - "*/5 * * * *"
+    - "*/15 * * * *"
   timezone: "UTC"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 60

--- a/tests/unit/test_pr_poller_api_volume.py
+++ b/tests/unit/test_pr_poller_api_volume.py
@@ -1,0 +1,56 @@
+"""Contracts for the PR poller's GitHub API cadence and request shape."""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CRON = ROOT / "manifests/pr-label-poller.yaml"
+POLLER = ROOT / "argo/workflow-templates/pr-poller.yaml"
+
+
+def poller_script():
+    doc = yaml.safe_load(POLLER.read_text(encoding="utf-8"))
+    (template,) = [
+        template
+        for template in doc["spec"]["templates"]
+        if template["name"] == "poll-labeled-prs"
+    ]
+    return template["script"]["source"]
+
+
+def test_pr_poller_uses_conservative_quarter_hour_cadence():
+    cron = yaml.safe_load(CRON.read_text(encoding="utf-8"))
+
+    assert cron["spec"]["schedules"] == ["*/15 * * * *"]
+    assert cron["spec"]["concurrencyPolicy"] == "Forbid"
+
+
+def test_auto_repo_scan_uses_full_pull_pages_without_detail_fetches():
+    source = poller_script()
+    pass_one = source.split("# --- Pass 1:", 1)[1].split("# --- Pass 2:", 1)[0]
+
+    assert (
+        "${API}/repos/${REPO}/pulls?state=open&per_page=100&page=${PAGE}"
+        in pass_one
+    )
+    assert pass_one.count("curl -sf") == 1
+    assert "/search/issues" not in pass_one
+    assert "PR_URL=" not in pass_one
+    assert '[[ "$ITEMS" -lt 100 ]] && break' in pass_one
+    assert "SCAN_OK=0" in pass_one
+    assert "skipping reap this run" in pass_one
+
+
+def test_label_catch_all_discovers_repositories_then_filters_pull_objects():
+    source = poller_script()
+    pass_two = source.split("# --- Pass 2:", 1)[1].split("# --- Pass 3:", 1)[0]
+
+    assert (
+        "${API}/search/issues?q=${LABEL_QUERY}&per_page=100&page=1" in pass_two
+    )
+    assert ".repository_url" in pass_two
+    assert "${API}/repos/${REPO}/pulls?state=open&per_page=100&page=${PAGE}" in pass_two
+    assert "test-on-lab" in pass_two
+    assert "PR_URL=" not in pass_two

--- a/tests/unit/test_pr_poller_reaper.py
+++ b/tests/unit/test_pr_poller_reaper.py
@@ -128,6 +128,18 @@ if "/search/issues" in url:
     print(json.dumps({"total_count": len(prs), "items": items}))
     sys.exit(0)
 
+if "/repos/" in url and "/pulls" in url:
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+    path = urllib.parse.urlparse(url).path
+    repo = path.split("/repos/", 1)[1].split("/pulls", 1)[0]
+    page = int(query.get("page", ["1"])[0])
+    if repo in state.get("search_fails", []):
+        log.write("pulls-fail %s\\n" % repo)
+        sys.exit(22)
+    prs = [p for p in state["open_prs"] if p["base"]["repo"]["full_name"] == repo]
+    print(json.dumps([] if page > 1 else prs))
+    sys.exit(0)
+
 if "/pr/" in url:
     _, repo_owner, repo_name, number = url.rsplit("/", 3)
     repo = "%s/%s" % (repo_owner.rsplit("/", 1)[-1], repo_name)
@@ -344,7 +356,7 @@ def test_dispatch_cap_is_aligned_with_the_execution_capacity():
     ]
     assert int(line.split("=")[1]) <= limit // parallelism, textwrap.dedent(
         """
-        Admitting more workflows per 5-minute poll than the runner can execute
+        Admitting more workflows per poll than the runner can execute
         concurrently (ghost-container-qa limit // pipeline parallelism) only
         deepens the queue.
         """


### PR DESCRIPTION
## Summary

- Replace the six auto-repo `search/issues` + per-PR detail loops with paged `GET /repos/{owner}/{repo}/pulls?state=open&per_page=100` calls.
- Keep the label catch-all, but use search only to discover repositories and filter full pull objects locally.
- Reduce the CronWorkflow cadence from every 5 minutes to every 15 minutes; keep `concurrencyPolicy: Forbid`.
- Preserve dispatch, SHA dedupe, superseded-run reaping, and Dakota BST throttles.

## Measured API-volume change

The audit baseline was **~12,000+ GitHub API calls/day** at 5-minute cadence. A live snapshot during this change showed 83 auto-repo open PRs (17 common, 6 knuckle, 10 testsuite, 15 bluefin, 16 bluefin-lts, 19 dakota) and zero `test-on-lab` PRs:

- Before, that snapshot would be 6 search calls + 83 PR-detail calls + 1 label search = **90 listing calls/poll**, or **25,920/day** at 288 polls/day (up to 26,784/day including the three-dispatch cap).
- After, it is 6 pull-list calls + 1 label-discovery search = **7 listing calls/poll**, or **672/day** at 96 polls/day. Including the three-dispatch cap, the worst case is **960/day**. Each additional pull page or non-auto labeled repository adds at most 96 calls/day.

The pull response was verified with `gh api`: it contains the fields used by dispatch (`base.repo.full_name`, `head.sha`, `head.ref`, `head.repo.clone_url`, `number`, `title`, and `labels`). Search results do not contain the base/head fields, which is why they are no longer used for auto-repo dispatch.

## Reaper safety

Every auto-repo pull page is checked for a successful HTTP response and valid array JSON. Any failed or malformed page sets `SCAN_OK=0`; the reaper only marks a repo healthy after all pages succeed and at least one open PR was observed. Failed listings therefore skip reaping for that repo instead of treating a partial result as closure.

Conditional requests were not added because poller pods are ephemeral and there is no clean persistent ETag cache in the current template.

## Validation

- `just lint` ✅
- `argo lint --offline argo/workflow-templates/` ✅
- `pytest -q tests/unit/test_pr_poller_api_volume.py tests/unit/test_pr_poller_reaper.py` ✅ 13 passed
- Full repository pytest remains blocked by unrelated pre-existing lab/infrastructure fixture failures (homelab DNS, Zot config, page dataset, and RECC seam tests).