### PR TITLE
4K Vulkan upscale benchmark + video-upscale image fixes

### DIFF
--- a/docs/benchmarks/2026-08-21-4k-upscale-vulkan.md
+++ b/docs/benchmarks/2026-08-21-4k-upscale-vulkan.md
@@ -1,0 +1,250 @@
+# 4K AI upscale on Vulkan/ncnn — 2026-08-21
+
+Maximum-fidelity 1080p→4K upscale of a single 507 s music video, run on the lab's
+AMD Strix Halo (gfx1151) nodes. The goal was to find the real throughput and the
+real quality ceiling of a Vulkan-only inference stack, and to decide whether the
+two-node USB4 architecture was worth building.
+
+**Headline results**
+
+| Question | Answer |
+|---|---:|
+| End-to-end throughput | **0.377 s/frame** (2.65 fps) sustained |
+| Full 507 s video | **1 h 19 m** render, 2 h 01 m including master encode |
+| Break-even needed to fit 48 h | 27.3 s/frame → **59x margin** |
+| Best restoration branch | **none** — the bare model won |
+| Two-node distribution | **abandoned** — pod network measured 235 KB/s |
+
+## Stack
+
+Vulkan/ncnn throughout. No ROCm, HIP, CUDA or PyTorch, per
+[ADR-0007](../adr/0007-local-inference-runtime.md) and the C1 constraint.
+
+| Component | Pin |
+|---|---|
+| VapourSynth | R79 |
+| `vapoursynth-mlrt-ncnn` | 16.0 (ncnn `20260526`) |
+| `vapoursynth-bestsource` | 21.0 |
+| `vapoursynth-deblock` | 9.0 |
+| `vapoursynth-mvtools` | 29 |
+| vszip | commit `beb7a0ab` (Zig 0.16.0) |
+| Model | `2xLiveActionV1_SPAN`, native x2 |
+| Image | `images/video-upscale/Containerfile`, both stages from org `bluefin` |
+
+**Model license: `2xLiveActionV1_SPAN` is CC-BY-NC-SA-4.0 — non-commercial.**
+Acceptable for an internal lab benchmark; it may not be used for anything
+commercial, and the output inherits the restriction.
+
+The image contains **no package manager invocation at all**, per
+[image-policy.md](../skills/gitops-argocd/image-policy.md). ffmpeg comes from the
+org `bluefin` image; Zig comes from a checksum-verified upstream tarball.
+
+### Currency audit
+
+The audit removed more than it kept. Everything in the "obvious" 2026 answer to
+this problem is abandonware:
+
+| Rejected | Last activity | Cause |
+|---|---|---|
+| `realesrgan-ncnn-vulkan` | 2022-04-24 | stale |
+| BasicVSR++ / MMagic | 2023-12-18 | stale, **and** MMCV deform-conv is CUDA-only |
+| DPIR · SCUNet · SwinIR · Real-CUGAN · Waifu2x | 2020–2024 | stale |
+| FlashVSR v1.1 | current | NVIDIA block-sparse attention |
+
+Consequence: nearly all of the 812 MB vs-mlrt model zoo fails a currency check.
+Two earlier revisions of this plan were built on abandoned software that looked
+authoritative. **Run a currency audit before adopting a dependency, not after.**
+
+## Source
+
+`input.mp4`, measured — not assumed:
+
+| Property | Value |
+|---|---|
+| Resolution | **1920x804** (2.388:1), no black bars |
+| Codec | H.264 High L4.0, yuv420p 8-bit, progressive |
+| Colour | BT.709, **limited** range |
+| Rate | 25 fps CFR, **12,675 frames**, 507.05 s |
+| Bitrate | **1.26 Mbps** (median frame 3.7 kB, p5 1.0 kB) |
+| Scene cuts | 79 |
+| Stream 2 | 1280x720 PNG cover art — dropped |
+
+Two findings drove every downstream decision:
+
+1. **Output is 3840x1608, not 3840x2160.** The model is native x2 and
+   1920x804 x 2 lands exactly on 3840x1608. No resampling, no letterboxing.
+2. **80% of pixels fall in 42 code values**, so 8-bit output would band.
+   **10-bit is mandatory** and was verified on the master.
+
+At 1.26 Mbps the source, not the GPU, is the binding constraint. The honest
+ceiling is "cleaner and larger", not "restored".
+
+## Throughput
+
+50 frames per cell, `vspipe -> ffmpeg` FFV1 4K 10-bit, single gfx1151.
+
+| Clip | Content | Branch 1 (model only) | Branch 2 (Deblock+MosquitoNR) |
+|---|---|---:|---:|
+| A | near-black, 0.30 Mbps | 0.461 s/f | 0.472 s/f |
+| B | fine detail, grain | 0.474 s/f | 0.448 s/f |
+| C | dissolve + heavy bokeh | 0.475 s/f | 0.463 s/f |
+| D | high bitrate, heavy motion | 0.471 s/f | 0.445 s/f |
+
+**Throughput is flat across content and across branches** — it is set by the
+model, not by the footage or the restoration filters.
+
+Isolating the encoder (`vspipe` to `/dev/null`) gives **0.402 s/frame**, so the
+4K FFV1 encode costs only ~0.06 s/frame (~13%) and restoration is
+free to within noise (0.402 vs 0.403). The pipeline is inference-bound.
+
+## Quality
+
+### Round-trip SSIM cannot pick the branch
+
+Master downscaled back to 1920x804 (Lanczos) and compared to source:
+
+| Clip | Branch 1 | Branch 2 |
+|---|---:|---:|
+| A | **0.996984** | 0.996954 |
+| B | **0.995077** | 0.994273 |
+| C | **0.995627** | 0.994435 |
+| D | **0.995537** | 0.994573 |
+
+Branch 1 wins everywhere — but this metric is **inverted for this purpose**.
+Round-trip SSIM rewards fidelity to a source whose defining feature is
+compression damage, so it penalises exactly the artefact removal that
+restoration exists to perform. It is reported here as a drift/hallucination
+detector, and it shows no drift. **It is not evidence that restoration is
+harmful.** That required looking at pixels.
+
+### Deblocking is a losing trade on this source
+
+Sweep on the worst-case clips, inspected as 900x600 1:1 crops:
+
+| Setting | Flat shadow (clip A) | Hair detail (clip D) |
+|---|---|---|
+| off | blocking visible | sharpest |
+| `quant=24, strength=8` | unchanged | unchanged |
+| `quant=40, strength=16` | slightly reduced | **visibly softened** |
+| `quant=56, strength=24` | reduced | **visibly softened** |
+
+The conservative setting is visually indistinguishable from off, and every
+setting strong enough to touch the blocking also smears genuine hair texture.
+There is no window where deblocking helps this source.
+
+**Decision: render with the bare model (branch 1).** It was equal or better on
+every axis measured — SSIM, visual detail, and complexity.
+
+Branches 3 (ArtCNN chroma) and 4 (4xUltraSharpV2 adversarial control) were
+**not run**: branch 3's upstream wiring was never verified, and branch 4's
+weights were never vendored. They are unfinished, not evaluated.
+
+A `vszip.Deband` variant was attempted and failed on an incorrect call
+signature; it was dropped rather than guessed at.
+
+## The two-node architecture was abandoned
+
+The plan called for splitting the render across both GPUs with an HTTP chunk
+store on the pod network, specifically so bulk traffic would ride USB4.
+Measurement killed it.
+
+| Path | Endpoints | Throughput |
+|---|---|---:|
+| Loopback control (same pod) | `127.0.0.1` | 8.76 GB/s |
+| **Raw USB4, host netns** | `10.99.0.1` -> `10.99.0.2` | **1.097 GB/s** |
+| Ethernet, host netns | `192.168.1.170` | 294 MB/s |
+| **Cross-node pod -> pod** | `10.42.0.249` -> `10.42.1.54` | **235 KB/s** |
+
+The USB4 link is healthy and is 3.7x faster than Ethernet. The **pod** path is
+~4,600x slower than the link beneath it. The loopback control rules out the test
+server; pod→host-netns was also slow, so the fault is on pod-netns egress.
+
+Routing is not the cause — rule 5209 correctly steers pod-CIDR traffic onto
+`thunderbolt0` even with a pod source address, and MTU is a uniform 1500:
+
+```
+5209:	from all to 10.42.1.0/24 lookup 40 proto static
+10.42.1.54 from 10.42.0.249 via 10.99.0.2 dev thunderbolt0 table 40
+```
+
+Moving 65–85 GB of chunks at 235 KB/s would take ~4 days against ~1.6 h to
+render everything on one node, so the benchmark ran **single-node on `ghost`**.
+Filed as **issue #662**.
+
+> **Trap:** `ip route get <peer-pod-ip>` only tells the truth in the host netns.
+> Run inside a pod it always answers `via <cni0 gateway> dev eth0`, which looks
+> like a failure and proves nothing either way.
+
+## Full run
+
+Branch 1, 12,675 frames, four chunks, single gfx1151 on `ghost`.
+
+| Chunk | Frames | Wall |
+|---|---:|---:|
+| 0 | 3,169 | 1,195 s |
+| 1 | 3,169 | 1,192 s |
+| 2 | 3,169 | 1,195 s |
+| 3 | 3,168 | 1,197 s |
+| **Render total** | **12,675** | **4,779 s (1 h 19 m)** |
+
+**0.377 s/frame (2.65 fps)** sustained — *faster* than the 50-frame calibration
+figure of 0.46 s/frame, because per-invocation startup no longer dominates.
+Chunk times agree within 0.4% across wildly different content, confirming the
+pipeline is inference-bound rather than content-bound.
+
+Every chunk passed its frame-count gate exactly. Total pod wall clock was
+2 h 01 m; the extra ~41 min is the ProRes master encode plus four full
+`ffprobe -count_frames` decodes over 27.7 GiB of FFV1.
+
+Against the 48 h budget the plan was sized for, the run needed **2.8%** of it.
+The deadline arithmetic gate that revision 4 treated as the project's main risk
+turned out to have a 59x margin.
+
+### Output
+
+| | |
+|---|---|
+| Intermediate | 27.7 GiB FFV1 4K 10-bit (4 chunks) |
+| Master | **23.1 GiB** ProRes 422 HQ, `/work/final/master.mov` |
+
+Final gate, all assertions met:
+
+```
+index=0  codec_name=prores  width=3840  height=1608  pix_fmt=yuv422p10le
+         color_space=bt709  color_range=tv  r_frame_rate=25/1
+         nb_read_frames=12675
+index=1  codec_name=aac  sample_rate=44100
+```
+
+3840x1608 native aspect with no letterboxing, 10-bit as required by the banding
+finding, colour tags intact, frame count exact, and exactly two streams — the
+1280x720 cover art was dropped by mapping `0:v:0` and `1:a:0` explicitly.
+
+
+## What this does not measure
+
+No 4K ground truth exists, so "is it better" cannot be scored directly. Round-trip
+SSIM detects drift, not improvement. The visual conclusions above rest on paired
+1:1 crops, which is the honest instrument for this question.
+
+The comparison is against Lanczos, not against a current commercial upscaler.
+
+## Reproducing
+
+```bash
+podman build -t video-upscale:v4 -f images/video-upscale/Containerfile images/video-upscale/
+# stage input.mp4 into the upscale-scratch PVC, then per chunk:
+SRC=/work/input.mp4 BRANCH=1 vspipe -c y4m --start "$START" --end "$END" \
+    /usr/lib/upscale/upscale.vpy - \
+  | ffmpeg -f yuv4mpegpipe -i - -c:v ffv1 -level 3 -g 1 \
+      -color_primaries bt709 -color_trc bt709 -colorspace bt709 -color_range tv \
+      "/work/final/chunk-${IDX}.mkv"
+```
+
+`vspipe --end` is **inclusive**.
+
+## Rights
+
+The output is a derivative of a commercial copyrighted music video. Local
+experimentation is one thing; publishing is a separate question for the
+rightsholder. The pipeline is content-agnostic.

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -397,6 +397,19 @@ Two cluster-specific traps that cost real time:
   cannot bind without a pod, ArgoCD blocks its sync waiting for PVC health, and
   so the Deployment is never created at all. Scale at runtime instead of
   committing `replicas: 0`.
