### PR TITLE
fix(kde): restore soak gate evaluator target to aurora-testing-kde-smoke.json

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -151,7 +151,7 @@ run-aurora-kde-sabotage:
 # Evaluate the rolling KDE soak window. A qualified result still needs human
 # approval before the suite is promoted to CI gating.
 evaluate-kde-soak:
-    python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-smoke.json
+    python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-kde-smoke.json
 
 # ── Observation ─────────────────────────────────────────────────────────────
 

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -405,10 +405,17 @@ triggers, and retains failed workflows for seven days.
 Each live run must publish the structured result and screenshot through
 `run-kde-tests`, and persist the result/artifact bundle before teardown. A
 qualified 30-run window is evidence only: retain the Argo workflow URL, the
-published `docs/results/aurora-testing-smoke.json` history, screenshot URL,
-and any filed issue URL for every classified infrastructure flake. Live-run
-evidence is required after ArgoCD reconciles the Git change; local lint cannot
-substitute for that evidence.
+published `docs/results/aurora-testing-kde-smoke.json` history, screenshot
+URL, and any filed issue URL for every classified infrastructure flake.
+Live-run evidence is required after ArgoCD reconciles the Git change; local
+lint cannot substitute for that evidence.
+
+`aurora-testing-kde-smoke.json` (suite `kde-smoke`, the name `nightly-kde` and
+`aurora-qa-pipeline` pass to `run-kde-tests`) is a distinct file from the
+pre-existing `aurora-testing-smoke.json`, which belongs to the unrelated
+generic `bluefin-qa-pipeline` smoke/developer/software suites triggered by
+`image-poll-aurora-testing`. Do not conflate the two: `just evaluate-kde-soak`
+and the soak gate only ever read the `kde-smoke` file.
 
 ### `aurora-kde-sabotage`
 

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -292,6 +292,12 @@ def test_aurora_qa_pipeline_exposes_safe_kde_sabotage_modes():
     assert "aurora-test" in runner
 
 
+def test_evaluate_kde_soak_targets_kde_smoke_results():
+    justfile = (ROOT / "Justfile").read_text(encoding="utf-8")
+    assert "scripts/evaluate_kde_soak.py docs/results/aurora-testing-kde-smoke.json" in justfile
+    assert "scripts/evaluate_kde_soak.py docs/results/aurora-testing-smoke.json" not in justfile
+
+
 def test_bluefin_server_build_pipeline_builds_k0s_sysext():
     pipeline_path = ROOT / "argo/workflow-templates/bluefin-server-build-pipeline.yaml"
     assert pipeline_path.exists()


### PR DESCRIPTION
## Summary

Relates to #466 (Gate C: soak to ≥95% pass rate over 30 runs).

Audit of the Gate C tooling revealed that `Justfile` recipe `evaluate-kde-soak` and `docs/reference/WORKFLOWS.md` regressed to pointing at `docs/results/aurora-testing-smoke.json`:
- PR #539 (`381774fc1`) originally corrected `Justfile` and `WORKFLOWS.md` to point to `docs/results/aurora-testing-kde-smoke.json`, which is the actual output file generated by `run-kde-tests` and `publish_test_results.py` when running the `kde-smoke` suite.
- When PR #492 (`3c9e59330`) merged afterward from a branch created before #539, it accidentally reverted `Justfile` and `WORKFLOWS.md` back to the pre-existing generic smoke results file (`aurora-testing-smoke.json`).
- Because of this regression, `just evaluate-kde-soak` reads the wrong dataset and would remain `pending` indefinitely even when real KDE soak runs are recorded.

## Changes

1. `Justfile`: Restore `evaluate-kde-soak` to read `docs/results/aurora-testing-kde-smoke.json`.
2. `docs/reference/WORKFLOWS.md`: Fix the filename reference and restore the note clarifying the distinction between `aurora-testing-kde-smoke.json` and `aurora-testing-smoke.json`.
3. `tests/unit/test_workflow_defaults.py`: Add `test_evaluate_kde_soak_targets_kde_smoke_results` to assert `Justfile` invokes `evaluate_kde_soak.py` against `aurora-testing-kde-smoke.json` and prevent future silent regressions.

## Validation

- `pytest tests/unit/test_workflow_defaults.py tests/unit/test_publish_test_results.py` passed (53 tests).
- `pytest tests/unit/` passed (540 passed, 1 skipped).
- `python3 scripts/evaluate_kde_soak.py docs/results/aurora-testing-kde-smoke.json` executes cleanly against the placeholder.
- `python3 scripts/check_semaphore_topology.py argo/` passed.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `95c2cc406`