### PR TITLE
fix(argo): raise bst-commit-poller check-sha memory limit to 1Gi

### DIFF
--- a/argo/workflow-templates/bst-commit-poller.yaml
+++ b/argo/workflow-templates/bst-commit-poller.yaml
@@ -224,10 +224,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 128Mi
           limits:
-            cpu: 200m
-            memory: 256Mi
+            cpu: 500m
+            memory: 1Gi
         env:
           - name: GITHUB_TOKEN
             valueFrom:


### PR DESCRIPTION
The lab-runner container running kubectl and jq in check-sha hit 256Mi cgroup memory limits and was OOMKilled (exit code 137). Raise request to 128Mi and limit to 1Gi.