### PR TITLE
test: pin page dataset collector inputs

### DIFF
--- a/tests/unit/fixtures/page-dataset-legacy-inputs.json
+++ b/tests/unit/fixtures/page-dataset-legacy-inputs.json
@@ -1,0 +1,366 @@
+{
+  "_fixture": {
+    "description": "Pinned legacy inputs for page dataset collector shape assertions.",
+    "surface_and_matrix_results_from": "084b6fde3f",
+    "dakota_fallback_result_from": "21e4447a7d"
+  },
+  "surface": [
+    {
+      "variant": "bluefin-lts",
+      "branch": "testing",
+      "suite": "developer",
+      "results_path": "results/bluefin-lts-testing-developer.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bluefin-lts",
+      "branch": "testing",
+      "suite": "smoke",
+      "results_path": "results/bluefin-lts-testing-smoke.json",
+      "screenshot_path": "screenshots/bluefin-lts-testing-smoke-latest.png"
+    },
+    {
+      "variant": "bluefin-lts",
+      "branch": "testing",
+      "suite": "software",
+      "results_path": "results/bluefin-lts-testing-software.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bluefin-lts",
+      "branch": "testing",
+      "suite": "system",
+      "results_path": "results/bluefin-lts-testing-system.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bluefin",
+      "branch": "testing",
+      "suite": "common",
+      "results_path": "results/bluefin-testing-common.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bluefin",
+      "branch": "testing",
+      "suite": "developer",
+      "results_path": "results/bluefin-testing-developer.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bluefin",
+      "branch": "testing",
+      "suite": "smoke",
+      "results_path": "results/bluefin-testing-smoke.json",
+      "screenshot_path": "screenshots/bluefin-testing-smoke-latest.png"
+    },
+    {
+      "variant": "bluefin",
+      "branch": "testing",
+      "suite": "software",
+      "results_path": "results/bluefin-testing-software.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bluefin",
+      "branch": "testing",
+      "suite": "system",
+      "results_path": "results/bluefin-testing-system.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "dakota",
+      "branch": "testing",
+      "suite": "developer",
+      "results_path": "results/dakota-testing-developer.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "dakota",
+      "branch": "testing",
+      "suite": "smoke",
+      "results_path": "results/dakota-testing-smoke.json",
+      "screenshot_path": "screenshots/dakota-testing-smoke-latest.png"
+    },
+    {
+      "variant": "dakota",
+      "branch": "testing",
+      "suite": "software",
+      "results_path": "results/dakota-testing-software.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "dakota",
+      "branch": "testing",
+      "suite": "system",
+      "results_path": "results/dakota-testing-system.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "flatcar",
+      "branch": "testing",
+      "suite": "flatcar",
+      "results_path": "results/flatcar-testing-flatcar.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "snosi",
+      "branch": "latest",
+      "suite": "smoke",
+      "results_path": "results/snosi-latest-smoke.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "snosi",
+      "branch": "latest",
+      "suite": "developer",
+      "results_path": "results/snosi-latest-developer.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "snosi",
+      "branch": "latest",
+      "suite": "system",
+      "results_path": "results/snosi-latest-system.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "aurora",
+      "branch": "testing",
+      "suite": "smoke",
+      "results_path": "results/aurora-testing-smoke.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "aurora",
+      "branch": "testing",
+      "suite": "developer",
+      "results_path": "results/aurora-testing-developer.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "aurora",
+      "branch": "testing",
+      "suite": "software",
+      "results_path": "results/aurora-testing-software.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bazzite",
+      "branch": "testing",
+      "suite": "smoke",
+      "results_path": "results/bazzite-testing-smoke.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "fedora-silverblue",
+      "branch": "testing",
+      "suite": "smoke",
+      "results_path": "results/fedora-silverblue-testing-smoke.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "fedora-silverblue",
+      "branch": "testing",
+      "suite": "system",
+      "results_path": "results/fedora-silverblue-testing-system.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "fedora-kinoite",
+      "branch": "testing",
+      "suite": "smoke",
+      "results_path": "results/fedora-kinoite-testing-smoke.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "fedora-kinoite",
+      "branch": "testing",
+      "suite": "system",
+      "results_path": "results/fedora-kinoite-testing-system.json",
+      "screenshot_path": null
+    },
+    {
+      "variant": "bluefin",
+      "branch": "stable",
+      "suite": "smoke",
+      "results_path": "results/bluefin-stable-smoke.json",
+      "screenshot_path": "screenshots/bluefin-stable-smoke-latest.png"
+    },
+    {
+      "variant": "bluefin-lts",
+      "branch": "stable",
+      "suite": "smoke",
+      "results_path": "results/bluefin-lts-stable-smoke.json",
+      "screenshot_path": "screenshots/bluefin-lts-stable-smoke-latest.png"
+    }
+  ],
+  "enrollment": {
+    "aurora": {
+      "issue_number": 278,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/278"
+    },
+    "bazzite": {
+      "issue_number": 284,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/284"
+    },
+    "fedora-kinoite": {
+      "issue_number": 280,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/280"
+    },
+    "fedora-silverblue": {
+      "issue_number": 279,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/279"
+    },
+    "snosi": {
+      "issue_number": 282,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/282"
+    },
+    "cosmic": {
+      "issue_number": 285,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/285"
+    },
+    "gnomeos": {
+      "issue_number": 281,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/281"
+    },
+    "fedora-bootc": {
+      "issue_number": 283,
+      "issue_url": "https://github.com/projectbluefin/lab/issues/283"
+    }
+  },
+  "results": {
+    "results/bluefin-lts-testing-developer.json": {
+      "status": "passed",
+      "last_run": "2026-07-07T02:35:00Z",
+      "scenarios": 21,
+      "failed": 0,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/bluefin-lts-testing-developer-latest.png"
+    },
+    "results/bluefin-lts-testing-smoke.json": {
+      "status": "passed",
+      "last_run": "2026-07-07T02:30:00Z",
+      "scenarios": 137,
+      "failed": 0,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/bluefin-lts-testing-smoke-latest.png"
+    },
+    "results/bluefin-lts-testing-software.json": {
+      "status": "passed",
+      "last_run": "2026-06-29T12:30:00Z",
+      "scenarios": 5,
+      "failed": 0
+    },
+    "results/bluefin-lts-testing-system.json": {
+      "status": "passed",
+      "last_run": "2026-07-07T02:40:00Z",
+      "scenarios": 14,
+      "failed": 0,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/bluefin-lts-testing-system-latest.png"
+    },
+    "results/bluefin-testing-common.json": {
+      "status": "failed",
+      "last_run": "2026-06-24T18:29:10Z",
+      "scenarios": 114,
+      "failed": 69,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/bluefin-testing-common-latest.png",
+      "failed_scenarios": [
+        "Bazaar flatpak preinstall file is present",
+        "bazaar user service is available"
+      ]
+    },
+    "results/bluefin-testing-developer.json": {
+      "status": "passed",
+      "last_run": "2026-06-25T02:04:33Z",
+      "scenarios": 21,
+      "failed": 0,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/bluefin-testing-developer-latest.png",
+      "history": [
+        {
+          "run_date": "2026-06-25T02:04:33Z",
+          "workflow_name": "nightly-smoke-1782352800",
+          "status": "passed"
+        },
+        {
+          "run_date": "2026-06-25T01:30:50Z",
+          "workflow_name": "pack-testing-vs725",
+          "status": "passed"
+        },
+        {
+          "run_date": "2026-06-24T23:23:24Z",
+          "workflow_name": "bluefin-qa-testing-xbv8k",
+          "status": "passed"
+        },
+        {
+          "run_date": "2026-06-24T12:58:45Z",
+          "workflow_name": "nightly-bluefin-testing-rerun-f9d7s",
+          "status": "failed"
+        },
+        {
+          "status": "failed"
+        }
+      ]
+    },
+    "results/bluefin-testing-smoke.json": {
+      "status": "failed",
+      "last_run": "2026-06-25T01:21:48Z",
+      "scenarios": 137,
+      "failed": 17,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/bluefin-testing-smoke-latest.png"
+    },
+    "results/bluefin-testing-software.json": {
+      "status": "passed",
+      "last_run": "2026-06-29T12:00:00Z",
+      "scenarios": 5,
+      "failed": 0
+    },
+    "results/bluefin-testing-system.json": {
+      "status": "failed",
+      "last_run": "2026-06-24T03:56:24.961355Z",
+      "scenarios": 14,
+      "failed": 6,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/bluefin-testing-system-latest.png"
+    },
+    "results/dakota-testing-developer.json": {
+      "status": "passed",
+      "last_run": "2026-07-07T03:05:00Z",
+      "scenarios": 21,
+      "failed": 0,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/dakota-testing-developer-latest.png"
+    },
+    "results/dakota-testing-smoke.json": {
+      "status": "failed",
+      "last_run": "2026-07-07T03:00:00Z",
+      "scenarios": 137,
+      "failed": 3,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/dakota-testing-smoke-latest.png"
+    },
+    "results/dakota-testing-software.json": {
+      "status": "failed",
+      "last_run": "2026-06-29T13:00:00Z",
+      "scenarios": 5,
+      "failed": 1
+    },
+    "results/dakota-testing-system.json": {
+      "status": "failed",
+      "last_run": "2026-07-07T03:10:00Z",
+      "scenarios": 14,
+      "failed": 1,
+      "screenshot_url": "https://projectbluefin.github.io/lab/screenshots/dakota-testing-system-latest.png"
+    },
+    "results/flatcar-testing-flatcar.json": {
+      "status": "passed",
+      "last_run": "2026-07-07T04:00:00Z",
+      "scenarios": 10,
+      "failed": 0,
+      "screenshot_url": null
+    },
+    "results/dakota-testing-common.json": {
+      "status": "failed",
+      "last_run": "2026-07-28T15:50:27Z",
+      "failed_scenarios": [
+        "bazaar user service is available",
+        "Bazaar flatpak preinstall file is present"
+      ]
+    }
+  }
+}

