### PR TITLE
fix: bound Zot sync prefixes and config version test

### DIFF
--- a/manifests/zot-cache.yaml
+++ b/manifests/zot-cache.yaml
@@ -69,10 +69,13 @@ data:
                 { "prefix": "flatcar/*", "destination": "/ghcr" },
                 { "prefix": "frostyard/*", "destination": "/ghcr" },
                 { "prefix": "ggml-org/*", "destination": "/ghcr" },
+                { "prefix": "jrottenberg/*", "destination": "/ghcr" },
                 { "prefix": "kagent-dev/**", "destination": "/ghcr" },
-                { "prefix": "kubestellar/*", "destination": "/ghcr" },
+                { "prefix": "kubestellar/**", "destination": "/ghcr" },
+                { "prefix": "oras-project/*", "destination": "/ghcr" },
                 { "prefix": "project-zot/*", "destination": "/ghcr" },
                 { "prefix": "projectbluefin/*", "destination": "/ghcr" },
+                { "prefix": "razorfinos-org/*", "destination": "/ghcr" },
                 { "prefix": "ublue-os/*", "destination": "/ghcr" }
               ]
             },
@@ -85,6 +88,7 @@ data:
               "content": [
                 { "prefix": "bitnami/*", "destination": "/docker" },
                 { "prefix": "curlimages/*", "destination": "/docker" },
+                { "prefix": "jrottenberg/*", "destination": "/docker" },
                 { "prefix": "library/*", "destination": "/docker" },
                 { "prefix": "linuxserver/*", "destination": "/docker" },
                 { "prefix": "rancher/*", "destination": "/docker" },
@@ -103,6 +107,7 @@ data:
                 { "prefix": "brancz/*", "destination": "/quay" },
                 { "prefix": "buildah/*", "destination": "/quay" },
                 { "prefix": "fedora/*", "destination": "/quay" },
+                { "prefix": "fedora-ostree-desktops/*", "destination": "/quay" },
                 { "prefix": "kubestellar/*", "destination": "/quay" },
                 { "prefix": "kubevirt/*", "destination": "/quay" },
                 { "prefix": "open-cluster-management/*", "destination": "/quay" },
@@ -117,7 +122,7 @@ data:
               "tlsVerify": true,
               "maxRetries": 1,
               "retryDelay": "2m",
-              "content": [{ "prefix": "**", "destination": "/fedora" }]
+              "content": [{ "prefix": "fedora*", "destination": "/fedora" }]
             },
             {
               "urls": ["https://registry.k8s.io"],
@@ -125,7 +130,13 @@ data:
               "tlsVerify": true,
               "maxRetries": 1,
               "retryDelay": "2m",
-              "content": [{ "prefix": "**", "destination": "/k8s" }]
+              "content": [
+                { "prefix": "kube-apiserver", "destination": "/k8s" },
+                { "prefix": "kube-controller-manager", "destination": "/k8s" },
+                { "prefix": "metrics-server/*", "destination": "/k8s" },
+                { "prefix": "nfd/*", "destination": "/k8s" },
+                { "prefix": "pause", "destination": "/k8s" }
+              ]
             },
             {
               "urls": ["https://cgr.dev"],
@@ -141,7 +152,9 @@ data:
               "tlsVerify": true,
               "maxRetries": 1,
               "retryDelay": "2m",
-              "content": [{ "prefix": "**", "destination": "/ecr" }]
+              "content": [
+                { "prefix": "docker/library/*", "destination": "/ecr" }
+              ]
             },
             {
               "urls": ["https://lscr.io"],
@@ -149,7 +162,7 @@ data:
               "tlsVerify": true,
               "maxRetries": 1,
               "retryDelay": "2m",
-              "content": [{ "prefix": "**", "destination": "/lscr" }]
+              "content": [{ "prefix": "linuxserver/*", "destination": "/lscr" }]
             }
           ]
         }
@@ -174,7 +187,7 @@ spec:
         app: zot-cache
         app.kubernetes.io/part-of: lab
       annotations:
-        lab.projectbluefin.io/config-version: sync-policy-v4
+        lab.projectbluefin.io/config-version: sync-policy-v5
     spec:
       automountServiceAccountToken: false
       priorityClassName: system-cluster-critical

--- a/tests/unit/test_zot_cache_policy.py
+++ b/tests/unit/test_zot_cache_policy.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pytest
 import yaml
 
 
@@ -24,18 +23,6 @@ def test_zot_sync_is_on_demand_and_bounded():
         assert registry["retryDelay"] == "2m"
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Task 2 of docs/superpowers/plans/2026-08-03-bandwidth-reduction.md is only "
-        "partially implemented: the retry bounds landed but the catch-all sync "
-        "prefixes were never replaced with an observed-repository allowlist. A broad "
-        "prefix means one cache miss on an unknown repository probes every configured "
-        "upstream. The scoped allowlist is proposed in PR #652, which also restarts "
-        "zot-cache, so it is being landed deliberately rather than folded into this "
-        "CI-unblocking change. Remove this marker when that lands."
-    ),
-)
 def test_zot_sync_prefixes_are_scoped_to_observed_repositories():
     for registry in sync_registries():
         assert registry["content"]


### PR DESCRIPTION
## Summary

- Make the Zot metrics test assert that the startup-reload annotation exists instead of pinning stale `sync-policy-v2`.
- Replace broad Zot sync filters with upstream-repository prefixes and bump the cache workload annotation to `sync-policy-v5`.
- Preserve recursive matching for nested `kagent-dev/**` and `kubestellar/**` paths under Zot's upstream-path semantics.

## Prefix inventory

- GHCR: `actions/*`, `buildbarn/*`, `flatcar/*`, `frostyard/*`, `ggml-org/*`, `jrottenberg/*`, `kagent-dev/**`, `kubestellar/**`, `oras-project/*`, `project-zot/*`, `projectbluefin/*`, `razorfinos-org/*`, `ublue-os/*`.
- Docker Hub: `bitnami/*`, `curlimages/*`, `jrottenberg/*`, `library/*`, `linuxserver/*`, `rancher/*`, `rocm/*`, `vllm/*`.
- Quay: existing observed namespaces plus `fedora-ostree-desktops/*`.
- Fedora registry: `fedora*` (uncertain: no current live catalog hit, but the generic Fedora image converter remains in the workflow contract).
- Kubernetes registry: observed `kube-apiserver`, `kube-controller-manager`, `metrics-server/*`, `nfd/*`, and `pause`.
- Chainguard: existing `chainguard/*`.
- Public ECR: `docker/library/*` (uncertain beyond observed `ecr/docker/library/redis`).
- LSIO: `linuxserver/*`.

The additions for `jrottenberg/*` came from live Zot logs; `oras-project/*`, `razorfinos-org/*`, and `fedora-ostree-desktops/*` are repository/workflow image references. The live cached catalog's 84 repositories are all covered by the new patterns.

## Validation

- `pytest -q tests/unit/test_zot_cache_policy.py tests/unit/test_build_metrics.py`: **5 passed**
- `just lint`: **passed**
- `pytest -q tests/unit`: **384 passed, 5 pre-existing failures** in unrelated page-dataset and RECC-runner tests; no new failures.
- Before this branch's ConfigMap is merged, live Zot manifest checks returned HTTP 200 for `ghcr/projectbluefin/lab-runner` and nested `ghcr/kagent-dev/kagent/controller`.

ArgoCD has not synced this branch, so the post-change Zot rollout and pull path remain unverified until the PR is merged/reconciled.