### PR TITLE
fix(qa): supply python-uinput dependency for nested container test input synthesis

### DIFF
--- a/argo/workflow-templates/run-container-tests.yaml
+++ b/argo/workflow-templates/run-container-tests.yaml
@@ -640,7 +640,7 @@ spec:
             pip_args+=(--break-system-packages)
           fi
           pip_args+=(--cache-dir "${PIP_CACHE_DIR}")
-          qa_dependencies=("setuptools<81" qecore dogtail behave)
+          qa_dependencies=("setuptools<81" qecore dogtail behave python-uinput)
           pip_ok=false
           for attempt in 1 2 3; do
             # setuptools is explicit and load-bearing, not incidental: qecore's
@@ -651,6 +651,8 @@ spec:
             # so without this pin every after_scenario hook raises
             # ModuleNotFoundError. Keep it pinned below 81 for as long as qecore
             # imports pkg_resources.
+            # python-uinput provides the C extension `uinput` module used by
+            # qecore.utility.check_uinput_availability() for synthetic input.
             if python3 -m pip install "${pip_args[@]}" \
                 --no-index --find-links /var/opt/qa-wheels --find-links /opt/qa-wheels \
                 "${qa_dependencies[@]}" >/tmp/pip-install.log 2>&1; then
@@ -669,7 +671,7 @@ spec:
             sleep 10
           done
           if [ "${pip_ok}" != true ]; then
-            echo "Failed to install test-only Python dependencies (setuptools qecore dogtail behave)" >&2
+            echo "Failed to install test-only Python dependencies (setuptools qecore dogtail behave python-uinput)" >&2
             echo "  python3: $(python3 --version 2>&1)" >&2
             echo "  pip:     $(python3 -m pip --version 2>&1)" >&2
             echo "  full pip log:" >&2

--- a/argo/workflow-templates/run-systemd-container-tests.yaml
+++ b/argo/workflow-templates/run-systemd-container-tests.yaml
@@ -292,7 +292,9 @@ spec:
         # Python 3.12+ no longer seeds it into fresh environments, so without
         # this pin every after_scenario hook raises ModuleNotFoundError. Keep it
         # pinned below 81 for as long as qecore imports pkg_resources.
-        qa_dependencies=("setuptools<81" qecore dogtail behave)
+        # python-uinput supplies the C extension `uinput` module required by
+        # qecore.utility.check_uinput_availability() for synthetic input steps.
+        qa_dependencies=("setuptools<81" qecore dogtail behave python-uinput)
         if ! python3 -m pip install --quiet "${pip_args[@]}" \
           --no-index --find-links /workspace/qa-wheels \
           "${qa_dependencies[@]}"; then

--- a/docs/skills/test-authoring/systemd-container-tests.md
+++ b/docs/skills/test-authoring/systemd-container-tests.md
@@ -177,6 +177,12 @@ desktop limitation, not as a regression in that provisioning.
     `RuntimeError: User 'bluefin-test' does not have write permissions for '/dev/uinput'`.
     Using `--user bluefin-test` ensures the runtime looks up the user and
     populates all supplementary groups.
+14. **Supply `python-uinput` to nested targets:** `qecore`'s
+    `check_uinput_availability()` checks `importlib.util.find_spec("uinput")`
+    before synthesizing key/mouse events via `/dev/uinput`. The Python module
+    is `uinput`, but the PyPI package distribution is `python-uinput` (bare
+    `uinput` does not exist on PyPI). Ensure `python-uinput` is declared in
+    `qa_dependencies` and in the runner's pre-baked `/opt/qa-wheels` wheelhouse.
 
 #### The `homebrew` lane
 

--- a/images/arc-runner/Containerfile
+++ b/images/arc-runner/Containerfile
@@ -33,7 +33,8 @@ RUN mkdir -p /opt/qa-wheels && \
       "setuptools<81" \
       qecore \
       dogtail \
-      behave && \
+      behave \
+      python-uinput && \
     chmod -R a+rX /opt/qa-wheels
 
 # kubectl (for cluster operations and debugging from ARC jobs)

--- a/tests/unit/test_run_container_tests_deps.py
+++ b/tests/unit/test_run_container_tests_deps.py
@@ -21,7 +21,7 @@ def test_arc_runner_bakes_tools_and_a_python_wheelhouse():
     for package in ("podman", "skopeo", "git", "python3-pip"):
         assert package in containerfile
     assert "/opt/qa-wheels" in containerfile
