### PR TITLE
fix(net): disable TSO on thunderbolt0 to unbreak cross-node pod traffic

### DIFF
--- a/docs/benchmarks/2026-08-21-4k-upscale-vulkan.md
+++ b/docs/benchmarks/2026-08-21-4k-upscale-vulkan.md
@@ -13,7 +13,7 @@ two-node USB4 architecture was worth building.
 | Full 507 s video | **1 h 19 m** render, 2 h 01 m including master encode |
 | Break-even needed to fit 48 h | 27.3 s/frame → **59x margin** |
 | Best restoration branch | **none** — the bare model won |
-| Two-node distribution | **abandoned** — pod network measured 235 KB/s |
+| Two-node distribution | **abandoned** — pod network measured 235 KB/s (root cause since fixed: TSO) |
 
 ## Stack
 
@@ -142,7 +142,7 @@ weights were never vendored. They are unfinished, not evaluated.
 A `vszip.Deband` variant was attempted and failed on an incorrect call
 signature; it was dropped rather than guessed at.
 
-## The two-node architecture was abandoned
+## The two-node architecture was abandoned — and the cause was later fixed
 
 The plan called for splitting the render across both GPUs with an HTTP chunk
 store on the pod network, specifically so bulk traffic would ride USB4.
@@ -155,11 +155,11 @@ Measurement killed it.
 | Ethernet, host netns | `192.168.1.170` | 294 MB/s |
 | **Cross-node pod -> pod** | `10.42.0.249` -> `10.42.1.54` | **235 KB/s** |
 
-The USB4 link is healthy and is 3.7x faster than Ethernet. The **pod** path is
+The USB4 link is healthy and is 3.7x faster than Ethernet. The **pod** path was
 ~4,600x slower than the link beneath it. The loopback control rules out the test
-server; pod→host-netns was also slow, so the fault is on pod-netns egress.
+server.
 
