### PR TITLE
fix(kde): make Gate B sabotage runs publishable, isolated, and self-verdicting

### DIFF
--- a/argo/workflow-templates/run-kde-tests.yaml
+++ b/argo/workflow-templates/run-kde-tests.yaml
@@ -130,6 +130,8 @@ spec:
         value: "{{inputs.parameters.suite}}"
       - name: VARIANT
         value: "{{inputs.parameters.variant}}"
+      - name: CONTAINERDISK_TAG
+        value: "{{inputs.parameters.containerdisk-tag}}"
       - name: BEHAVE_TAGS
         value: "{{inputs.parameters.behave-tags}}"
       - name: IMAGE
@@ -262,6 +264,35 @@ spec:
           ARTIFACT_RC=1
         fi
 
+        # Derive the bounded failed-scenario list consumed by the
+        # `failed-scenarios` output parameter and the QA run evidence
+        # reconciler (same contract as the GNOME runner).
+        if [[ -f /results/results.json ]]; then
+          python3 - /results/results.json > /tmp/results/failed-scenarios.json <<'PY'
+        import json
+        import re
+        import sys
+
+        with open(sys.argv[1], encoding="utf-8") as result_file:
+            data = json.load(result_file)
+        safe_name = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 .,:;()/_+-]{0,159}$")
+        failed_scenarios = []
+        for feature in data:
+            for scenario in feature.get("elements", []):
+                name = scenario.get("name")
+                if (
+                    scenario.get("status") == "failed"
+                    and isinstance(name, str)
+                    and safe_name.fullmatch(name)
+                    and not any(word in name.lower() for word in
+                                ("token", "password", "secret", "authorization"))
+                    and name not in failed_scenarios
+                ):
+                    failed_scenarios.append(name)
+        json.dump(failed_scenarios[:20], sys.stdout, separators=(",", ":"))
+        PY
+        fi
+
         # Keep both the directory and a portable tarball for each kde_faillog
         # bundle produced by the testsuite failure hook. lab-runner does not
         # provide tar, so use the guaranteed Python standard library tool.
@@ -275,7 +306,14 @@ spec:
           fi
         done < <(find /tmp/results -type d -name 'faillog_*' -print0)
 
-        RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
+        # Sabotage runs persist into their own evidence directory so the two
+        # sabotage modes cannot clobber each other's results.json and faillog
+        # bundles; non-sabotage runs keep the historical path.
+        if [[ "${SABOTAGE_MODE}" == "none" ]]; then
+          RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"
+        else
+          RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}-sabotage-${SABOTAGE_MODE}"
+        fi
         mkdir -p "${RESULT_DIR}"
         if ! cp -r /tmp/results/. "${RESULT_DIR}/"; then
           echo "ERROR: failed to persist KDE results to ${RESULT_DIR}" >&2
@@ -303,6 +341,21 @@ spec:
           echo "GHCR screenshot publication disabled; retaining screenshot locally only." >&2
         fi
 
+        # publish_test_results.py keys results by "<img-slug>-<suite>.json".
+        # Derive the slug the same way the GNOME runner does: variant plus
+        # containerdisk tag (aurora + testing -> aurora-testing). Sabotage runs
+        # publish under a sabotage-specific suite label so their intentional
+        # red results do not pollute the KDE soak-gate history and each mode's
+        # published evidence survives the second run.
+        IMG_SLUG="${VARIANT}"
+        if [[ -n "${CONTAINERDISK_TAG}" ]]; then
+          IMG_SLUG="${VARIANT}-${CONTAINERDISK_TAG}"
+        fi
+        PUBLISH_SUITE="${SUITE}"
+        if [[ "${SABOTAGE_MODE}" != "none" ]]; then
+          PUBLISH_SUITE="${SUITE}-sabotage-${SABOTAGE_MODE}"
+        fi
+
         PUBLISH_RC=0
         if ! {
           rm -rf /workspace/lab-code
@@ -310,7 +363,7 @@ spec:
             "https://x-access-token:${GITHUB_TOKEN}@github.com/projectbluefin/lab.git" \
             /workspace/lab-code
           python3 /workspace/lab-code/scripts/publish_test_results.py \
-            /results/results.json "${IMG_SLUG}" "${SUITE}" \
+            /results/results.json "${IMG_SLUG}" "${PUBLISH_SUITE}" \
             "{{workflow.name}}" "${GITHUB_TOKEN}" "" \
             "${FAILURE_CLASS}" "${FAILURE_ISSUE_URL}"
         }; then
@@ -318,9 +371,96 @@ spec:
           PUBLISH_RC=1
         fi
 
