### PR TITLE
fix(storage): stop local-path helper pod delete loop

### DIFF
--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -51,6 +51,60 @@ across KubeVirt-capable nodes. Knuckle VMs co-schedule on the node holding their
 local-path PVC. Other workflow pods may land on exo-0 according to template
 constraints.
 
+## Local-path storage paths and stale PV cleanup
+
+`manifests/local-path-config.yaml` is the source of truth for the bundled Rancher
+Local Path Provisioner. The current node-local data mounts are:
+
+| Node | Provisioner path |
+|---|---|
+| `ghost` | `/var/mnt/ghost-data/local-path` |
+| `exo-0` | `/var/mnt/exo0-data/local-path` |
+
+These names identify different physical mounts. Never apply `ghost`'s path to
+`exo-0`, and do not add `DEFAULT_PATH_FOR_NON_LISTED_NODES`: an unconfigured
+node must fail closed rather than provision PVCs on its root disk. Local-path
+stores the selected path in each PV's `spec.local.path`; changing the ConfigMap
+does not migrate or rewrite existing PVs.
+
+In the August 2026 helper-pod incident, a privileged hostPath probe found
+`/var/mnt/ghost-data` was a real directory on `ghost`, but a dangling symlink on
+`exo-0` pointing to `/var/mnt/exo0-data/ghost-data`; the valid exo-0 storage
+directory was `/var/mnt/exo0-data/local-path`. That mismatch is why kubelet
+reported `mkdir ... file exists` before the teardown container could start.
+
+### Helper-pod delete loop
+
+When `helper-pod-delete-pvc-*` pods churn in `CreateContainerError` with
+`failed to mkdir "/var/mnt/ghost-data/local-path/": mkdir /var/mnt/ghost-data:
+file exists`, inspect the helper pod's node, its hostPath, and the PV's stored
+path:
+
+```bash
+kubectl -n kube-system describe pod <helper-pod>
+kubectl -n kube-system get cm local-path-config -o yaml
+kubectl get pv <pv-name> -o yaml
+kubectl get pvc -A | grep -i terminating
+```
+
+Do not SSH to a node. To inspect the host path, run a short-lived privileged
+diagnostic pod with `/var/mnt` mounted read-only and pinned to the affected
+node. A dangling symlink or other non-directory at the parent mount produces
+the same kubelet `mkdir ... file exists` error.
+
+After the node map is corrected in Git and reconciled, clean up only PVs that
+are all of the following:
+
+1. `Released`, with `reclaimPolicy: Delete`;
+2. storing the incorrect node path and pinned to the affected node;
+3. no longer referenced by any PVC or active workload; and
+4. verified to contain no data that must be retained.
+
+Delete the explicitly identified stale PVs, then remove any remaining helper
+pods for those PVs. Never mass-delete `Bound` PVs or PVCs merely to stop the
+churn. Confirm that new helper pods are absent and that newly provisioned
+PV paths match the node map.
+
 ## GitOps ownership
 
 | Area | Source of truth | Reconciler |

--- a/manifests/local-path-config.yaml
+++ b/manifests/local-path-config.yaml
@@ -9,8 +9,11 @@ metadata:
     app.kubernetes.io/part-of: lab
 data:
   # Rancher Local Path Provisioner creates data beneath the selected node path.
-  # Omitting a default entry makes PVC provisioning fail on unlisted nodes rather
-  # than silently creating storage on their root filesystem.
+  # These paths are node-local identities, not interchangeable cluster paths:
+  # never reuse ghost's mount name on another node. Omitting a default entry makes
+  # PVC provisioning fail on unlisted nodes rather than using a root-disk fallback.
+  # A PV stores the selected path, so correcting this map does not rewrite older
+  # PVs; stale Released PVs must be checked and cleaned up separately.
   config.json: |-
     {
       "nodePathMap": [

--- a/tests/unit/test_local_path_node_paths.py
+++ b/tests/unit/test_local_path_node_paths.py
@@ -1,0 +1,24 @@
+"""Regression checks for node-local Local Path Provisioner storage mappings."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = ROOT / "manifests/local-path-config.yaml"
+
+
+def test_local_path_uses_each_nodes_data_mount_without_a_default():
+    manifest = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    config = json.loads(manifest["data"]["config.json"])
+    node_paths = {entry["node"]: entry["paths"] for entry in config["nodePathMap"]}
+
+    assert node_paths == {
+        "ghost": ["/var/mnt/ghost-data/local-path"],
+        "exo-0": ["/var/mnt/exo0-data/local-path"],
+    }
+    assert "DEFAULT_PATH_FOR_NON_LISTED_NODES" not in node_paths


### PR DESCRIPTION
## Root cause

The live `local-path-config` already has the correct per-node map:

- `ghost` -> `/var/mnt/ghost-data/local-path`
- `exo-0` -> `/var/mnt/exo0-data/local-path`

The loop came from historical PVs created before that mapping fix. 38 `Released`
local-path PVs created on 2026-07-11 retained `/var/mnt/ghost-data/local-path`
in `spec.local.path` while their node affinity was `exo-0`. PV paths are
immutable after provisioning, so correcting the ConfigMap did not repair them.

Live evidence:

- Four helper pods continuously churned on `exo-0` in `CreateContainerError`.
- Kubelet reported `mkdir /var/mnt/ghost-data: file exists` while mounting the
  teardown hostPath.
- A privileged read-only hostPath probe found `/var/mnt/ghost-data` is a real
  directory on `ghost`, but a dangling symlink on `exo-0` to
  `/var/mnt/exo0-data/ghost-data`; `/var/mnt/exo0-data/local-path` is the valid
  exo-0 directory.
- Current PV audit showed zero cross-node paths after cleanup: exo-0 PVs use
  `exo0-data`, and ghost PVs use `ghost-data`.

## Changes

- Add a regression test locking the explicit node-local paths and fail-closed
  behavior.
- Clarify the GitOps ConfigMap comments and document the immutable-PV failure
  mode and surgical cleanup procedure in `docs/ops/RUNBOOK.md`.

## Live cleanup and verification

All 38 stale PVs were `Released`, used `reclaimPolicy: Delete`, had no matching
PVCs (38/38 claim references absent), and no active workflows. I deleted only
that exact stale set, then deleted the four orphaned helper pods. I did not
delete bound PVs, PVCs, or the two remaining Released PVs that already use the
valid exo-0 path.

After a 75-second observation window:

- `helper-pod-delete-pvc-*`: 0
- stale exo-0 PVs using `ghost-data`: 0
- terminating PVCs: 0
- provisioner errors in the last 60 seconds: none
- `local-path-provisioner`: 1/1 and both nodes Ready

ArgoCD `testing-lab-infra` was already `Synced`/`Healthy` on `main`; the
functional node map is live. This PR adds the guardrail and documentation and
must not be auto-merged.

## Validation

- `just lint`
- `python3 -m pytest -q tests/unit/test_local_path_node_paths.py`
- `git diff --check`