### PR TITLE
fix(qa): cache runner dependencies and aggregate results

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -17,8 +17,12 @@ spec:
   - name: run-container-tests
     # GNOME/DRM tests need the physical desktop host. exo-0 is headless and
     # cannot provide a graphical seat even when /sys and /run/udev are mounted.
+    # Keep every suite pod on ghost as well: the result store is node-local,
+    # and ghost is the only node whose canonical local-path mount is
+    # /var/mnt/ghost-data/local-path. exo-0 uses a different physical mount.
     nodeSelector:
       node-role.kubernetes.io/control-plane: "true"
+      kubernetes.io/hostname: ghost
     activeDeadlineSeconds: 3600
     # Cross-workflow backpressure: this template is referenced by every
     # container-only QA pipeline, so a template-level semaphore caps total
@@ -231,39 +235,75 @@ spec:
         fi
 
         persist_suite_results() {
-          # The hostPath is shared by this workflow's suite pods. Keep the
-          # complete per-suite directory for debugging and for the one
-          # aggregate publisher that wins the mkdir lock below.
+          # The hostPath is shared by this workflow's suite pods, which are
+          # explicitly pinned to ghost above. Keep the complete per-suite
+          # directory for debugging and for the one aggregate publisher that
+          # wins the mkdir lock below.
           mkdir -p "${SUITE_RESULT_DIR}"
-          if [[ -d /tmp/results ]]; then
-            cp -a /tmp/results/. "${SUITE_RESULT_DIR}/" 2>/dev/null || true
+          if ! cp -a /tmp/results/. "${SUITE_RESULT_DIR}/"; then
+            echo "ERROR: failed to persist suite results to ${SUITE_RESULT_DIR}" >&2
+            return 1
           fi
           touch "${SUITE_RESULT_DIR}/.complete"
 
           # A suite must never make publication failures change its test
           # verdict. The last suite to finish owns the single clone/commit/push
           # for the workflow; mkdir is an atomic cross-pod lock on the shared
-          # hostPath.
+          # hostPath. If all suite nodes are terminal but a result directory is
+          # missing, fail loudly instead of publishing incomplete evidence.
           if [[ -z "${GITHUB_TOKEN:-}" ]]; then
             echo "No GITHUB_TOKEN - skipping aggregate test-results publication" >&2
             return 0
           fi
-          local expected_suite normalized_suite all_complete=true
+          local expected_suite normalized_suite
           local -a expected_suites=()
           if [[ -z "${WORKFLOW_SUITES}" ]]; then
             expected_suites=("${SUITE}")
           else
             IFS=',' read -r -a expected_suites <<< "${WORKFLOW_SUITES}"
           fi
+          local -a missing_suites=()
           for expected_suite in "${expected_suites[@]}"; do
             normalized_suite="${expected_suite//[[:space:]]/}"
             [[ -n "${normalized_suite}" ]] || continue
             if [[ ! -f "${RESULT_STORE}/${normalized_suite}/.complete" ]]; then
-              all_complete=false
-              break
+              missing_suites+=("${normalized_suite}")
             fi
           done
-          if [[ "${all_complete}" != true ]]; then
+          if ((${#missing_suites[@]} > 0)); then
+            local workflow_json lane_count terminal_count expected_count
+            workflow_json=$(
+              kubectl get workflow "{{workflow.name}}" \
+                -n "{{workflow.namespace}}" -o json 2>/dev/null || true
+            )
+            expected_count=0
+            for expected_suite in "${expected_suites[@]}"; do
+              normalized_suite="${expected_suite//[[:space:]]/}"
+              [[ -n "${normalized_suite}" ]] || continue
+              expected_count=$((expected_count + 1))
+            done
+            lane_count=0
+            terminal_count=0
+            if [[ -n "${workflow_json}" && "${expected_count}" -gt 0 ]]; then
+              lane_count=$(
+                jq '[.status.nodes[]?
+                  | select(.type == "Pod" and .templateName == "run-container-tests")]
+                  | length' <<<"${workflow_json}" 2>/dev/null || printf '0'
+              )
+              terminal_count=$(
+                jq '[.status.nodes[]?
+                  | select(.type == "Pod" and .templateName == "run-container-tests")
+                  | select(.phase == "Succeeded" or .phase == "Failed" or
+                           .phase == "Error" or .phase == "Skipped" or
+                           .phase == "Omitted" or .phase == "Daemoned")]
+                  | length' <<<"${workflow_json}" 2>/dev/null || printf '0'
+              )
+            fi
+            if [[ "${lane_count}" -ge "${expected_count}" &&
+                  "${terminal_count}" -ge "${expected_count}" ]]; then
+              echo "ERROR: all ${expected_count} suite nodes are terminal but result directories are missing: ${missing_suites[*]}" >&2
+              return 1
+            fi
             return 0
           fi
           if ! mkdir "${RESULT_STORE}/.publish.lock" 2>/dev/null; then
@@ -290,6 +330,7 @@ spec:
           else
             echo "Published aggregate test results for ${IMG_SLUG} in one commit" >&2
           fi
+          return 0
         }
 
         cleanup_target() {
@@ -297,8 +338,13 @@ spec:
         }
         on_exit() {
           local rc=$?
-          persist_suite_results || true
+          local persist_rc=0
+          persist_suite_results || persist_rc=$?
           cleanup_target
+          if [[ "${persist_rc}" -ne 0 ]]; then
+            echo "ERROR: suite result persistence/aggregation failed (rc=${persist_rc})" >&2
+            [[ "${rc}" -ne 0 ]] || rc="${persist_rc}"
+          fi
           return "${rc}"
         }
         trap on_exit EXIT
@@ -593,7 +639,8 @@ spec:
           if python3 -m pip install --help 2>/dev/null | grep -q -- --break-system-packages; then
             pip_args+=(--break-system-packages)
           fi
-          pip_args+=(--cache-dir "${PIP_CACHE_DIR}" --find-links /opt/qa-wheels)
+          pip_args+=(--cache-dir "${PIP_CACHE_DIR}")
+          qa_dependencies=("setuptools<81" qecore dogtail behave)
           pip_ok=false
           for attempt in 1 2 3; do
             # setuptools is explicit and load-bearing, not incidental: qecore's
@@ -604,7 +651,16 @@ spec:
             # so without this pin every after_scenario hook raises
             # ModuleNotFoundError. Keep it pinned below 81 for as long as qecore
             # imports pkg_resources.
-            if python3 -m pip install "${pip_args[@]}" "setuptools<81" qecore dogtail behave >/tmp/pip-install.log 2>&1; then
+            if python3 -m pip install "${pip_args[@]}" \
+                --no-index --find-links /opt/qa-wheels \
+                "${qa_dependencies[@]}" >/tmp/pip-install.log 2>&1; then
+              pip_ok=true
+              break
+            fi
+            echo "Local QA wheelhouse did not satisfy this target interpreter; falling back to the configured package index." >&2
+            if python3 -m pip install "${pip_args[@]}" \
+                --find-links /opt/qa-wheels \
+                "${qa_dependencies[@]}" >/tmp/pip-install.log 2>&1; then
               pip_ok=true
               break
             fi
@@ -838,8 +894,8 @@ spec:
         type: Directory
     - name: results-store
       hostPath:
-        path: /var/mnt/ghost-data/test-results
-        type: DirectoryOrCreate
+        path: /var/mnt/ghost-data/local-path
+        type: Directory
     - name: pip-cache
       hostPath:
         path: /var/cache/bluefin-qa-pip

--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -85,7 +85,10 @@ spec:
         git clone --depth 1 --branch "${TSBRANCH}" "${TSREPO}" /workspace/testsuite
         echo "Cloned testsuite @ ${TSBRANCH}"
     script:
-      image: quay.io/podman/stable:latest
+      # The ARC runner image is also the lab's reusable QA runner. It carries
+      # podman/skopeo/git and the pre-fetched Python wheelhouse, so every suite
+      # starts without a per-pod package-manager bootstrap.
+      image: ghcr.io/projectbluefin/arc-runner:latest
       imagePullPolicy: IfNotPresent
       securityContext:
         # Podman needs a writable cgroup hierarchy to boot the nested systemd host.
@@ -114,6 +117,8 @@ spec:
         value: "{{inputs.parameters.variant}}"
       - name: BEHAVE_TAGS
         value: "{{inputs.parameters.behave-tags}}"
+      - name: WORKFLOW_SUITES
+        value: "__auto__"
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
@@ -131,6 +136,10 @@ spec:
         name: containers-runroot
       - mountPath: /run/udev
         name: udev
+      - mountPath: /var/mnt/ghost-data/test-results
+        name: results-store
+      - mountPath: /var/cache/bluefin-qa-pip
+        name: pip-cache
       command: [bash]
       source: |
         set -euo pipefail
@@ -188,10 +197,6 @@ spec:
             ;;
         esac
         if [[ -z "${IMAGE_DIGEST:-}" ]]; then
-          if ! command -v skopeo >/dev/null 2>&1; then
-            echo "skopeo not found; installing for digest resolution..." >&2
-            dnf install -y skopeo >/dev/null 2>&1 || true
-          fi
           DIGEST=""
           if command -v skopeo >/dev/null 2>&1 && [[ "${ZOT_IMAGE_REPO}" != "${IMAGE_REPO}" ]]; then
             DIGEST=$(timeout 120 skopeo inspect --tls-verify=false --no-tags \
@@ -212,13 +217,97 @@ spec:
         runroot = "/run/containers/storage"
         EOF
         export CONTAINERS_STORAGE_CONF="${STORAGE_CONF}"
-        trap 'podman rm --force "${TARGET_NAME}" >/dev/null 2>&1 || true' EXIT
+        RESULT_STORE="/var/mnt/ghost-data/test-results/{{workflow.name}}"
+        SUITE_RESULT_DIR="${RESULT_STORE}/${SUITE}"
+        mkdir -p "${SUITE_RESULT_DIR}"
+        if [[ "${WORKFLOW_SUITES}" == "__auto__" ]]; then
+          WORKFLOW_SUITES=$(
+            kubectl get workflow "{{workflow.name}}" \
+              -n "{{workflow.namespace}}" -o json 2>/dev/null |
+              jq -r '.spec.arguments.parameters[]? | select(.name == "suites") | .value' |
+              head -n 1 || true
+          )
+          [[ -n "${WORKFLOW_SUITES}" ]] || WORKFLOW_SUITES="${SUITE}"
+        fi
+
+        persist_suite_results() {
+          # The hostPath is shared by this workflow's suite pods. Keep the
+          # complete per-suite directory for debugging and for the one
+          # aggregate publisher that wins the mkdir lock below.
+          mkdir -p "${SUITE_RESULT_DIR}"
+          if [[ -d /tmp/results ]]; then
+            cp -a /tmp/results/. "${SUITE_RESULT_DIR}/" 2>/dev/null || true
+          fi
+          touch "${SUITE_RESULT_DIR}/.complete"
+
+          # A suite must never make publication failures change its test
+          # verdict. The last suite to finish owns the single clone/commit/push
+          # for the workflow; mkdir is an atomic cross-pod lock on the shared
+          # hostPath.
+          if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+            echo "No GITHUB_TOKEN - skipping aggregate test-results publication" >&2
+            return 0
+          fi
+          local expected_suite normalized_suite all_complete=true
+          local -a expected_suites=()
+          if [[ -z "${WORKFLOW_SUITES}" ]]; then
+            expected_suites=("${SUITE}")
+          else
+            IFS=',' read -r -a expected_suites <<< "${WORKFLOW_SUITES}"
+          fi
+          for expected_suite in "${expected_suites[@]}"; do
+            normalized_suite="${expected_suite//[[:space:]]/}"
+            [[ -n "${normalized_suite}" ]] || continue
+            if [[ ! -f "${RESULT_STORE}/${normalized_suite}/.complete" ]]; then
+              all_complete=false
+              break
+            fi
+          done
+          if [[ "${all_complete}" != true ]]; then
+            return 0
+          fi
+          if ! mkdir "${RESULT_STORE}/.publish.lock" 2>/dev/null; then
+            return 0
+          fi
+
+          local publish_rc=0
+          {
+            rm -rf /tmp/lab-code
+            git clone --depth 1 \
+              "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
+              /tmp/lab-code
+            python3 /tmp/lab-code/scripts/publish_test_results.py \
+              --batch-dir "${RESULT_STORE}" \
+              --img-slug "${IMG_SLUG}" \
+              --workflow-name "{{workflow.name}}" \
+              --github-token "${GITHUB_TOKEN}" \
+              --digest "${DIGEST}" \
+              --repo-dir /tmp/lab-code
+          } || publish_rc=$?
+          if [[ "${publish_rc}" -ne 0 ]]; then
+            echo "Warning: failed to publish aggregate test results (rc=${publish_rc})" >&2
+            rmdir "${RESULT_STORE}/.publish.lock" 2>/dev/null || true
+          else
+            echo "Published aggregate test results for ${IMG_SLUG} in one commit" >&2
+          fi
+        }
+
+        cleanup_target() {
+          podman rm --force "${TARGET_NAME}" >/dev/null 2>&1 || true
+        }
+        on_exit() {
+          local rc=$?
+          persist_suite_results || true
+          cleanup_target
+          return "${rc}"
+        }
+        trap on_exit EXIT
 
         command -v podman >/dev/null || {
           echo "Podman is required for nested systemd QA" >&2
           exit 1
         }
-        mkdir -p /tmp/results
+        mkdir -p /tmp/results /opt/qa-wheels /var/cache/bluefin-qa-pip
         if [[ "${ZOT_IMAGE_REPO}" != "${IMAGE_REPO}" ]]; then
           if [[ -n "${DIGEST:-}" ]]; then
             TARGET_IMAGE="${ZOT_IMAGE_REPO}@${DIGEST}"
@@ -272,6 +361,8 @@ spec:
           --mount type=bind,source=/run/udev,destination=/run/udev,ro,bind-propagation=rprivate \
           --volume /workspace:/workspace:ro \
           --volume /tmp/results:/tmp/results \
+          --volume /opt/qa-wheels:/opt/qa-wheels:ro \
+          --volume /var/cache/bluefin-qa-pip:/var/cache/bluefin-qa-pip:rw \
           --volume /etc/resolv.conf:/etc/resolv.conf:ro \
           "${TARGET_IMAGE}" /sbin/init >/dev/null
 
@@ -493,10 +584,16 @@ spec:
           # Bootc/Fedora images mark the system interpreter as externally
           # managed (PEP 668); the target container is disposable, so opt out
           # when the flag is supported.
+          # The wheelhouse and shared cache reduce WAN work without changing
+          # the contract: qecore/dogtail/behave are still installed by pip
+          # inside the shipped target image under test.
+          mkdir -p /var/cache/bluefin-qa-pip
+          export PIP_CACHE_DIR=/var/cache/bluefin-qa-pip
           pip_args=(--disable-pip-version-check --no-input)
           if python3 -m pip install --help 2>/dev/null | grep -q -- --break-system-packages; then
             pip_args+=(--break-system-packages)
           fi
+          pip_args+=(--cache-dir "${PIP_CACHE_DIR}" --find-links /opt/qa-wheels)
           pip_ok=false
           for attempt in 1 2 3; do
             # setuptools is explicit and load-bearing, not incidental: qecore's
@@ -725,28 +822,6 @@ spec:
           printf 'Execution failed' >/tmp/results/result-summary.txt
         fi
 
-
-        # Publish digest-pinned test results back to the lab repo.
-        if [[ -n "${GITHUB_TOKEN:-}" && -f /tmp/results/results.json ]]; then
-          if ! command -v git >/dev/null 2>&1; then
-            echo "git not found; installing git-core before result publication..." >&2
-            dnf install -y git-core >/dev/null 2>&1 || true
-          fi
-          PUBLISH_RC=0
-          {
-            rm -rf /tmp/lab-code
-            git clone --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" /tmp/lab-code
-            python3 /tmp/lab-code/scripts/publish_test_results.py /tmp/results/results.json "${IMG_SLUG}" "${SUITE}" "{{workflow.name}}" "${GITHUB_TOKEN}" "${DIGEST}"
-          } || PUBLISH_RC=$?
-          if [[ "${PUBLISH_RC}" -ne 0 ]]; then
-            echo "Warning: failed to publish test results (rc=${PUBLISH_RC})" >&2
-          fi
-        elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
-          echo "No GITHUB_TOKEN - skipping test results publication" >&2
-        else
-          echo "Skipping publication: /tmp/results/results.json not found" >&2
-        fi
-
         exit "${BEHAVE_RC}"
     volumes:
     - name: workspace
@@ -761,3 +836,11 @@ spec:
       hostPath:
         path: /run/udev
         type: Directory
+    - name: results-store
+      hostPath:
+        path: /var/mnt/ghost-data/test-results
+        type: DirectoryOrCreate
+    - name: pip-cache
+      hostPath:
+        path: /var/cache/bluefin-qa-pip
+        type: DirectoryOrCreate

--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -251,10 +251,6 @@ spec:
           # for the workflow; mkdir is an atomic cross-pod lock on the shared
           # hostPath. If all suite nodes are terminal but a result directory is
           # missing, fail loudly instead of publishing incomplete evidence.
-          if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-            echo "No GITHUB_TOKEN - skipping aggregate test-results publication" >&2
-            return 0
-          fi
           local expected_suite normalized_suite
           local -a expected_suites=()
           if [[ -z "${WORKFLOW_SUITES}" ]]; then
@@ -304,6 +300,10 @@ spec:
               echo "ERROR: all ${expected_count} suite nodes are terminal but result directories are missing: ${missing_suites[*]}" >&2
               return 1
             fi
+            return 0
+          fi
+          if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+            echo "No GITHUB_TOKEN - skipping aggregate test-results publication" >&2
             return 0
           fi
           if ! mkdir "${RESULT_STORE}/.publish.lock" 2>/dev/null; then

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -85,6 +85,31 @@ spec:
           restartPolicy: Never
           terminationGracePeriodSeconds: 30
           automountServiceAccountToken: false
+          initContainers:
+          - name: qa-wheelhouse
+            image: ghcr.io/projectbluefin/arc-runner:latest
+            imagePullPolicy: IfNotPresent
+            command: [bash, -c]
+            args:
+            - |
+              set -euo pipefail
+              if [[ -d /opt/qa-wheels ]]; then
+                mkdir -p /workspace/qa-wheels
+                cp -a /opt/qa-wheels/. /workspace/qa-wheels/
+              fi
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+            volumeMounts:
+            - name: workspace
+              mountPath: /workspace
           containers:
           - name: target
             image: "{{inputs.parameters.image}}:{{inputs.parameters.image-tag}}"
@@ -111,12 +136,18 @@ spec:
               mountPath: /run
             - name: workspace
               mountPath: /workspace
+            - name: pip-cache
+              mountPath: /var/cache/bluefin-qa-pip
           volumes:
           - name: run
             emptyDir:
               medium: Memory
           - name: workspace
             emptyDir: {}
+          - name: pip-cache
+            hostPath:
+              path: /var/cache/bluefin-qa-pip
+              type: DirectoryOrCreate
 
   - name: run-tests
     # 2h, sized for the slowest lane (suite=homebrew) rather than the fastest.
@@ -158,8 +189,11 @@ spec:
       - name: testsuite-branch
       - name: behave-tags
     script:
-      image: ghcr.io/projectbluefin/lab-runner:latest
+      image: ghcr.io/projectbluefin/arc-runner:latest
       command: [bash]
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
       resources:
         requests:
           cpu: 100m
@@ -242,7 +276,25 @@ spec:
         if ! python3 -m pip --version >/dev/null 2>&1; then
           python3 -m ensurepip --default-pip
         fi
-        python3 -m pip install --quiet qecore dogtail behave
+        # The wheelhouse and shared cache reduce WAN work without changing
+        # the contract: these packages are still installed by pip inside the
+        # shipped target image under test.
+        mkdir -p /var/cache/bluefin-qa-pip
+        pip_args=(--disable-pip-version-check --no-input
+          --cache-dir /var/cache/bluefin-qa-pip
+          --find-links /workspace/qa-wheels)
+        if python3 -m pip install --help 2>/dev/null | grep -q -- --break-system-packages; then
+          pip_args+=(--break-system-packages)
+        fi
+        # setuptools is explicit and load-bearing, not incidental: qecore's
+        # Sandbox._attach_version_status_to_report() does `import
+        # pkg_resources` to build the per-scenario version table. That module
+        # ships only with setuptools and was dropped from setuptools 81+, and
+        # Python 3.12+ no longer seeds it into fresh environments, so without
+        # this pin every after_scenario hook raises ModuleNotFoundError. Keep it
+        # pinned below 81 for as long as qecore imports pkg_resources.
+        python3 -m pip install --quiet "${pip_args[@]}" \
+          "setuptools<81" qecore dogtail behave
         if ! grep -q "^bluefin-test:" /etc/passwd; then
           echo "bluefin-test:x:1000:1000:Bluefin QA:/home/bluefin-test:/bin/bash" >>/etc/passwd
         fi

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -281,8 +281,7 @@ spec:
         # shipped target image under test.
         mkdir -p /var/cache/bluefin-qa-pip
         pip_args=(--disable-pip-version-check --no-input
-          --cache-dir /var/cache/bluefin-qa-pip
-          --find-links /workspace/qa-wheels)
+          --cache-dir /var/cache/bluefin-qa-pip)
         if python3 -m pip install --help 2>/dev/null | grep -q -- --break-system-packages; then
           pip_args+=(--break-system-packages)
         fi
@@ -293,8 +292,15 @@ spec:
         # Python 3.12+ no longer seeds it into fresh environments, so without
         # this pin every after_scenario hook raises ModuleNotFoundError. Keep it
         # pinned below 81 for as long as qecore imports pkg_resources.
-        python3 -m pip install --quiet "${pip_args[@]}" \
-          "setuptools<81" qecore dogtail behave
+        qa_dependencies=("setuptools<81" qecore dogtail behave)
+        if ! python3 -m pip install --quiet "${pip_args[@]}" \
+          --no-index --find-links /workspace/qa-wheels \
+          "${qa_dependencies[@]}"; then
+          echo "Local QA wheelhouse did not satisfy this target interpreter; falling back to the configured package index." >&2
+          python3 -m pip install --quiet "${pip_args[@]}" \
+            --find-links /workspace/qa-wheels \
+            "${qa_dependencies[@]}"
+        fi
         if ! grep -q "^bluefin-test:" /etc/passwd; then
           echo "bluefin-test:x:1000:1000:Bluefin QA:/home/bluefin-test:/bin/bash" >>/etc/passwd
         fi

--- a/images/arc-runner/Containerfile
+++ b/images/arc-runner/Containerfile
@@ -6,15 +6,35 @@ FROM ghcr.io/actions/actions-runner:latest@sha256:0cfdcc701ce933c6d243c6b0b2da76
 
 USER root
 
-# Install bluefin CI toolchain: buildah, skopeo, cosign, oras, argo CLI, kubectl, jq
+# Install bluefin CI toolchain and the tools used by container QA runners:
+# buildah, podman, skopeo, git-core (the Ubuntu package is `git`), cosign,
+# oras, argo CLI, kubectl, jq.
 # Using apt (actions-runner base is Ubuntu); these are the tools currently installed per-job.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
       buildah \
+      podman \
       skopeo \
+      git \
       curl \
       jq \
+      python3-pip \
     && rm -rf /var/lib/apt/lists/*
+
+# Keep the target image under test authoritative for the installed Python
+# environment. This wheelhouse only moves the download once into the runner
+# image; the disposable target still performs the real installation, including
+# its load-bearing setuptools<81 pin.
+RUN mkdir -p /opt/qa-wheels && \
+    python3 -m pip download \
+      --disable-pip-version-check \
+      --no-cache-dir \
+      --dest /opt/qa-wheels \
+      "setuptools<81" \
+      qecore \
+      dogtail \
+      behave && \
+    chmod -R a+rX /opt/qa-wheels
 
 # kubectl (for cluster operations and debugging from ARC jobs)
 RUN curl -sSfL \

--- a/scripts/publish_test_results.py
+++ b/scripts/publish_test_results.py
@@ -6,6 +6,8 @@ import re
 import subprocess
 import shutil
 import urllib.request
+from pathlib import Path
+import argparse
 from datetime import datetime, timezone
 
 from evaluate_kde_soak import evaluate_kde_soak, is_trusted_github_issue_url
@@ -190,73 +192,60 @@ def parse_results_and_build_update(
         updated_data["digest"] = digest
     return updated_data
 
-def main():
-    if len(sys.argv) < 6:
-        print("Usage: publish_test_results.py <results_json_path> <img_slug> <suite> <workflow_name> <github_token> [digest] [failure_class] [failure_issue_url]")
-        sys.exit(1)
-
-    results_json_path = sys.argv[1]
-    img_slug = sys.argv[2]
-    suite = sys.argv[3]
-    workflow_name = sys.argv[4]
-    github_token = sys.argv[5]
-    digest = sys.argv[6] if len(sys.argv) > 6 else None
-    failure_class = sys.argv[7] if len(sys.argv) > 7 else "test"
-    failure_issue_url = sys.argv[8] if len(sys.argv) > 8 else None
-
-    if not digest:
-        print(f"No digest provided. Attempting anonymous resolution for slug {img_slug}...")
-        digest = resolve_digest_for_slug(img_slug)
-        if digest:
-            print(f"Successfully resolved digest: {digest}")
-        else:
-            print("Digest resolution skipped or failed.")
-
-    if not github_token:
-        print("ERROR: github_token is empty.", file=sys.stderr)
-        sys.exit(2)
-
-    if not os.path.exists(results_json_path):
-        print(f"ERROR: {results_json_path} not found.", file=sys.stderr)
-        sys.exit(2)
-
-    # 1. Parse behave results.json
+def _load_json(path, description):
     try:
-        with open(results_json_path, 'r') as f:
-            data = json.load(f)
-    except Exception as e:
-        print(f"ERROR: Failed to parse {results_json_path}: {e}")
+        with open(path, "r", encoding="utf-8") as result_file:
+            return json.load(result_file)
+    except Exception as exc:
+        print(f"ERROR: Failed to parse {description} {path}: {exc}", file=sys.stderr)
         sys.exit(2)
 
-    current_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # 2. Clone projectbluefin/lab to a temporary directory
-    temp_dir = os.path.join(os.getcwd(), ".lab-repo-clone")
-    if os.path.exists(temp_dir):
-        shutil.rmtree(temp_dir)
+def _resolve_digest(img_slug, digest):
+    if digest:
+        return digest
+    print(f"No digest provided. Attempting anonymous resolution for slug {img_slug}...")
+    resolved = resolve_digest_for_slug(img_slug)
+    if resolved:
+        print(f"Successfully resolved digest: {resolved}")
+    else:
+        print("Digest resolution skipped or failed.")
+    return resolved
 
+
+def _clone_repo(github_token, repo_dir):
+    repo_dir = os.path.abspath(repo_dir)
+    if os.path.exists(repo_dir):
+        shutil.rmtree(repo_dir)
     repo_url = f"https://x-access-token:{github_token}@github.com/projectbluefin/lab.git"
-    run_cmd(["git", "clone", "--depth", "1", repo_url, temp_dir])
+    run_cmd(["git", "clone", "--depth", "1", repo_url, repo_dir])
+    return repo_dir
 
-    # 3. Locate or create docs/results/<img_slug>-<suite>.json
-    results_dir = os.path.join(temp_dir, "docs", "results")
+
+def _write_updated_result(
+    results_json_path,
+    repo_dir,
+    img_slug,
+    suite,
+    workflow_name,
+    digest,
+    failure_class="test",
+    failure_issue_url=None,
+):
+    data = _load_json(results_json_path, "behave results")
+    results_dir = os.path.join(repo_dir, "docs", "results")
     os.makedirs(results_dir, exist_ok=True)
     result_filename = f"{img_slug}-{suite}.json"
     result_filepath = os.path.join(results_dir, result_filename)
 
     existing_data = None
     if os.path.exists(result_filepath):
-        try:
-            with open(result_filepath, 'r') as f:
-                existing_data = json.load(f)
-        except Exception as e:
-            print(f"ERROR: Failed to parse existing results file {result_filepath}: {e}", file=sys.stderr)
-            sys.exit(2)
+        existing_data = _load_json(result_filepath, "existing result")
 
     updated_data = parse_results_and_build_update(
         data=data,
         existing_data=existing_data,
-        current_utc=current_utc,
+        current_utc=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         workflow_name=workflow_name,
         img_slug=img_slug,
         suite=suite,
@@ -264,35 +253,181 @@ def main():
         failure_class=failure_class,
         failure_issue_url=failure_issue_url,
     )
+    with open(result_filepath, "w", encoding="utf-8") as result_file:
+        json.dump(updated_data, result_file)
+    return f"docs/results/{result_filename}"
 
-    with open(result_filepath, 'w') as f:
-        json.dump(updated_data, f)
 
-    # 4. Commit and push back to git
-    # Set config
-    run_cmd(["git", "config", "user.name", "github-actions[bot]"], cwd=temp_dir)
-    run_cmd(["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"], cwd=temp_dir)
-
-    # Git add and commit
-    run_cmd(["git", "add", f"docs/results/{result_filename}"], cwd=temp_dir)
-
-    # Check if there are changes before committing
-    diff_check = run_cmd(["git", "diff", "--cached", "--quiet"], cwd=temp_dir, check=False)
+def _commit_and_push(repo_dir, paths, workflow_name, description):
+    run_cmd(["git", "config", "user.name", "github-actions[bot]"], cwd=repo_dir)
+    run_cmd(
+        [
+            "git",
+            "config",
+            "user.email",
+            "github-actions[bot]@users.noreply.github.com",
+        ],
+        cwd=repo_dir,
+    )
+    run_cmd(["git", "add", *paths], cwd=repo_dir)
+    diff_check = run_cmd(["git", "diff", "--cached", "--quiet"], cwd=repo_dir, check=False)
     if diff_check.returncode == 0:
         print("No changes to test results. Skipping push.")
-        # Clean up
-        shutil.rmtree(temp_dir)
-        sys.exit(0)
+        return False
 
-    commit_msg = f"chore: update test results for {img_slug}-{suite} ({workflow_name})\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-    run_cmd(["git", "commit", "-m", commit_msg], cwd=temp_dir)
+    commit_msg = (
+        f"chore: update test results for {description} ({workflow_name})\n\n"
+        "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+    )
+    run_cmd(["git", "commit", "-m", commit_msg], cwd=repo_dir)
+    run_cmd(["git", "push", "origin", "HEAD:main"], cwd=repo_dir)
+    return True
 
-    # Git push back to main
-    run_cmd(["git", "push", "origin", "HEAD:main"], cwd=temp_dir)
-    print(f"SUCCESS: Pushed updated test results for {img_slug}-{suite} back to repository!")
 
-    # Clean up
-    shutil.rmtree(temp_dir)
+def publish_batch_results(
+    batch_dir,
+    img_slug,
+    workflow_name,
+    github_token,
+    digest=None,
+    repo_dir=None,
+):
+    """Publish all suite JSON files from one QA workflow in one git transaction.
+
+    Each suite writes ``<batch_dir>/<suite>/results.json``. The caller may
+    supply an already-cloned repository so the workflow performs exactly one
+    clone and this function performs exactly one push.
+    """
+    if not github_token:
+        raise ValueError("github_token is empty")
+
+    result_paths = sorted(Path(batch_dir).glob("*/results.json"))
+    if not result_paths:
+        raise FileNotFoundError(f"no suite results found below {batch_dir}")
+
+    digest = _resolve_digest(img_slug, digest)
+    temporary_repo = repo_dir is None
+    if temporary_repo:
+        repo_dir = os.path.join(os.getcwd(), ".lab-repo-clone")
+        _clone_repo(github_token, repo_dir)
+
+    try:
+        published_paths = []
+        suites = []
+        for result_path in result_paths:
+            suite = result_path.parent.name
+            published_paths.append(
+                _write_updated_result(
+                    str(result_path),
+                    repo_dir,
+                    img_slug,
+                    suite,
+                    workflow_name,
+                    digest,
+                )
+            )
+            suites.append(suite)
+        pushed = _commit_and_push(
+            repo_dir,
+            published_paths,
+            workflow_name,
+            f"{img_slug} suites {','.join(suites)}",
+        )
+        if pushed:
+            print(
+                "SUCCESS: Pushed aggregated test results for "
+                f"{img_slug} ({', '.join(suites)}) back to repository!"
+            )
+        return pushed
+    finally:
+        if temporary_repo:
+            shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def _publish_single(
+    results_json_path,
+    img_slug,
+    suite,
+    workflow_name,
+    github_token,
+    digest=None,
+    failure_class="test",
+    failure_issue_url=None,
+    repo_dir=None,
+):
+    if not github_token:
+        print("ERROR: github_token is empty.", file=sys.stderr)
+        sys.exit(2)
+    if not os.path.exists(results_json_path):
+        print(f"ERROR: {results_json_path} not found.", file=sys.stderr)
+        sys.exit(2)
+
+    digest = _resolve_digest(img_slug, digest)
+    temporary_repo = repo_dir is None
+    if temporary_repo:
+        repo_dir = os.path.join(os.getcwd(), ".lab-repo-clone")
+        _clone_repo(github_token, repo_dir)
+    try:
+        path = _write_updated_result(
+            results_json_path,
+            repo_dir,
+            img_slug,
+            suite,
+            workflow_name,
+            digest,
+            failure_class,
+            failure_issue_url,
+        )
+        pushed = _commit_and_push(repo_dir, [path], workflow_name, f"{img_slug}-{suite}")
+        if pushed:
+            print(f"SUCCESS: Pushed updated test results for {img_slug}-{suite} back to repository!")
+    finally:
+        if temporary_repo:
+            shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--batch-dir":
+        parser = argparse.ArgumentParser(description=__doc__)
+        parser.add_argument("--batch-dir", required=True)
+        parser.add_argument("--img-slug", required=True)
+        parser.add_argument("--workflow-name", required=True)
+        parser.add_argument("--github-token", required=True)
+        parser.add_argument("--digest", default=None)
+        parser.add_argument("--repo-dir", default=None)
+        args = parser.parse_args()
+        try:
+            publish_batch_results(
+                batch_dir=args.batch_dir,
+                img_slug=args.img_slug,
+                workflow_name=args.workflow_name,
+                github_token=args.github_token,
+                digest=args.digest,
+                repo_dir=args.repo_dir,
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(2)
+        return
+
+    if len(sys.argv) < 6:
+        print(
+            "Usage: publish_test_results.py <results_json_path> <img_slug> "
+            "<suite> <workflow_name> <github_token> [digest] [failure_class] "
+            "[failure_issue_url]"
+        )
+        sys.exit(1)
+
+    _publish_single(
+        results_json_path=sys.argv[1],
+        img_slug=sys.argv[2],
+        suite=sys.argv[3],
+        workflow_name=sys.argv[4],
+        github_token=sys.argv[5],
+        digest=sys.argv[6] if len(sys.argv) > 6 else None,
+        failure_class=sys.argv[7] if len(sys.argv) > 7 else "test",
+        failure_issue_url=sys.argv[8] if len(sys.argv) > 8 else None,
+    )
 
 if __name__ == "__main__":
     main()

--- a/tests/unit/test_run_container_tests_deps.py
+++ b/tests/unit/test_run_container_tests_deps.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTAINERFILE = ROOT / "images/arc-runner/Containerfile"
+CONTAINER_RUNNER = ROOT / "argo/workflow-templates/run-container-tests.yaml"
+SYSTEMD_RUNNER = ROOT / "argo/workflow-templates/run-systemd-container-tests.yaml"
+PUBLISHER = ROOT / "scripts/publish_test_results.py"
+
+
+def _template(path, name):
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return next(template for template in document["spec"]["templates"] if template["name"] == name)
+
+
+def test_arc_runner_bakes_tools_and_a_python_wheelhouse():
+    containerfile = CONTAINERFILE.read_text(encoding="utf-8")
+
+    for package in ("podman", "skopeo", "git", "python3-pip"):
+        assert package in containerfile
+    assert "/opt/qa-wheels" in containerfile
+    for dependency in ('"setuptools<81"', "qecore", "dogtail", "behave"):
+        assert dependency in containerfile
+
+
+def test_container_runner_uses_baked_runner_tools_without_dnf_bootstrap():
+    runner = _template(CONTAINER_RUNNER, "run-container-tests")
+    source = runner["script"]["source"]
+
+    assert runner["script"]["image"] == "ghcr.io/projectbluefin/arc-runner:latest"
+    assert "dnf install -y skopeo" not in source
+    assert "dnf install -y git-core" not in source
+    assert "--volume /opt/qa-wheels:/opt/qa-wheels:ro" in source
+    assert "--cache-dir" in source
+    assert "PIP_CACHE_DIR=/var/cache/bluefin-qa-pip" in source
+
+
+def test_target_python_dependencies_remain_target_installs_with_load_bearing_pin():
+    container_source = _template(CONTAINER_RUNNER, "run-container-tests")["script"]["source"]
+    systemd_source = _template(SYSTEMD_RUNNER, "run-tests")["script"]["source"]
+
+    # These packages exercise the shipped target image, so they must still be
+    # installed inside that disposable image rather than imported from the
+    # runner's Python environment.
+    for source in (container_source, systemd_source):
+        assert "qecore" in source
+        assert "dogtail" in source
+        assert "behave" in source
+        assert '"setuptools<81"' in source
+        assert "--find-links" in source
+        assert "bluefin-qa-pip" in source
+
+    assert "Sandbox._attach_version_status_to_report()" in container_source
+    assert "pkg_resources" in systemd_source
+
+
+def test_aggregate_publication_has_one_lab_clone_and_one_batch_push():
+    runner_source = _template(CONTAINER_RUNNER, "run-container-tests")["script"]["source"]
+    publisher_source = PUBLISHER.read_text(encoding="utf-8")
+
+    assert runner_source.count("github.com/projectbluefin/lab.git") == 1
+    assert "--batch-dir" in runner_source
+    assert ".publish.lock" in runner_source
+    assert "results-store" in CONTAINER_RUNNER.read_text(encoding="utf-8")
+    assert "def publish_batch_results(" in publisher_source
+    assert publisher_source.count('["git", "push", "origin", "HEAD:main"]') == 1
+
+
+def test_systemd_target_preseeds_wheels_without_changing_target_image():
+    create_target = _template(SYSTEMD_RUNNER, "create-target")
+    target = create_target["resource"]["manifest"]
+
+    assert "name: qa-wheelhouse" in target
+    assert "ghcr.io/projectbluefin/arc-runner:latest" in target
+    assert "/opt/qa-wheels" in target
+    assert "name: pip-cache" in target
+    assert 'path: /var/cache/bluefin-qa-pip' in target
+    assert 'image: "{{inputs.parameters.image}}:{{inputs.parameters.image-tag}}"' in target

--- a/tests/unit/test_run_container_tests_deps.py
+++ b/tests/unit/test_run_container_tests_deps.py
@@ -35,6 +35,12 @@ def test_container_runner_uses_baked_runner_tools_without_dnf_bootstrap():
     assert "--volume /opt/qa-wheels:/opt/qa-wheels:ro" in source
     assert "--cache-dir" in source
     assert "PIP_CACHE_DIR=/var/cache/bluefin-qa-pip" in source
+    assert "--no-index --find-links /opt/qa-wheels" in source
+    assert "falling back to the configured package index" in source
+    container_text = CONTAINER_RUNNER.read_text(encoding="utf-8")
+    assert "kubernetes.io/hostname: ghost" in container_text
+    assert "path: /var/mnt/ghost-data/local-path" in container_text
+    assert "type: Directory" in container_text
 
 
 def test_target_python_dependencies_remain_target_installs_with_load_bearing_pin():
@@ -50,6 +56,8 @@ def test_target_python_dependencies_remain_target_installs_with_load_bearing_pin
         assert "behave" in source
         assert '"setuptools<81"' in source
         assert "--find-links" in source
+        assert "--no-index" in source
+        assert "falling back to the configured package index" in source
         assert "bluefin-qa-pip" in source
 
     assert "Sandbox._attach_version_status_to_report()" in container_source
@@ -63,6 +71,8 @@ def test_aggregate_publication_has_one_lab_clone_and_one_batch_push():
     assert runner_source.count("github.com/projectbluefin/lab.git") == 1
     assert "--batch-dir" in runner_source
     assert ".publish.lock" in runner_source
+    assert "all ${expected_count} suite nodes are terminal" in runner_source
+    assert "persist_suite_results || persist_rc=$?" in runner_source
     assert "results-store" in CONTAINER_RUNNER.read_text(encoding="utf-8")
     assert "def publish_batch_results(" in publisher_source
     assert publisher_source.count('["git", "push", "origin", "HEAD:main"]') == 1


### PR DESCRIPTION
## Summary

Reduce uncached WAN traffic from container QA without changing the suite matrix:

- Extend the existing `images/arc-runner` image with Podman, Skopeo, Git, and a baked wheelhouse for `setuptools<81`, `qecore`, `dogtail`, and `behave`.
- Keep the Python dependencies installed inside the disposable bootc/Fedora image under test, preserving the load-bearing `setuptools<81` / `pkg_resources` contract.
- Prefer a `--no-index` install from the baked wheelhouse; if a target interpreter cannot use the wheelhouse, fall back to the configured package index rather than failing the QA lane.
- Remove per-suite `dnf` bootstraps and persist suite results to the shared test-results store.
- Pin all container suite pods to `ghost`, use the node-correct `/var/mnt/ghost-data/local-path` mount as a read/write result store, and fail loudly when terminal suite nodes have missing result directories or persistence fails.
- Aggregate all completed suite JSON files and use an atomic workflow lock so one suite performs one lab clone, one commit, and one push.
- Add focused unit coverage for the runner/dependency/publication contract.

## Traffic estimate (bounded)

The measured audit found Zot ingesting **1011 GiB in 24h** while only **13.24 GiB crossed the internet** (~**98.7% cache hit rate**); image layers were not the problem.

The old install frequencies were per **suite pod**, not per workflow:

- `skopeo`: once when `image-digest` was empty and the binary was absent. Image-poller QA passes a digest and therefore skipped this path; direct/manual/PR workflows with an empty digest could run it once for every selected suite, up to **5 times per workflow**.
- `git-core`: once in every publishing suite pod when Git was absent, also up to **5 times per workflow**. The old clone/commit/push happened in that same per-suite path.
- New behavior: both DNF installs are **zero** because the runner image carries the tools; clone/commit/push is **1 per workflow** instead of up to 5.

Assuming the measured workload of **20 workflows/day × 5 suites = 100 suite pods/day**, the fresh-container measurement of **~100 MB for `skopeo` + `git-core` together** gives a deliberately conservative DNF ceiling of **~10,000 MB/day (~9.8 GiB/day)**. This is a combined per-pod measurement, not 100 MB per package, and it must not be double-counted. Because the old commands ended in `|| true`, some calls were no-ops or partial failures; using a 20–80% full-download sensitivity gives **~2–8 GiB/day** for the DNF term. The original audit's **7–8 GiB/day** observed estimate falls inside that bound.

Additional measured reductions are approximately **0.2 GiB/day** from the 2.0 MB wheelhouse at 100 pods/day and **0.8 GiB/day** from shallow clone downloads (9.9 MiB × 100 old clones versus 20 new clones). Thus the honest planning range is roughly **3–9 GiB/day total**, with the realized value dependent on how often the old `|| true` installs actually downloaded metadata/packages. The 100 MB measurement came from `quay.io/fedora/fedora:latest`, not the old `quay.io/podman/stable`/lab runner base, so post-rollout egress counters are still required to replace this bound with a base-image-specific measurement.

## Capacity and the `ghost` pin

This pin does not newly serialize or remove an eligible QA node. The old template already required `node-role.kubernetes.io/control-plane=true`; live labels show that only `ghost` has that label (`exo-0` does not), and all 12 retained `run-container-tests` pods are on `ghost`. The per-workflow `parallelism: 2` and cross-workflow `ghost-container-qa` semaphore limit of 6 are unchanged.

Live capacity snapshot: `ghost` has **31.7 CPU / 58.6 GiB allocatable**, `kubectl top` reports **1.54 CPU / 17.4 GiB** in use, and four active QA runner pods request **8.4 CPU / 16.25 GiB** total. At the semaphore maximum of six QA pods, the current snapshot would be approximately **19.4 CPU / 38.9 GiB requested**, leaving about **12.3 CPU / 19.7 GiB** of allocatable headroom. Higher-priority VM pods can still preempt lower-priority build pods as documented; that is an existing cluster tradeoff, not a new consequence of this explicit hostname constraint.

## Validation

- `just lint` ✅
- `argo lint --offline argo/workflow-templates/run-container-tests.yaml argo/workflow-templates/run-systemd-container-tests.yaml` ✅
- `pytest -q tests/unit/test_run_container_tests_deps.py tests/unit/test_publish_test_results.py tests/unit/test_container_only_qa_workflows.py` — **83 passed** ✅
- Shell syntax checks for both embedded runner scripts ✅
- Full-suite failures previously observed are pre-existing on clean `origin/main` and are being handled separately.

Do not auto-merge; coordinator review and queueing are required.
