### PR TITLE
fix(server): repair and wire the Bluefin Server lab gate

### DIFF
--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -354,7 +354,8 @@ spec:
           echo "=== Cloning bluefin-server @ ${REF} ==="
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "https://x-access-token:${GITHUB_TOKEN}@${REPO#https://}" /src
-          cd /src          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
+          cd /src
+          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cp /etc/buildstream/buildstream.conf /tmp/buildstream-cluster.conf
           BST_CONF=/tmp/buildstream-cluster.conf

--- a/argo/workflow-templates/bst-commit-poller.yaml
+++ b/argo/workflow-templates/bst-commit-poller.yaml
@@ -118,6 +118,92 @@ spec:
                 - name: expected-sha
                   value: "{{tasks.check-sha.outputs.parameters.stored-sha}}"
 
+    - name: poll-bluefin-server
+      dag:
+        tasks:
+          - name: check-sha
+            template: check-sha
+          - name: run-build
+            depends: "check-sha.Succeeded"
+            when: "{{tasks.check-sha.outputs.parameters.changed}} == true"
+            templateRef:
+              name: bluefin-server-build-pipeline
+              template: build
+            arguments:
+              parameters:
+                - name: ref
+                  value: "{{workflow.parameters.branch}}"
+                - name: repo
+                  value: "https://github.com/{{workflow.parameters.repo}}.git"
+                - name: registry
+                  value: "{{workflow.parameters.registry}}"
+                - name: build-mode
+                  value: "re"
+          # The gate is the install-and-reboot result, not the build. The build
+          # pipeline publishes <registry>/bluefin-server-installer:latest, which
+          # is what the boot test consumes.
+          - name: run-boot-test
+            depends: "run-build.Succeeded"
+            templateRef:
+              name: bluefin-server-boot-test
+              template: pipeline
+            arguments:
+              parameters:
+                - name: installer-image
+                  value: "{{workflow.parameters.registry}}/bluefin-server-installer:latest"
+          - name: report-pass
+            depends: "run-boot-test.Succeeded"
+            templateRef:
+              name: github-status-reporter
+              template: send
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{workflow.parameters.repo}}"
+                - name: sha
+                  value: "{{tasks.check-sha.outputs.parameters.sha}}"
+                - name: state
+                  value: completed
+                - name: conclusion
+                  value: success
+                - name: workflow-name
+                  value: "{{workflow.name}}"
+                - name: title
+                  value: Lab boot gate
+                - name: summary
+                  value: Installer installed and the target disk booted to a systemd target.
+          - name: report-fail
+            depends: "run-build.Failed || run-boot-test.Failed"
+            templateRef:
+              name: github-status-reporter
+              template: send
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{workflow.parameters.repo}}"
+                - name: sha
+                  value: "{{tasks.check-sha.outputs.parameters.sha}}"
+                - name: state
+                  value: completed
+                - name: conclusion
+                  value: failure
+                - name: workflow-name
+                  value: "{{workflow.name}}"
+                - name: title
+                  value: Lab boot gate
+                - name: summary
+                  value: The lab build or installer-to-boot test failed.
+          # State only advances on a green gate, so a failed ref is retried.
+          - name: update-sha
+            depends: "run-boot-test.Succeeded"
+            template: update-sha
+            arguments:
+              parameters:
+                - name: sha
+                  value: "{{tasks.check-sha.outputs.parameters.sha}}"
+                - name: expected-sha
+                  value: "{{tasks.check-sha.outputs.parameters.stored-sha}}"
+
     - name: check-sha
       outputs:
         parameters:

--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -356,7 +356,8 @@ spec:
           echo "=== Cloning cosmic-build-meta @ ${REF} ==="
           rm -rf /src
           git clone --depth=1 --branch "${REF}" "${REPO}" /src
-          cd /src          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
+          cd /src
+          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
 
           cat >> /tmp/buildstream-cluster.conf <<EOF
           projects:

--- a/argo/workflow-templates/github-status-reporter.yaml
+++ b/argo/workflow-templates/github-status-reporter.yaml
@@ -93,8 +93,12 @@ spec:
         source: |
           set -euo pipefail
 
