### PR TITLE
sec(ci): pin actionlint and verify argo cli download integrity

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,16 +17,23 @@ jobs:
 
       - name: Install argo CLI
         run: |
-          ARGO_VERSION=$(curl -s https://api.github.com/repos/argoproj/argo-workflows/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
-          curl -sLO "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz"
+          ARGO_VERSION="v4.1.3"
+          ARGO_SHA256="f3cf6ae424e9d2b3139efd29f673e7efc47a68881352a26a4122f72c4fc0efd4"
+          curl -sSfL -o argo-linux-amd64.gz "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz"
+          echo "${ARGO_SHA256}  argo-linux-amd64.gz" | sha256sum -c -
           gunzip argo-linux-amd64.gz
           chmod +x argo-linux-amd64
           sudo mv argo-linux-amd64 /usr/local/bin/argo
 
       - name: Install actionlint
         run: |
-          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ACTIONLINT_VERSION="1.7.12"
+          ACTIONLINT_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          curl -sSfL -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
           sudo mv actionlint /usr/local/bin/
+          rm -f actionlint.tar.gz
 
       - name: Lint GitHub Actions workflows
         run: actionlint


### PR DESCRIPTION
Closes projectbluefin/lab#683

### Description
- Replaces pipe-to-bash actionlint installer with pinned `v1.7.12` release tarball and verifies SHA-256 checksum against official release artifacts.
- Pins argo CLI download from dynamic `releases/latest` to exact `v4.1.3` release and validates SHA-256 checksum against official release checksums.