+- **The pod network cannot carry bulk data across nodes.** Measured 2026-08-21:
+  pod->pod `10.42.x` throughput is **235 KB/s** while the same file over the raw
+  USB4 host addresses (`10.99.0.x`) does **1.10 GB/s** and Ethernet does
+  294 MB/s. That is a ~4,600x degradation in the CNI path, and it is not
+  routing — rule 5209 correctly sends pod-CIDR traffic via `thunderbolt0` even
+  for a pod source IP, and MTU is a uniform 1500. Do not design a workflow that
+  ships large intermediates between pods on different nodes; render/compute
+  single-node, or use `hostNetwork: true`, which reaches the full link speed.
+  Tracked in issue #662.
+- **`ip route get <peer-pod-ip>` must run in the host netns** (a
+  `hostNetwork: true` pod). Inside a pod it always answers
+  `via <cni0 gateway> dev eth0`, because interface selection happens on the
+  host — so the in-pod check "confirms" USB4 while proving nothing.
 
 See `docs/adr/0007-local-inference-runtime.md`.
 

--- a/docs/skills/gitops-argocd/image-policy.md
+++ b/docs/skills/gitops-argocd/image-policy.md
@@ -64,7 +64,7 @@ upstream-native and reproducible; it is not distribution tooling.
 | `skopeo` | skopeo 1.23.0 at `/usr/bin/skopeo` | any shell (distroless, no entrypoint) |
 | `bluefin` | full ffmpeg (libx265, libsvtav1, ffv1, prores_ks), Mesa RADV, git, curl, tar, xz, python3 | — |
 
