### PR TITLE
fix(qa): mount qa wheels through the ostree var hierarchy

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -407,7 +407,7 @@ spec:
           --mount type=bind,source=/run/udev,destination=/run/udev,ro,bind-propagation=rprivate \
           --volume /workspace:/workspace:ro \
           --volume /tmp/results:/tmp/results \
-          --volume /opt/qa-wheels:/opt/qa-wheels:ro \
+          --volume /opt/qa-wheels:/var/opt/qa-wheels:ro \
           --volume /var/cache/bluefin-qa-pip:/var/cache/bluefin-qa-pip:rw \
           --volume /etc/resolv.conf:/etc/resolv.conf:ro \
           "${TARGET_IMAGE}" /sbin/init >/dev/null
@@ -652,14 +652,14 @@ spec:
             # ModuleNotFoundError. Keep it pinned below 81 for as long as qecore
             # imports pkg_resources.
             if python3 -m pip install "${pip_args[@]}" \
-                --no-index --find-links /opt/qa-wheels \
+                --no-index --find-links /var/opt/qa-wheels --find-links /opt/qa-wheels \
                 "${qa_dependencies[@]}" >/tmp/pip-install.log 2>&1; then
               pip_ok=true
               break
             fi
             echo "Local QA wheelhouse did not satisfy this target interpreter; falling back to the configured package index." >&2
             if python3 -m pip install "${pip_args[@]}" \
-                --find-links /opt/qa-wheels \
+                --find-links /var/opt/qa-wheels --find-links /opt/qa-wheels \
                 "${qa_dependencies[@]}" >/tmp/pip-install.log 2>&1; then
               pip_ok=true
               break

--- a/tests/unit/test_run_container_tests_deps.py
+++ b/tests/unit/test_run_container_tests_deps.py
@@ -49,10 +49,11 @@ def test_container_runner_uses_baked_runner_tools_without_dnf_bootstrap():
     assert runner["script"]["image"] == "ghcr.io/projectbluefin/arc-runner:latest"
     assert "dnf install -y skopeo" not in source
     assert "dnf install -y git-core" not in source
-    assert "--volume /opt/qa-wheels:/opt/qa-wheels:ro" in source
+    assert "--volume /opt/qa-wheels:/var/opt/qa-wheels:ro" in source
     assert "--cache-dir" in source
     assert "PIP_CACHE_DIR=/var/cache/bluefin-qa-pip" in source
-    assert "--no-index --find-links /opt/qa-wheels" in source
+    assert "--no-index --find-links /var/opt/qa-wheels" in source
+    assert "--find-links /opt/qa-wheels" in source
     assert "falling back to the configured package index" in source
     container_text = CONTAINER_RUNNER.read_text(encoding="utf-8")
     assert "kubernetes.io/hostname: ghost" in container_text
@@ -105,3 +106,18 @@ def test_systemd_target_preseeds_wheels_without_changing_target_image():
     assert "name: pip-cache" in target
     assert 'path: /var/cache/bluefin-qa-pip' in target
     assert 'image: "{{inputs.parameters.image}}:{{inputs.parameters.image-tag}}"' in target
+
+
+def test_container_runner_wheel_mount_targets_ostree_var_opt_hierarchy():
+    runner = _template(CONTAINER_RUNNER, "run-container-tests")
+    source = runner["script"]["source"]
+
+    # In ostree/bootc images (Bluefin), /opt is a symlink to var/opt or /var/opt,
+    # but /var/opt does not exist in the rootfs before boot/mounts.
+    # Mounting to destination /opt/qa-wheels causes crun openat2 to fail with ENOENT
+    # on 'opt'. Mounting to /var/opt/qa-wheels allows crun to create /var/opt
+    # under existing /var, which simultaneously satisfies the /opt symlink.
+    assert "--volume /opt/qa-wheels:/var/opt/qa-wheels:ro" in source
+    assert "--volume /opt/qa-wheels:/opt/qa-wheels:ro" not in source
+    assert "/var/opt/qa-wheels" in source
+


### PR DESCRIPTION
Fixes the Ghost Lab nested-container wheelhouse mount failure: an ostree image may have a dangling /opt -> /var/opt symlink before boot, so crun cannot prepare a mount at /opt/qa-wheels. Mount through /var/opt/qa-wheels and make the pip wheel lookup accept both resolved paths.\n\nValidation: focused wheel-mount unit test and the full 503-test unit suite.