### PR TITLE
sec(ci): add top-level permissions blocks to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
 
+permissions:
+  contents: read
+
 jobs:
   test-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ on:
       - ".github/workflows/docs.yml"
       - "*.md"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/example-container-mode-build.yml
+++ b/.github/workflows/example-container-mode-build.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: "testing"
 
+permissions:
+  contents: read
+
 # Container mode requires a container: block on every job. The runner pod is
 # tiny; heavy work is submitted to the cluster as an Argo Workflow so the
 # actual build pods get full cluster resources.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,6 +9,9 @@ on:
   # Allows a manual lint run against any branch.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add minimal top-level permissions block (`permissions: contents: read`) to workflows that were missing one, enforcing the principle of least privilege.

- `.github/workflows/ci.yml`
- `.github/workflows/docs.yml`
- `.github/workflows/lint.yaml`
- `.github/workflows/example-container-mode-build.yml`

Closes projectbluefin/lab#684