-Routing is not the cause — rule 5209 correctly steers pod-CIDR traffic onto
+Routing was not the cause — rule 5209 correctly steers pod-CIDR traffic onto
 `thunderbolt0` even with a pod source address, and MTU is a uniform 1500:
 
 ```
@@ -169,11 +169,49 @@ Routing is not the cause — rule 5209 correctly steers pod-CIDR traffic onto
 
 Moving 65–85 GB of chunks at 235 KB/s would take ~4 days against ~1.6 h to
 render everything on one node, so the benchmark ran **single-node on `ghost`**.
-Filed as **issue #662**.
+That was the right call with the information available at the time.
+
+### Root cause, found afterwards: TSO
+
+Filed as **issue #662** and diagnosed the same day. Per-interface byte counters
+showed the link carrying **90.4 MB to deliver a 33.5 MB payload** — 2.7x
+amplification. `/proc/net/snmp` *inside the sending pod* showed
+`RetransSegs 30525 / OutSegs 201734` — a **15% retransmit rate**. Traffic was on
+the right interface; most of it was being sent twice.
+
+The culprit is **TCP segmentation offload on `thunderbolt0`**, isolated by
+toggling each offload individually:
+
+| `thunderbolt0` offload state | Pod -> pod throughput |
+|---|---:|
+| `tso on`, gso off, gro on | 244 KB/s |
+| `tso on`, `gso on`, gro off | 313 KB/s |
+| tso off, `gso on`, gro off | 361 MB/s |
+| tso off, gso off, `gro on` | 372 MB/s |
+| tso off, `gso on`, `gro on` | **380 MB/s** |
+| all off | 375 MB/s |
+
+**TSO alone accounts for the entire collapse; GSO and GRO are innocent.** The
+decisive detail is that host-locally-generated traffic over the same link was
+*never* affected (1.097 GB/s throughout) — only **forwarded** frames. k3s runs
+flannel in `host-gw` mode, so pod-to-pod is plain IP forwarding, which is
+exactly the path the offload mishandles. This is why every raw link test looked
+healthy and hid the bug.
+
+The fix is one knob, `ethtool -K thunderbolt0 tso off`, reconciled every 15 s by
+the `usb4-link-monitor` DaemonSet because `ethtool` state is not persisted by
+NetworkManager and resets on reboot or link re-init.
+
+**Consequence for future work:** the two-node distributed architecture in the
+plan is now viable. At 380 MB/s, 65–85 GB of chunks moves in ~3–4 minutes
+instead of ~4 days. A rerun should expect close to 2x throughput.
 
 > **Trap:** `ip route get <peer-pod-ip>` only tells the truth in the host netns.
 > Run inside a pod it always answers `via <cni0 gateway> dev eth0`, which looks
 > like a failure and proves nothing either way.
+
+> **Trap:** `/proc/net/snmp` is per-netns. Read it on the host and the stack
+> looks perfectly healthy while the pod is retransmitting 15% of its segments.
 
 ## Full run
 

--- a/docs/ops/architecture.md
+++ b/docs/ops/architecture.md
@@ -106,6 +106,22 @@ standard Ethernet only — none currently have a physical USB4/Thunderbolt link 
   completely invisible and immune to flannel/k3s route reconciliation. If any other node joins
   the cluster over the LAN, its traffic continues over Ethernet, preventing any route isolation.
 
+- **TSO must stay disabled on `thunderbolt0`.** flannel runs in `host-gw` mode,
+  so cross-node pod traffic is plain IP **forwarding** — and TCP segmentation
+  offload on this driver mishandles forwarded frames. Measured 2026-08-21: pod
+  to pod ran at **244 KB/s** with TSO on versus **380 MB/s** with it off, caused
+  by a 15% TCP retransmit rate. Host-locally-generated traffic over the same
+  link is unaffected at 1.10 GB/s, so raw link tests look perfectly healthy and
+  hide the fault completely. `gso` and `gro` were measured individually and are
+  not implicated; they stay on.
+
+  `ethtool` settings are **not** persisted by NetworkManager and reset on reboot
+  or `thunderbolt0` re-init, so the `usb4-link-monitor` DaemonSet reconciles
+  `ethtool -K thunderbolt0 tso off` on the same 15-second loop as the DNS rules.
+
+  Verify with `ethtool -k thunderbolt0 | grep tcp-segmentation-offload` on both
+  nodes — it must read `off`. Tracked in issue #662.
+
 
 ---
 

--- a/docs/skills/cluster-tooling/SKILL.md
+++ b/docs/skills/cluster-tooling/SKILL.md
@@ -397,15 +397,21 @@ Two cluster-specific traps that cost real time:
   cannot bind without a pod, ArgoCD blocks its sync waiting for PVC health, and
   so the Deployment is never created at all. Scale at runtime instead of
   committing `replicas: 0`.
-- **The pod network cannot carry bulk data across nodes.** Measured 2026-08-21:
-  pod->pod `10.42.x` throughput is **235 KB/s** while the same file over the raw
-  USB4 host addresses (`10.99.0.x`) does **1.10 GB/s** and Ethernet does
-  294 MB/s. That is a ~4,600x degradation in the CNI path, and it is not
-  routing — rule 5209 correctly sends pod-CIDR traffic via `thunderbolt0` even
-  for a pod source IP, and MTU is a uniform 1500. Do not design a workflow that
-  ships large intermediates between pods on different nodes; render/compute
-  single-node, or use `hostNetwork: true`, which reaches the full link speed.
-  Tracked in issue #662.
+- **TSO on `thunderbolt0` destroys cross-node pod traffic — turn it off.**
+  Measured 2026-08-21: pod->pod `10.42.x` throughput was **244 KB/s** with TSO
+  on and **379 MB/s** with it off, a ~1,550x collapse from a **15% TCP
+  retransmit rate** (`RetransSegs 30525 / OutSegs 201734`). The link carried
+  90.4 MB to deliver a 33.5 MB payload. **Only forwarded traffic is affected** —
+  host-locally-generated traffic over the same link always did 1.10 GB/s, which
+  is why raw link tests look healthy and hide the bug entirely. flannel runs
+  `host-gw` here, so every cross-node pod flow is forwarded and hits this path.
+  `gso` and `gro` were measured individually and are innocent; leave them on.
+  Reconciled every 15 s by the `usb4-link-monitor` DaemonSet, because `ethtool`
+  state is not persisted by NetworkManager and resets on reboot. Issue #662.
+- **Read TCP stats in the *sending pod*, not on the host.** `/proc/net/snmp` is
+  per-netns, so a host-side read shows a healthy stack while the pod is
+  retransmitting 15% of its segments. Pair it with per-interface byte counters
+  read on the **receiving** side to spot amplification.
 - **`ip route get <peer-pod-ip>` must run in the host netns** (a
   `hostNetwork: true` pod). Inside a pod it always answers
   `via <cni0 gateway> dev eth0`, because interface selection happens on the

--- a/manifests/usb4-link-monitor.yaml
+++ b/manifests/usb4-link-monitor.yaml
@@ -11,6 +11,10 @@
 #
 # hostNetwork gives the pod the host network namespace, so /sys/class/net
 # shows the host's thunderbolt0 and the TCP probe routes over the tb link.
+#
+# The loop also reconciles two host-level settings that nothing else persists:
+# - thunderbolt0 TSO stays OFF (it destroys forwarded pod-to-pod throughput)
+# - DNS (port 53) stays pinned to the main table via ip rule pref 5208
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -108,6 +112,21 @@ spec:
               IF=/sys/class/net/thunderbolt0
               LAST=""
               while true; do
+                # TSO on thunderbolt0 destroys FORWARDED (pod-to-pod) throughput.
+                # Measured 244 KB/s with TSO on vs 379 MB/s with it off -- a ~1550x
+                # collapse caused by a ~15% TCP retransmit rate. Host-local traffic
+                # over the same link is unaffected, which is why raw link tests look
+                # healthy and hide the bug. flannel runs host-gw here, so all pod
+                # traffic is forwarded and every cross-node pod flow hits this path.
+                # GSO and GRO are innocent (measured individually) and stay ON.
+                # Reconciled every loop: ethtool state is not persisted by
+                # NetworkManager and resets on reboot or thunderbolt0 re-init.
+                if nsenter -t 1 -m -n -- /usr/sbin/ethtool -k thunderbolt0 2>/dev/null \
+                     | grep -q "^tcp-segmentation-offload: on"; then
+                  echo "thunderbolt0: disabling TSO (breaks forwarded pod traffic)"
+                  nsenter -t 1 -m -n -- /usr/sbin/ethtool -K thunderbolt0 tso off || true
+                fi
+
                 # Ensure DNS traffic (UDP/TCP port 53) is ALWAYS routed via Ethernet (main table)
                 # This guarantees DNS queries are immune to any USB4 interface state or table 40.
                 for proto in udp tcp; do


### PR DESCRIPTION
## The defect

Cross-node pod-to-pod throughput measured **244 KB/s** against a **1.10 GB/s** USB4 link — a ~4,600x collapse. Filed as #662 while running the 4K upscale benchmark, which had to abandon its two-node architecture because of it.

## Root cause

**TCP segmentation offload on `thunderbolt0` mishandles _forwarded_ frames.**

Evidence:
- Per-interface byte counters: the link carried **90.4 MB to deliver a 33.5 MB payload** — 2.7x amplification.
- `/proc/net/snmp` **inside the sending pod**: `RetransSegs 30525 / OutSegs 201734` = **15% retransmit rate**.
- Host-locally-generated traffic over the same link was **never** affected (1.097 GB/s throughout).

That last point is why this hid for so long: every raw link test looked perfectly healthy. k3s runs flannel in `host-gw` mode, so pod-to-pod is plain IP forwarding — and only forwarded frames hit the broken path.

## Isolation

Toggled each offload individually rather than shipping a blunt "disable everything":

| `thunderbolt0` state | Pod → pod |
|---|---:|
| `tso on`, gso off, gro on | 244 KB/s |
| `tso on`, `gso on`, gro off | 313 KB/s |
| tso off, `gso on`, gro off | 361 MB/s |
| tso off, gso off, `gro on` | 372 MB/s |
| tso off, `gso on`, `gro on` | **380 MB/s** |
| all off | 375 MB/s |

**TSO alone accounts for the entire collapse.** GSO and GRO are innocent and stay on, so we keep their CPU savings and the fix is a single knob.

## The change

`ethtool` state is **not** persisted by NetworkManager and resets on reboot or `thunderbolt0` re-init, so a one-off `ethtool` invocation is not a fix. This adds an idempotent reconcile step to the `usb4-link-monitor` DaemonSet's existing 15-second loop, guarded to act only on drift — mirroring the DNS `ip rule` pattern already in that loop, and matching its documented "immune to manual operator changes or NetworkManager profile resets" intent.

Uses `nsenter -t 1 -m -n -- /usr/sbin/ethtool`, the same host-namespace escape the loop already uses for `/usr/sbin/ip`; `/usr/sbin/ethtool` confirmed present on both `ghost` and `exo-0`.

Docs updated — all three described the defect as an unfixable property of the cluster:
- `docs/ops/architecture.md` — the requirement, why `host-gw` makes it bite, and a verify command
- `docs/skills/cluster-tooling/SKILL.md` — rewrote the "pod network cannot carry bulk data" bullet, plus the per-netns `/proc/net/snmp` trap
- `docs/benchmarks/2026-08-21-4k-upscale-vulkan.md` — the abandonment was correct at the time; the cause is now fixed and **the two-node distributed render is viable again** (65–85 GB of chunks moves in ~3–4 min instead of ~4 days)

## Validation

- `just lint` passes
- DaemonSet YAML parses; embedded script passes `bash -n`
- Fix measured live on both nodes: **244 KB/s → 380 MB/s**

Closes #662