-    for dependency in ('"setuptools<81"', "qecore", "dogtail", "behave"):
+    for dependency in ('"setuptools<81"', "qecore", "dogtail", "behave", "python-uinput"):
         assert dependency in containerfile
 
 
@@ -72,6 +72,7 @@ def test_target_python_dependencies_remain_target_installs_with_load_bearing_pin
         assert "qecore" in source
         assert "dogtail" in source
         assert "behave" in source
+        assert "python-uinput" in source
         assert '"setuptools<81"' in source
         assert "--find-links" in source
         assert "--no-index" in source
@@ -80,6 +81,19 @@ def test_target_python_dependencies_remain_target_installs_with_load_bearing_pin
 
     assert "Sandbox._attach_version_status_to_report()" in container_source
     assert "pkg_resources" in systemd_source
+
+
+def test_nested_target_installs_python_uinput_dependency():
+    container_source = _template(CONTAINER_RUNNER, "run-container-tests")["script"]["source"]
+    systemd_source = _template(SYSTEMD_RUNNER, "run-tests")["script"]["source"]
+
+    # python-uinput provides the C extension `uinput` module required by
+    # qecore.utility.check_uinput_availability() for synthetic input events.
+    # The PyPI distribution name is `python-uinput` (not bare `uinput`, which does
+    # not exist on PyPI). Ensure both runners declare python-uinput in qa_dependencies.
+    for source in (container_source, systemd_source):
+        assert "python-uinput" in source
+        assert 'qa_dependencies=("setuptools<81" qecore dogtail behave python-uinput)' in source
 
 
 def test_aggregate_publication_has_one_lab_clone_and_one_batch_push():


### PR DESCRIPTION
## Root Cause

In live Ghost Lab workflow `testsuite-792-fix-e2e-robust-toggle-updates-mt5nz` (specifically smoke suite run `testsuite-792-fix-e2e-robust-toggle-updates-mt5nz-run-container-tests-1742119637`), tests executing synthetic input steps such as `Key combo: "<Ctrl><T>" with uinput` failed with:
```
RuntimeError: Missing module 'uinput' on the System. Unable to use this function.
  File "/usr/local/lib/python3.14/site-packages/qecore/common_steps.py", line 708, in key_combo_uinput_step
    check_uinput_availability()
  File "/usr/local/lib/python3.14/site-packages/qecore/utility.py", line 1075, in check_uinput_availability
    raise RuntimeError("Missing module 'uinput' on the System. Unable to use this function.")
```

While PR #706 successfully resolved effective group propagation for `/dev/uinput` permissions, `qecore`'s `check_uinput_availability()` also verifies `importlib.util.find_spec("uinput")`.
The Python module `uinput` is provided by the PyPI package `python-uinput` (bare `uinput` does not exist on PyPI). However:
1. `qa_dependencies` in `run-container-tests.yaml` and `run-systemd-container-tests.yaml` only listed `setuptools<81`, `qecore`, `dogtail`, and `behave`, omitting `python-uinput`.
2. The pre-baked wheelhouse in `images/arc-runner/Containerfile` did not download `python-uinput`.

## Fix

1. Add `python-uinput` to `qa_dependencies` in `argo/workflow-templates/run-container-tests.yaml` and `argo/workflow-templates/run-systemd-container-tests.yaml`.
2. Add `python-uinput` to the `pip download` invocation in `images/arc-runner/Containerfile`.
3. Add contract regression tests in `tests/unit/test_run_container_tests_deps.py` asserting `python-uinput` is declared in `qa_dependencies` and the runner wheelhouse.
4. Document the `python-uinput` requirement in `docs/skills/test-authoring/systemd-container-tests.md`.

## Validation

- Focused regression tests executed red before the fix (3 failures asserting `python-uinput`) and green after the fix.
- Full unit test suite passes: 505 passed with 70.00% coverage (threshold >= 60%).
- Verified live in the nested container target (`bluefin-qa-target`): installing `python-uinput` allows `qecore.utility.check_uinput_availability()` to pass cleanly and allows creating synthetic input devices (`uinput.Device([uinput.KEY_A])`) as user `bluefin-test`.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: castrojo <castrojo@users.noreply.github.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>