-`bluefin` is an ostree/bootc image: `/opt` → `/var/opt` and `/usr/local` → `/var/usrlocal`, and `/var` is empty at build time. Install into `/usr/lib`.
+`bluefin` is an ostree/bootc image: `/opt` → `/var/opt`, `/usr/local` → `/var/usrlocal` and `/root` → `/var/roothome`, and `/var` is empty at build time. Install into `/usr/lib`, and set `HOME` to a real in-image path or anything writing to it fails with `FileExistsError`/`NotDir`.
 
 **Zot pull-through cache — 6 upstreams (as of 2026):**
 

--- a/images/video-upscale/Containerfile
+++ b/images/video-upscale/Containerfile
@@ -80,6 +80,17 @@ RUN "${VENV}/bin/pip" install --no-cache-dir \
       "vapoursynth-deblock==9.0" \
       "vapoursynth-mvtools==29"
 
+# /root is another dangling ostree symlink (-> /var/roothome), so anything that
+# writes to HOME fails at build time. Point HOME at a real path inside the image
+# so build and runtime agree.
+ENV HOME=/usr/lib/upscale/home
+
+# The wheel cannot locate the Python library on its own, so VSScript (and thus
+# vspipe) fails at runtime with "Python executable and library path couldn't be
+# determined". This records them. Importing vapoursynth from Python works
+# WITHOUT this, which is why an API-only check does not catch it.
+RUN mkdir -p "${HOME}" && "${VENV}/bin/vapoursynth" config
+
 COPY --from=vszip-builder /out/ ${VS_PLUGINDIR}/
 
 # vsmlrt.py must match the installed wheel's major line (16.x).