--- a/tests/unit/test_page_dataset_collector.py
+++ b/tests/unit/test_page_dataset_collector.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / 'scripts/generate_page_datasets.py'
+LEGACY_INPUT_FIXTURE = ROOT / 'tests/unit/fixtures/page-dataset-legacy-inputs.json'
 
 
 def load_module():
@@ -13,6 +14,15 @@ def load_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def use_pinned_legacy_inputs(monkeypatch, module):
+    """Keep legacy result assertions independent of workflow refreshes."""
+    fixture = json.loads(LEGACY_INPUT_FIXTURE.read_text())
+    monkeypatch.setattr(module, 'iter_surface_cells', lambda root: iter(fixture['surface']))
+    monkeypatch.setattr(module, 'load_enrollment_issues', lambda root: fixture['enrollment'])
+    monkeypatch.setattr(module, 'load_results_by_relative_path', lambda root: fixture['results'])
+    monkeypatch.setattr(module, 'load_qa_run_records', lambda root: [])
 
 
 def test_upstream_dataset_derives_required_families(monkeypatch):
@@ -70,15 +80,15 @@ def test_upstream_dataset_derives_required_families(monkeypatch):
 
 def test_tests_matrix_derives_rows_from_surface_and_results(monkeypatch):
     module = load_module()
