### PR TITLE
Replace non-commercial upscale model with CC-BY-4.0 equivalent

### DIFF
--- a/docs/benchmarks/2026-08-21-4k-upscale-vulkan.md
+++ b/docs/benchmarks/2026-08-21-4k-upscale-vulkan.md
@@ -28,12 +28,18 @@ Vulkan/ncnn throughout. No ROCm, HIP, CUDA or PyTorch, per
 | `vapoursynth-deblock` | 9.0 |
 | `vapoursynth-mvtools` | 29 |
 | vszip | commit `beb7a0ab` (Zig 0.16.0) |
-| Model | `2xLiveActionV1_SPAN`, native x2 |
+| Model | `2xNomosUni_span_multijpg`, native x2 |
 | Image | `images/video-upscale/Containerfile`, both stages from org `bluefin` |
 
-**Model license: `2xLiveActionV1_SPAN` is CC-BY-NC-SA-4.0 — non-commercial.**
-Acceptable for an internal lab benchmark; it may not be used for anything
-commercial, and the output inherits the restriction.
+**Model license: `2xNomosUni_span_multijpg` is CC-BY-4.0 — commercial use is
+permitted with attribution** (Philip Hofmann / Phhofm). Attribution ships inside
+the image at `/usr/lib/upscale/models/ATTRIBUTION`.
+
+The benchmark run itself used `2xLiveActionV1_SPAN`, which is
+**CC-BY-NC-SA-4.0** — non-commercial, and the restriction is inherited by every
+frame it renders. That was acceptable for an internal benchmark and is not
+acceptable for anything published, so the model was replaced. See
+[Replacing the non-commercial model](#replacing-the-non-commercial-model).
 
 The image contains **no package manager invocation at all**, per
 [image-policy.md](../skills/gitops-argocd/image-policy.md). ffmpeg comes from the
@@ -48,7 +54,7 @@ this problem is abandonware:
 |---|---|---|
 | `realesrgan-ncnn-vulkan` | 2022-04-24 | stale |
 | BasicVSR++ / MMagic | 2023-12-18 | stale, **and** MMCV deform-conv is CUDA-only |
-| DPIR · SCUNet · SwinIR · Real-CUGAN · Waifu2x | 2020–2024 | stale |
+| DPIR · SCUNet · SwinIR · Real-CUGAN · Waifu2x | 2020–2024 | stale — and the transformer ones are additionally **unconvertible by ncnn**, see below |
 | FlashVSR v1.1 | current | NVIDIA block-sparse attention |
 
 Consequence: nearly all of the 812 MB vs-mlrt model zoo fails a currency check.
@@ -141,6 +147,62 @@ weights were never vendored. They are unfinished, not evaluated.
 
 A `vszip.Deband` variant was attempted and failed on an incorrect call
 signature; it was dropped rather than guessed at.
+
+### Replacing the non-commercial model
+
+The benchmark shipped on `2xLiveActionV1_SPAN`, which is **CC-BY-NC-SA-4.0**.
+A non-commercial model taints every frame it produces, so it cannot be used for
+published work. The replacement search had three hard filters, and the second
+one is the surprise.
+
+**1. The licence must permit commercial use.** Verify it at the primary source.
+A web search claimed Real-ESRGAN was CC-BY-NC; reading the actual `LICENSE` file
+showed BSD-3-Clause. Never take a licence from a summary.
+
+**2. The architecture must be a CNN — transformers do not run on this stack.**
+`SwinIR-M x2 GAN` looked ideal on paper: Apache-2.0, native x2, and trained on
+BSRGAN degradations, i.e. exactly for compressed sources. It does not work.
+`vsncnn` rejects it during ONNX conversion:
+
+```
+Unsupported slice step !
+Cast not supported yet!
+Unknown data type 0
+```
+
+ncnn's ONNX converter covers a **subset** of operators, and Swin-style attention
+falls outside it. This rules out the whole transformer family available in the
+vs-mlrt zoo — SwinIR, SCUNet, DAT, HAT, RGT, DRCT, ATD, OmniSR, and waifu2x's
+`swin_unet_*`. It is a property of the backend, not of any one model, so it
+applies to every future model choice on this cluster.
+
+That constraint is load-bearing in the other direction too: SwinIR-M is ~12.7 M
+parameters against SPAN's ~0.4 M, so even had it converted, it would not have
+been affordable for a feature-length render.
+
+**3. It must be an ONNX artefact with a checksum, from the author's own
+release.** OpenModelDB indexes 671 models; filtering to permissive-licence,
+CNN-architecture, native-x2 candidates left 22. Most publish only `.pth` on
+Google Drive, which is neither pinnable nor good provenance.
+
+The bake-off, on the same clips as the branch comparison:
+
+| Model | Licence | Arch | s/frame | Verdict |
+|---|---|---|---:|---|
+| `2xLiveActionV1_SPAN` | CC-BY-NC-SA-4.0 | SPAN | 0.424 | incumbent — unusable licence |
+| **`2xNomosUni_span_multijpg`** | **CC-BY-4.0** | SPAN | **0.414** | **selected** |
+| `2xNomosUni_compact_otf_medium` | CC-BY-4.0 | Compact | 0.458 | rejected — over-sharpens |
+
+Decided on paired 1:1 crops, viewed directly, per the SSIM finding above. The
+Compact model rings badly: hard black outlines around every subject edge and
+posterised "cut-out" detail. The selected SPAN model is visually
+indistinguishable from the incumbent on natural texture and preserves
+out-of-focus regions without inventing detail in them — the failure mode the
+plan called the top quality risk.
+
+**The permissive licence cost nothing.** Same architecture, same parameter count,
+marginally *faster*, same visual result. The non-commercial model was removed
+from the image rather than kept as a selectable option.
 
 ## The two-node architecture was abandoned — and the cause was later fixed
 

--- a/images/video-upscale/Containerfile
+++ b/images/video-upscale/Containerfile
@@ -101,13 +101,28 @@ RUN mkdir -p /usr/lib/upscale/lib && \
 
 # Model weights are baked and checksum-verified, so a render is reproducible and
 # cannot silently pick up different weights later.
-# 2xLiveActionV1_SPAN — native x2: 1920x804 -> 3840x1608 exactly, no resampling.
-# LICENSE: CC-BY-NC-SA-4.0 (non-commercial). Record this in any published report.
-ARG SPAN_SHA=bfa72f3c6347076aed140d0836cee30c27ea434c047beeaf9466469483836ecc
+#
+# 2xNomosUni_span_multijpg — SPAN, native x2: 1920x804 -> 3840x1608 exactly, no
+# resampling. Trained with multi-scale JPEG degradation, which is what a
+# low-bitrate 1080p source actually suffers from.
+#
+# LICENSE: CC-BY-4.0 — commercial use permitted with attribution. This matters:
+# the obvious alternative, 2xLiveActionV1_SPAN, is CC-BY-NC-SA-4.0, and a
+# non-commercial model taints every frame it renders. Measured at 0.414 s/frame
+# against that model's 0.424, so the permissive licence costs nothing.
+# Attribution is shipped in the image at /usr/lib/upscale/models/ATTRIBUTION.
+ARG MODEL_SHA=4c088922fcb40584a95a1b98009e3042a61ada46f237a9e72e8a2ed127832004
 RUN mkdir -p /usr/lib/upscale/models && \
-    curl -sSfL -o /usr/lib/upscale/models/2xLiveActionV1_SPAN.onnx \
-      "https://github.com/jcj83429/upscaling/raw/f73a3a02874360ec6ced18f8bdd8e43b5d7bba57/2xLiveActionV1_SPAN/2xLiveActionV1_SPAN_490000.onnx" && \
-    echo "${SPAN_SHA}  /usr/lib/upscale/models/2xLiveActionV1_SPAN.onnx" | sha256sum -c -
+    curl -sSfL -o /usr/lib/upscale/models/2xNomosUni_span_multijpg.onnx \
+      "https://github.com/Phhofm/models/releases/download/2xNomosUni_span_multijpg/2xNomosUni_span_multijpg_fp32_opset17.onnx" && \
+    echo "${MODEL_SHA}  /usr/lib/upscale/models/2xNomosUni_span_multijpg.onnx" | sha256sum -c - && \
+    printf '%s\n' \
+      '2xNomosUni_span_multijpg' \
+      '  Author:  Philip Hofmann (Phhofm)' \
+      '  License: CC-BY-4.0 <https://creativecommons.org/licenses/by/4.0/>' \
+      '  Source:  https://github.com/Phhofm/models/releases/tag/2xNomosUni_span_multijpg' \
+      '  Arch:    SPAN, native x2' \
+      > /usr/lib/upscale/models/ATTRIBUTION
 
 COPY upscale.vpy /usr/lib/upscale/upscale.vpy
 

--- a/images/video-upscale/upscale.vpy
+++ b/images/video-upscale/upscale.vpy
@@ -9,7 +9,7 @@ for _p in os.scandir(os.environ.get("VS_PLUGINDIR", "/usr/lib/upscale/vs-plugins
 
 SRC    = os.environ["SRC"]
 BRANCH = int(os.environ.get("BRANCH", "1"))
-MODEL  = os.environ.get("MODEL", "/usr/lib/upscale/models/2xLiveActionV1_SPAN.onnx")
+MODEL  = os.environ.get("MODEL", "/usr/lib/upscale/models/2xNomosUni_span_multijpg.onnx")
 TILE   = int(os.environ.get("TILE", "256"))
 OVER   = int(os.environ.get("OVERLAP", "16"))
 FP16   = os.environ.get("FP16", "1") == "1"


### PR DESCRIPTION
The 4K upscale image shipped `2xLiveActionV1_SPAN`, which is **CC-BY-NC-SA-4.0**. A non-commercial model taints every frame it renders, so nothing this pipeline produces could be published.

## Change

Replaced with **`2xNomosUni_span_multijpg`** (CC-BY-4.0, Philip Hofmann). Attribution ships in the image at `/usr/lib/upscale/models/ATTRIBUTION`. The non-commercial model is **removed outright**, not kept as a selectable option.

| Model | Licence | Arch | s/frame | Verdict |
|---|---|---|---:|---|
| `2xLiveActionV1_SPAN` | CC-BY-NC-SA-4.0 | SPAN | 0.424 | incumbent — unusable licence |
| **`2xNomosUni_span_multijpg`** | **CC-BY-4.0** | SPAN | **0.414** | **selected** |
| `2xNomosUni_compact_otf_medium` | CC-BY-4.0 | Compact | 0.458 | rejected — over-sharpens |

The permissive licence cost nothing: same architecture, same native x2 geometry, marginally *faster*, visually indistinguishable on paired 1:1 crops. The Compact model was rejected on crops — it rings, with hard black outlines and posterised cut-out detail.

## The finding worth keeping

`SwinIR-M x2 GAN` was the obvious candidate — Apache-2.0, native x2, BSRGAN-degradation trained (i.e. built for compressed sources). **It does not run on this stack.** `vsncnn` rejects it during ONNX conversion:

```
Unsupported slice step !
Cast not supported yet!
Unknown data type 0
```

ncnn's ONNX converter covers only a **subset** of operators and Swin-style attention falls outside it. This rules out the entire transformer family in the vs-mlrt zoo — SwinIR, SCUNet, DAT, HAT, RGT, DRCT, ATD, OmniSR, waifu2x `swin_unet_*` — as a property of the backend, not of any one model. It constrains every future model choice on this cluster, so it is documented in the benchmark report.

## Verification

- `just lint` passes.
- Image builds through all existing gates (encoder/ICD/ncnn assertions, `vspipe → ffmpeg` smoke test, `vspipe --info` across all 4 branches).
- Real render on a GPU node with the **baked-in default** model: 3840x1608, 10-bit, 0.427 s/frame.
- Asserted the image contains no non-commercial weights.