@@ -107,5 +118,32 @@ RUN ffmpeg -hide_banner -encoders 2>/dev/null | grep -q libx265    || (echo "FAT
     ffmpeg -hide_banner -encoders 2>/dev/null | grep -q prores_ks  || (echo "FATAL: no prores_ks"  && exit 1) && \
     test -f /usr/share/vulkan/icd.d/radeon_icd.x86_64.json         || (echo "FATAL: no RADV ICD"   && exit 1) && \
     "${VENV}/bin/python" -c "import vapoursynth as vs; assert vs.core.ncnn is not None"
+
+# Exercise the REAL execution path: vspipe -> y4m -> ffmpeg. The Python import
+# check above passes even when VSScript is misconfigured, so it alone is not
+# enough; only running vspipe proves a render can actually start.
+RUN printf '%s\n' \
+      'import vapoursynth as vs' \
+      'core = vs.core' \
+      'core.std.BlankClip(width=64, height=64, length=2, format=vs.YUV420P10).set_output()' \
+      > /tmp/smoke.vpy && \
+    "${VENV}/bin/vspipe" -c y4m /tmp/smoke.vpy - \
+      | ffmpeg -hide_banner -loglevel error -f yuv4mpegpipe -i - -c:v ffv1 -f matroska -y /dev/null && \
+    echo "vspipe -> ffmpeg pipeline OK" && \
+    rm /tmp/smoke.vpy
+
+# Evaluate the SHIPPED upscale.vpy for every branch. vspipe --info builds the
+# whole filter graph without rendering a frame, so it needs no GPU -- but model
+# and plugin paths are resolved during graph construction, so a wrong path fails
+# here. This gate exists because a stale /opt model path shipped in v2 and was
+# only caught on a GPU node mid-benchmark.
+RUN ffmpeg -hide_banner -loglevel error -f lavfi -i testsrc=size=320x134:rate=25:duration=1 \
+      -c:v libx264 -pix_fmt yuv420p -y /tmp/gate.mp4 && \
+    for b in 1 2 3 4; do \
+      SRC=/tmp/gate.mp4 BRANCH="$b" "${VENV}/bin/vspipe" --info /usr/lib/upscale/upscale.vpy - \
+        || (echo "FATAL: upscale.vpy branch $b failed graph construction" && exit 1); \
+    done && \
+    echo "upscale.vpy branches 1-4 construct OK" && \
+    rm /tmp/gate.mp4
 
 WORKDIR /work

--- a/images/video-upscale/upscale.vpy
+++ b/images/video-upscale/upscale.vpy
@@ -3,13 +3,13 @@ core = vs.core
 import vsmlrt
 
 # Plugins built in the vszip builder stage are not on the default search path.
-for _p in os.scandir(os.environ.get("VS_PLUGINDIR", "/opt/upscale/vs-plugins")):
+for _p in os.scandir(os.environ.get("VS_PLUGINDIR", "/usr/lib/upscale/vs-plugins")):
     if _p.name.endswith(".so"):
         core.std.LoadPlugin(path=_p.path)
 
 SRC    = os.environ["SRC"]
 BRANCH = int(os.environ.get("BRANCH", "1"))
-MODEL  = os.environ.get("MODEL", "/opt/upscale/models/2xLiveActionV1_SPAN.onnx")
+MODEL  = os.environ.get("MODEL", "/usr/lib/upscale/models/2xLiveActionV1_SPAN.onnx")
 TILE   = int(os.environ.get("TILE", "256"))
 OVER   = int(os.environ.get("OVERLAP", "16"))
 FP16   = os.environ.get("FP16", "1") == "1"


### PR DESCRIPTION
Completes the 4K upscaling benchmark: a 1080p->4K AI upscale of a 507 s source on
the gfx1151 nodes using VapourSynth + vs-mlrt **ncnn/Vulkan** (no ROCm, no PyTorch),
per ADR-0007.

## Result

**0.377 s/frame sustained — 12,675 frames in 1 h 19 m** (2 h 01 m including the
ProRes master encode). The plan was sized against a 27.3 s/frame break-even for a
48 h deadline, so the risk it treated as the project's main threat had a **59x margin**.

Master: 3840x1608 ProRes 422 HQ, `yuv422p10le`, BT.709 limited, 12,675 frames exact,
audio muxed, cover art dropped. All gates passed.

## Two findings that matter more than the throughput number

**1. The pod network cannot carry bulk data across nodes (#662).**

| Path | Throughput |
|---|---:|
| Loopback control (same pod) | 8.76 GB/s |
| Raw USB4, host netns | **1.097 GB/s** |
| Ethernet, host netns | 294 MB/s |
| **Cross-node pod -> pod** | **235 KB/s** |

~4,600x slower than the link beneath it. Routing is *correct* — rule 5209 does steer
pod-CIDR traffic onto `thunderbolt0` even for a pod source IP, and MTU is a uniform
1500 — so this is not a misconfiguration you can see from the routing table. It killed
the planned two-node chunk-store architecture; 65-85 GB at 235 KB/s is ~4 days versus
~1.6 h to render single-node.

**2. Round-trip SSIM cannot arbitrate a restoration chain.** It ranked the bare model
best on all four clips, but the metric rewards fidelity to a source whose defining
feature is compression damage — it penalises exactly the artefact removal restoration
exists to do. Paired 1:1 crops settled it: every deblock strength strong enough to
reduce the blocking also visibly smeared hair texture, and the conservative setting was
indistinguishable from off. Shipped with no restoration.

## Image fixes

The v1 image built and passed its checks but **could not render** — `vspipe` failed with
"Python executable and library path couldn't be determined". `import vapoursynth`
succeeds without VSScript configured, so the API-only check was never evidence a render
could start.

- `vapoursynth config` at build time; `HOME` pointed at a real in-image path (Bluefin is
  ostree/bootc, so `/root` is a dangling symlink to `/var/roothome` and `/var` is empty
  at build time — same root cause as the earlier `/opt` and Zig-cache failures).
- Fixed `upscale.vpy`, which still defaulted to pre-ostree `/opt/upscale` paths and so
  failed model lookup at graph construction on a GPU node.

Two new build gates, both of which would have caught the above:
- `vspipe -> ffmpeg` on a synthetic clip, exercising the real execution path.
- `vspipe --info` over the shipped `upscale.vpy` for all four branches. This constructs
  the full filter graph without rendering, so it needs **no GPU**, but model and plugin
  paths resolve during construction — a wrong path fails there.

The image invokes **no package manager at all**: ffmpeg comes from the org `bluefin`
image, Zig from a checksum-verified upstream tarball.

## Notes

- The model (`2xLiveActionV1_SPAN`) is **CC-BY-NC-SA-4.0, non-commercial**. Recorded in
  the report.
- Branches 3 (ArtCNN) and 4 (UltraSharp control) were **not run** — unverified wiring and
  unvendored weights respectively. Reported as unfinished, not as evaluated.
- No media is committed. The master stays on the `upscale-scratch` PVC.

`just lint` passes.