-          [[ "${REPOSITORY}" == "projectbluefin/testsuite" ]] ||
-            { echo "Refusing status for ${REPOSITORY}" >&2; exit 1; }
+          # Explicit allowlist: the lab token must never write statuses to an
+          # arbitrary repository derived from workflow parameters.
+          case "${REPOSITORY}" in
+            projectbluefin/testsuite|projectbluefin/server) ;;
+            *) echo "Refusing status for ${REPOSITORY}" >&2; exit 1 ;;
+          esac
           [[ "${SHA}" =~ ^[0-9a-f]{40}$ ]] ||
             { echo "Invalid commit SHA: ${SHA}" >&2; exit 1; }
 

--- a/manifests/server-commit-poller.yaml
+++ b/manifests/server-commit-poller.yaml
@@ -1,0 +1,38 @@
+# Bluefin Server is gated on install-and-reboot, not on a successful build, so
+# this poller chains bluefin-server-build-pipeline into bluefin-server-boot-test
+# and only records the SHA when the installed disk boots.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: server-commit-poller
+  namespace: argo
+  labels:
+    app.kubernetes.io/component: commit-poller
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  # Offset from the dakota and cosmic pollers so the three share bounded BST
+  # admission rather than contending for the same slot.
+  schedules:
+    - "2-59/15 * * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  workflowMetadata:
+    labels:
+      bluefin.io/bst-workload: "true"
+      bluefin.io/bst-source: bluefin-server
+  workflowSpec:
+    serviceAccountName: argo
+    entrypoint: poll-bluefin-server
+    arguments:
+      parameters:
+        - name: repo
+          value: projectbluefin/server
+        - name: branch
+          value: main
+        - name: state-key
+          value: sha-bluefin-server-main
+        - name: force
+          value: "false"
+    workflowTemplateRef:
+      name: bst-commit-poller


### PR DESCRIPTION
## Problem

The Bluefin Server lab gate has been broken since it was introduced, and nothing was driving it.

**1. Every server BST build failed in under a minute.** In `bluefin-server-build-pipeline`, a newline was lost:

```bash
cd /src          PROJECT_NAME=$(awk -F': *' '/^name:/{print $2; exit}' project.conf | tr -d '\r')
```

Command substitution runs first, so `awk` executed in the pod's working directory:

```
awk: fatal: cannot open file `project.conf' for reading: No such file or directory
/argo/staging/script: line 11: cd: too many arguments
```

Reproduced today on `server-gate-build-wxsm7` (Failed, 50s). `cosmic-build-pipeline` carries the identical corruption.

**2. Nothing triggered it.** There is no server commit poller, and `bluefin-server-boot-test` was never chained after the build — it just sat pointing at whatever `:latest` happened to be in Zot.

Net effect: installer boot testing silently fell back to developers' workstations.

## Change

- Restore the lost newline in both affected pipelines.
- Add a `poll-bluefin-server` entrypoint to `bst-commit-poller`: build → **boot test** → status → record SHA.
- Add the `server-commit-poller` CronWorkflow, offset from the dakota/cosmic pollers so the three share bounded BST admission.
- Post the outcome to `projectbluefin/server` as the `ghost-lab` commit status.

The gate is the install-and-reboot result, not the build. `update-sha` depends on `run-boot-test.Succeeded`, so a ref that builds but fails to boot is retried rather than recorded as done.

## Security note

`github-status-reporter` hard-coded a single allowed repository. It now uses an explicit two-entry allowlist (`projectbluefin/testsuite`, `projectbluefin/server`), preserving the property that the lab token cannot write a status to a repository derived from workflow parameters.

## Validation

- `just lint` passes.
- `kubectl apply --dry-run=server` accepts all four changed/added manifests.
- The cron manifest cannot fully lint until this merges, since `bst-commit-poller.poll-bluefin-server` does not exist on the cluster yet.

## Follow-up (not in this PR)

`bluefin-server-boot-test`'s `prepare-installer` step runs `dnf install -y -q zstd podman`, which conflicts with the repo's no-RPM/no-dnf boundary and is a live dependency on network + package availability inside the gate.