### PR TITLE
feat(argo): repoint pr-poller Aurora route to aurora-qa-pipeline

### DIFF
--- a/argo/workflow-templates/aurora-qa-pipeline.yaml
+++ b/argo/workflow-templates/aurora-qa-pipeline.yaml
@@ -52,6 +52,12 @@ spec:
         value: bluefin-test
       - name: ssh-key-secret
         value: bluefin-test-ssh-key
+      - name: sha
+        value: ""
+      - name: repo
+        value: ""
+      - name: pr-number
+        value: ""
   templates:
     - name: aurora-qa
       synchronization:

--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -321,20 +321,8 @@ spec:
                  value: ${TESTSUITE_BRANCH}
                - name: testsuite-repo
                  value: ${TESTSUITE_REPO}" ;;
-            */aurora)       TMPL="bluefin-qa-pipeline"
-                            EXTRA_PARAMS="
-               - name: image
-                 value: ghcr.io/ublue-os/aurora
-               - name: image-tag
-                 value: testing
-               - name: suites
-                 value: system
-               - name: variant
-                 value: aurora
-               - name: testsuite-branch
-                 value: ${TESTSUITE_BRANCH}
-               - name: testsuite-repo
-                 value: ${TESTSUITE_REPO}" ;;
+            */aurora)       TMPL="aurora-qa-pipeline"
+                            EXTRA_PARAMS="" ;;
             */bluefin-lts)  TMPL="bluefin-qa-pipeline"
                             EXTRA_PARAMS="
                - name: image

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -1261,6 +1261,16 @@ def test_pr_poller_declares_parameters_used_by_inline_workflow():
         assert f"- name: {name}" in args_block
 
 
+def test_pr_poller_routes_aurora_to_aurora_qa_pipeline():
+    content = (ROOT / "argo/workflow-templates/pr-poller.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    aurora_block = content.split("*/aurora)", 1)[1].split(";;", 1)[0]
+    assert 'TMPL="aurora-qa-pipeline"' in aurora_block
+    assert 'EXTRA_PARAMS=""' in aurora_block
+
+
 def test_container_runner_never_falls_back_to_a_different_testsuite_revision():
     content = (ROOT / "argo/workflow-templates/run-container-tests.yaml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Problem

Issue projectbluefin/lab#467: The `pr-poller.yaml` workflow routes per-repo via a `case` statement. The `*/aurora` route previously pointed to `bluefin-qa-pipeline` (container test suite). To run KDE GUI tests on Aurora PRs, this must point to `aurora-qa-pipeline`.

## Changes

1. In `argo/workflow-templates/pr-poller.yaml`, updated `*/aurora)` to set `TMPL="aurora-qa-pipeline"` and `EXTRA_PARAMS=""`.
2. In `argo/workflow-templates/aurora-qa-pipeline.yaml`, declared optional arguments `sha`, `repo`, and `pr-number` to align with the parameters dispatched by `pr-poller`.
3. In `tests/unit/test_container_only_qa_workflows.py`, added `test_pr_poller_routes_aurora_to_aurora_qa_pipeline` to verify the routing contract.

## Acceptance Criteria

- [x] `*/aurora` route points to `aurora-qa-pipeline`.
- [x] GNOME routes (`*/bluefin`, etc.) are unchanged.
- [x] Dependency #465 (Gate B) was verified and closed.
- [x] Human sign-off was recorded on #467 by maintainer @castrojo.

Note: The task instructions specified base branch `v4`, but `v4` does not exist upstream in `projectbluefin/lab` (only `main` and feature branches exist). The PR is opened against `main` accordingly.

Fixes #467

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `5552d767a`