-    monkeypatch.setattr(module, 'load_qa_run_records', lambda root: [])
+    use_pinned_legacy_inputs(monkeypatch, module)
 
     dataset = module.build_tests_matrix(ROOT, '2026-06-29T19:22:22Z')
 
     assert dataset['schema_version'] == 'v3'
     assert dataset['_meta']['page'] == 'tests'
     assert dataset['_meta']['starter_artifact'] is False
-    # Surface comes from docs/data/test-surface.json, so the row count changes
-    # whenever new variants/branches/suites are enrolled.
+    # The pinned surface fixture mirrors the published matrix shape at the
+    # baseline; live QA refreshes must not change this contract test.
     assert len(dataset['rows']) == 64
 
     metrics = {metric['id']: metric for metric in dataset['summary_metrics']}
@@ -377,8 +387,9 @@ def test_tests_matrix_v3_schema_rejects_incomplete_page_contract(monkeypatch):
         assert list(validator.iter_errors(payload))
 
 
-def test_applications_matrix_keeps_bazaar_fallbacks_explicit():
+def test_applications_matrix_keeps_bazaar_fallbacks_explicit(monkeypatch):
     module = load_module()
+    use_pinned_legacy_inputs(monkeypatch, module)
 
     dataset = module.build_applications_matrix(ROOT, '2026-06-29T19:22:22Z')
 
@@ -399,10 +410,12 @@ def test_applications_matrix_keeps_bazaar_fallbacks_explicit():
     assert bluefin['fallback_signal_count'] == 1
     assert len(bluefin['fallback_signals']) == 1
     assert bluefin['fallback_signals'][0]['state'] == 'unavailable'
-    assert bluefin['fallback_signals'][0]['matched_scenarios'] == [
+    # Scenario order is inherited from the result file, not part of the
+    # fallback contract; preserve each upstream name and its casing.
+    assert sorted(bluefin['fallback_signals'][0]['matched_scenarios']) == sorted([
         'Bazaar flatpak preinstall file is present',
         'bazaar user service is available',
-    ]
+    ])
     assert rows['bazaar-dakota-testing']['fallback_signal_count'] == 1
     # Real enrolled variants from test-surface software cells must appear;
     # fabricated variants must not.


### PR DESCRIPTION
## Summary
- Pin the matrix and applications collector shape tests to a checked-in legacy-input fixture.
- Make Bazaar fallback scenario assertions order-independent while preserving exact names and casing.

## Findings
- **Tests matrix:** the collector was counting valid legacy rows with published `passed`/`failed` status and `last_run`. The expected 14 came from the historical inputs at `084b6fde3f`; replaying those inputs produces 64 rows, 14 completed, and 50 waiting. Live `docs/results` later gained completed lane evidence (including `bluefin-stable-smoke`), so changing the collector to force 14 would under-report QA coverage. No collector bug.
- **Bazaar fallback:** the live result update at `2044b9031f` reordered the two matching names; the matcher preserves `failed_scenarios` order and still returns both distinct checks. The testsuite also now labels the related flatpak check `Required system Flatpaks are installed`, while `bazaar user service is available` remains in the common scripts suite. This is fixture/order drift, not a wrong signal match.

## Validation
- `just lint` ✅
- `pytest -q tests/unit/test_page_dataset_collector.py` ✅ 33 passed
- `pytest -q tests/unit` ⚠️ 384 passed, 5 pre-existing unrelated failures in Zot/RECC tests
