### PR TITLE
feat(pipeline): add k0s-sysext build step to bluefin-server-build-pipeline

### DIFF
--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -176,6 +176,23 @@ spec:
                   value: "{{inputs.parameters.registry}}"
                 - name: mode
                   value: "{{tasks.detect-build-mode.outputs.parameters.mode}}"
+          - name: build-sysext
+            template: run-bst-step
+            depends: detect-build-mode
+            arguments:
+              parameters:
+                - name: element
+                  value: "oci/k0s-sysext.bst"
+                - name: tag
+                  value: "k0s-sysext"
+                - name: ref
+                  value: "{{inputs.parameters.ref}}"
+                - name: repo
+                  value: "{{inputs.parameters.repo}}"
+                - name: registry
+                  value: "{{inputs.parameters.registry}}"
+                - name: mode
+                  value: "{{tasks.detect-build-mode.outputs.parameters.mode}}"
 
     - name: detect-build-mode
       inputs:

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -290,6 +290,23 @@ def test_aurora_qa_pipeline_exposes_safe_kde_sabotage_modes():
     assert "aurora-test" in runner
 
 
+def test_bluefin_server_build_pipeline_builds_k0s_sysext():
+    pipeline_path = ROOT / "argo/workflow-templates/bluefin-server-build-pipeline.yaml"
+    assert pipeline_path.exists()
+    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+
+    core = next(t for t in pipeline["spec"]["templates"] if t["name"] == "build-core")
+    tasks = {task["name"]: task for task in core["dag"]["tasks"]}
+
+    assert "build-ddi" in tasks
+    assert "build-installer" in tasks
+    assert "build-sysext" in tasks
+
+    sysext_args = {p["name"]: p["value"] for p in tasks["build-sysext"]["arguments"]["parameters"]}
+    assert sysext_args["element"] == "oci/k0s-sysext.bst"
+    assert sysext_args["tag"] == "k0s-sysext"
+
+
 def test_aurora_kde_sabotage_workflow_runs_both_controlled_failures():
     path = ROOT / "argo/aurora-kde-sabotage.yaml"
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Closes #691.

Bluefin Server replaced k3s with k0s as an optional systemd-sysext (`oci/k0s-sysext.bst`).
This adds the `build-sysext` step into `build-core` in `bluefin-server-build-pipeline` so `k0s-sysext` is built and published to `192.168.1.102:30500/k0s-sysext:latest` alongside the DDI and installer.