+        # Publish a result only when structured Behave output exists and can
+        # be parsed. A missing summary must not make an execution failure look
+        # successful to the evidence reconciler.
+        if [[ -f /results/results.json ]]; then
+          python3 -c "
+        import json, sys
+        data = json.load(open('/results/results.json'))
+        failed = sum(1 for f in data for s in f.get('elements',[]) if s.get('type') == 'scenario' and s.get('status') == 'failed')
+        total = sum(1 for f in data for s in f.get('elements',[]) if s.get('type') == 'scenario')
+        print(f'{total - failed}/{total} scenarios passed')
+          " > /tmp/results/result-summary.txt 2>/dev/null || {
+            rm -f /tmp/results/result-summary.txt
+            echo "ERROR: unable to derive result summary from results.json" >&2
+          }
+        fi
+        # Print full results JSON to stderr — captured by Loki and Argo logs.
+        if [[ -f /results/results.json ]]; then
+          echo "=== BEHAVE RESULTS JSON ===" >&2
+          cat /results/results.json >&2
+          echo "=== END BEHAVE RESULTS ===" >&2
+        fi
+
+        # Gate B: a sabotaged run must go red with a recorded error, never a
+        # silent pass or an all-skip. Verify the behave results actually
+        # recorded failed scenarios before trusting the exit code.
+        SABOTAGE_VERDICT_RC=0
+        if [[ "${SABOTAGE_MODE}" != "none" ]]; then
+          python3 - "${SABOTAGE_MODE}" /results/results.json <<'SABOTAGE_VERDICT' || SABOTAGE_VERDICT_RC=1
+        import json
+        import sys
+
+        mode, results_path = sys.argv[1], sys.argv[2]
+        try:
+            with open(results_path, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, ValueError) as exc:
+            print(
+                "SABOTAGE VERDICT ERROR: behave results for '%s' are unreadable: %s"
+                % (mode, exc),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        scenarios = [
+            element
+            for feature in data
+            for element in feature.get("elements", [])
+            if element.get("type") == "scenario"
+        ]
+        failed = [s for s in scenarios if s.get("status") == "failed"]
+        skipped = [s for s in scenarios if s.get("status") == "skipped"]
+        if not scenarios:
+            print(
+                "SABOTAGE VERDICT ERROR: sabotage '%s' recorded zero scenarios; "
+                "the suite cannot be trusted to go red" % mode,
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not failed:
+            print(
+                "SABOTAGE VERDICT ERROR: sabotage '%s' recorded 0 failed scenarios "
+                "(%d skipped); sabotage must produce recorded errors, not skips"
+                % (mode, len(skipped)),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        for scenario in failed:
+            print(
+                "SABOTAGE VERDICT: sabotage '%s' failed scenario %r"
+                % (mode, scenario.get("name", "Unnamed Scenario")),
+                file=sys.stderr,
+            )
+        print(
+            "SABOTAGE VERDICT OK: sabotage '%s' recorded %d failed scenario(s)"
+            % (mode, len(failed)),
+            file=sys.stderr,
+        )
+        SABOTAGE_VERDICT
+          if ! find /tmp/results -type d -name 'faillog_*' | grep -q .; then
+            echo "SABOTAGE VERDICT ERROR: no kde_faillog_* bundle was retained for sabotage '${SABOTAGE_MODE}'" >&2
+            SABOTAGE_VERDICT_RC=1
+          fi
+        fi
+
         if [[ "${ARTIFACT_RC}" -ne 0 ]]; then
           echo "ERROR: KDE evidence artifacts were not fully retained" >&2
           exit "${ARTIFACT_RC}"
+        fi
+        if [[ "${SABOTAGE_VERDICT_RC}" -ne 0 ]]; then
+          echo "ERROR: Gate B sabotage verdict failed" >&2
+          exit "${SABOTAGE_VERDICT_RC}"
         fi
         if [[ "${PUBLISH_RC}" -ne 0 ]]; then
           exit "${PUBLISH_RC}"

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import re
+
 import yaml
 
 
@@ -489,3 +491,130 @@ def test_dakota_build_pipeline_includes_non_blocking_nvidia_variant():
     )[0]
     assert "continueOn:" in nonblocking
     assert "continueOn:" not in default_task
+
+
+KDE_RUNNER_PATH = ROOT / "argo/workflow-templates/run-kde-tests.yaml"
+
+# Variables any bash process can rely on without an explicit definition.
+AMBIENT_SHELL_VARS = {
+    "BASH", "BASH_VERSION", "EUID", "HOME", "HOSTNAME", "IFS", "LANG",
+    "LC_ALL", "LINENO", "LOGNAME", "MACHTYPE", "OLDPWD", "OPTARG", "OPTIND",
+    "OSTYPE", "PATH", "PPID", "PWD", "RANDOM", "SECONDS", "SHELL", "SHLVL",
+    "TERM", "TMPDIR", "UID", "USER", "_",
+}
+
+
+def _kde_runner_script_and_env():
+    template = yaml.safe_load(KDE_RUNNER_PATH.read_text(encoding="utf-8"))[
+        "spec"
+    ]["templates"][0]
+    container = template["container"]
+    return "\n".join(container["args"]), {item["name"] for item in container["env"]}
+
+
+def _strip_single_quoted_spans(script: str) -> str:
+    """Drop single-quoted spans; their contents are not shell-expanded."""
+    characters = []
+    in_single_quote = False
+    for char in script:
+        if char == "'":
+            in_single_quote = not in_single_quote
+        elif not in_single_quote:
+            characters.append(char)
+    return "".join(characters)
+
+
+def test_kde_runner_defines_every_shell_variable_it_references():
+    """A single unbound variable kills the runner under `set -u`.
+
+    Regression guard for the `${IMG_SLUG}` crash: the publish step expanded a
+    variable that was never defined, so every KDE run (green, red, or
+    sabotaged) died before publishing results.
+    """
+    script, env_names = _kde_runner_script_and_env()
+    # Argo placeholders are interpolated before bash executes the script.
+    script = re.sub(r"\{\{[^}]*\}\}", "ARGO", script)
+    body = _strip_single_quoted_spans(script)
+
+    defined = AMBIENT_SHELL_VARS | env_names
+    for line in body.splitlines():
+        for match in (
+            re.match(r"\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=", line),
+            re.match(r".*\bread\b.*\s([A-Za-z_][A-Za-z0-9_]*)\s*;?\s*$", line),
+            re.match(r"\s*for\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\b", line),
+        ):
+            if match:
+                defined.add(match.group(1))
+
+    referenced = set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", body))
+    referenced |= set(re.findall(r"\$([A-Za-z_][A-Za-z0-9_]*)", body))
+    referenced = {
+        name for name in referenced if not re.fullmatch(r"[0-9#?@*!$-]", name)
+    }
+
+    undefined = referenced - defined
+    assert not undefined, (
+        "run-kde-tests references undefined shell variables "
+        f"(fatal under set -u): {sorted(undefined)}"
+    )
+
+
+def test_kde_runner_publishes_result_outputs_for_evidence_reconciler():
+    """The declared outputs must actually be produced by the script.
+
+    `result` has no valueFrom default, so a missing summary file errored the
+    task even after a green run, and `failed-scenarios` always fell back to
+    "[]", which the QA run evidence reconciler treats as "results
+    unavailable".
+    """
+    doc = yaml.safe_load(KDE_RUNNER_PATH.read_text(encoding="utf-8"))
+    template = doc["spec"]["templates"][0]
+    script = "\n".join(template["container"]["args"])
+
+    output_names = {
+        parameter["name"] for parameter in template["outputs"]["parameters"]
+    }
+    assert output_names == {"result", "failed-scenarios"}
+    assert "/tmp/results/result-summary.txt" in script
+    assert "scenarios passed" in script
+    assert "/tmp/results/failed-scenarios.json" in script
+    # Same bounded failed-scenario list contract as the GNOME runner.
+    assert "[A-Za-z0-9 .,:;()/_+-]" in script
+    assert "failed_scenarios[:20]" in script
+
+
+def test_kde_runner_keeps_sabotage_evidence_isolated_per_mode():
+    """Sabotage runs must not clobber each other's evidence.
+
+    Both sabotage modes previously persisted into and published from the same
+    paths, so the kill-plasmashell run overwrote the missing-binary run's
+    results.json, and their intentional failures polluted the KDE soak-gate
+    history.
+    """
+    doc = yaml.safe_load(KDE_RUNNER_PATH.read_text(encoding="utf-8"))
+    script = "\n".join(doc["spec"]["templates"][0]["container"]["args"])
+
+    # Non-sabotage runs keep the historical evidence path and suite key.
+    assert 'RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}/${SUITE}"' in script
+    # Sabotage runs get a mode-specific evidence directory and publish suite.
+    assert (
+        'RESULT_DIR="/var/mnt/ghost-data/test-results/{{workflow.name}}'
+        '/${SUITE}-sabotage-${SABOTAGE_MODE}"'
+    ) in script
+    assert 'PUBLISH_SUITE="${SUITE}-sabotage-${SABOTAGE_MODE}"' in script
+    assert 'IMG_SLUG="${VARIANT}"' in script
+    assert "- name: CONTAINERDISK_TAG" in KDE_RUNNER_PATH.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_kde_runner_sabotage_verdict_requires_recorded_failures():
+    """A sabotaged run must go red with recorded errors, never a silent skip."""
+    script, _ = _kde_runner_script_and_env()
+
+    assert "SABOTAGE_VERDICT_RC=0" in script
+    assert "recorded zero scenarios" in script
+    assert "recorded 0 failed scenarios" in script
+    assert "no kde_faillog_* bundle was retained" in script
+    # The verdict must be able to fail the task, not just log.
+    assert 'exit "${SABOTAGE_VERDICT_RC}"' in script


### PR DESCRIPTION
## What this does

Gate B (#465) needs live evidence that the KDE suite can go **red** with *recorded* errors. This PR fixes four runner-side defects in `run-kde-tests` that made that evidence impossible to produce or trust, so the sabotage run (once executed against the lab cluster by someone with `argo` access via `just run-aurora-kde-sabotage`) yields complete, non-clobbered, self-verdicting evidence.

## Defects fixed

1. **`${IMG_SLUG}` unbound — publish step crashed every KDE run.**
   `argo/workflow-templates/run-kde-tests.yaml` referenced `${IMG_SLUG}` in the `publish_test_results.py` call but never defined it (unlike the GNOME runner, which derives it). Under `set -euo pipefail`, an unbound expansion is fatal *even inside the `if ! { ... }` guard*, so every `run-kde-tests` execution — normal, green, or sabotaged — died at the publish block: results were never published and the step always exited non-zero. Now derived the same way the GNOME runner does: `aurora-<containerdisk-tag>` → `aurora-testing`.

2. **Declared outputs were never written.**
   The template declares `result` (`/tmp/results/result-summary.txt`, **no default**) and `failed-scenarios` (`/tmp/results/failed-scenarios.json`, default `"[]"`). The script wrote neither: `result` errored output collection on *every* task (even green runs), and the QA run evidence reconciler (`publish_qa_run.py`) always saw an empty `failed-scenarios` list → "results unavailable". Both artifacts are now written with the exact contracts the GNOME runner uses (`N/M scenarios passed` summary; bounded, sanitized failed-scenario list).

3. **The two sabotage runs clobbered each other's evidence.**
   Both modes persisted into `/var/mnt/ghost-data/test-results/<workflow>/kde-smoke` and published to the same `docs/results/<slug>-kde-smoke.json`, so the `kill-plasmashell` run overwrote the `missing-binary` run's `results.json` — destroying exit-criterion evidence for Sabotage 1 — and both intentional failures would pollute the KDE soak-gate history (window allows only 1 non-infra failure per 30). Sabotage runs now persist into and publish under `kde-smoke-sabotage-<mode>`; non-sabotage runs keep the historical paths unchanged.

4. **No automated sabotage verdict.**
   A sabotaged run that silently skipped everything (the exact kde-smoke disease #653 fixed) or recorded zero scenarios would still just "exit non-zero". After behave, sabotage runs now verify their own `results.json`: **at least one failed scenario must be recorded** (zero-scenario/all-skip → loud `SABOTAGE VERDICT ERROR` and task failure) and **at least one `kde_faillog_*` bundle must be retained**. The verdict can fail the task, not just log. The existing "unexpectedly passed" guard remains.

## Verification

- `argo lint --offline argo/workflow-templates/` ✔ (v4.1.2)
- `bash -n` on the extracted runner script ✔
- New regression test `test_kde_runner_defines_every_shell_variable_it_references` fails on the old code (`IMG_SLUG` undefined) and passes now; it mechanically extracts the runner script, strips single-quoted spans and Argo placeholders, and cross-checks every `${VAR}` against script assignments, container env, and ambient vars.
- Sabotage-verdict logic unit-exercised: failed-present → OK; all-skipped → exit 1 "recorded 0 failed scenarios"; zero scenarios → exit 1; unreadable results → exit 1.
- `python -m pytest tests/unit/` ✔ (414 passed; the 3 pre-existing failures on `upstream/main` are environmental — missing `jsonschema`/`yaml` in the local venv — and unrelated to this change).
- `scripts/check_semaphore_topology.py argo/` ✔

## Notes for reviewers

- No cluster access in this environment, so the live runs + evidence posting on #465 remain for the operator (as noted in the issue's code-readiness audit); this PR is the runner-side prerequisite so those runs can actually produce the required evidence.
- The sabotage sed target `Launch "kcmshell6 kcm_autostart"` was verified to still exist in `projectbluefin/testsuite@main` `tests/kde-smoke/features/kde_smoke.feature` (line 45), and the `is not installed` hard assert is present in `steps.py` (line 242), so Sabotage 1 will fail the KCM scenario with a recorded error as designed.

Fixes #465 (runner-side prerequisites for the live evidence runs)

— hive: backend=goose
