### PR TITLE
sec(ci): pin CI tool downloads with SHA-256 verification and add least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
 
+permissions:
+  contents: read
+
 jobs:
   test-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ on:
       - ".github/workflows/docs.yml"
       - "*.md"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/example-container-mode-build.yml
+++ b/.github/workflows/example-container-mode-build.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: "testing"
 
+permissions:
+  contents: read
+
 # Container mode requires a container: block on every job. The runner pod is
 # tiny; heavy work is submitted to the cluster as an Argo Workflow so the
 # actual build pods get full cluster resources.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,6 +9,9 @@ on:
   # Allows a manual lint run against any branch.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,16 +20,23 @@ jobs:
 
       - name: Install argo CLI
         run: |
-          ARGO_VERSION=$(curl -s https://api.github.com/repos/argoproj/argo-workflows/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
-          curl -sLO "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz"
+          ARGO_VERSION="v4.1.3"
+          ARGO_SHA256="f3cf6ae424e9d2b3139efd29f673e7efc47a68881352a26a4122f72c4fc0efd4"
+          curl -sSfL -o argo-linux-amd64.gz "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz"
+          echo "${ARGO_SHA256}  argo-linux-amd64.gz" | sha256sum -c -
           gunzip argo-linux-amd64.gz
           chmod +x argo-linux-amd64
           sudo mv argo-linux-amd64 /usr/local/bin/argo
 
       - name: Install actionlint
         run: |
-          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ACTIONLINT_VERSION="1.7.12"
+          ACTIONLINT_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          curl -sSfL -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
           sudo mv actionlint /usr/local/bin/
+          rm -f actionlint.tar.gz
 
       - name: Lint GitHub Actions workflows
         run: actionlint

--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -40,9 +40,12 @@ jobs:
       - name: Install oras
         run: |
           ORAS_VER="1.2.3"
-          curl -sSfL \
-            "https://github.com/oras-project/oras/releases/download/v${ORAS_VER}/oras_${ORAS_VER}_linux_amd64.tar.gz" \
-            | tar xz -C /usr/local/bin oras
+          ORAS_SHA256="b4efc97a91f471f323f193ea4b4d63d8ff443ca3aab514151a30751330852827"
+          curl -sSfL -o oras.tar.gz \
+            "https://github.com/oras-project/oras/releases/download/v${ORAS_VER}/oras_${ORAS_VER}_linux_amd64.tar.gz"
+          echo "${ORAS_SHA256}  oras.tar.gz" | sha256sum -c -
+          tar xzf oras.tar.gz -C /usr/local/bin oras
+          rm -f oras.tar.gz
 
       - name: Pull screenshots from GHCR
         env:


### PR DESCRIPTION
Consolidates the three security hardening fixes for CI workflows into one landing (supersedes #752, #753, #754).

## Changes

- **update-test-results.yml**: verify SHA-256 checksum of the pinned oras 1.2.3 tarball against the official release checksum before extraction (previously piped straight to `tar` in a scheduled workflow holding `packages: read`).
- **lint.yaml**: replace pipe-to-bash actionlint install from the mutable `main` branch with the pinned v1.7.12 release tarball + SHA-256 verification; pin argo CLI from dynamic `releases/latest` to exact v4.1.3 + SHA-256 verification.
- **ci.yml, docs.yml, lint.yaml, example-container-mode-build.yml**: add top-level `permissions: contents: read` so jobs no longer inherit the repository default token scope. (`update-test-results.yml`, `derive.yml`, `iso-e2e-dispatch.yml` already declare explicit permissions.)

All three SHA-256 values verified against the official upstream release checksums (oras_project/oras v1.2.3, rhysd/actionlint v1.7.12, argoproj/argo-workflows v4.1.3). The `lint` job exercises the pinned downloads on this PR; no workflow losing its default token performs any `GITHUB_TOKEN` write.

Closes projectbluefin/lab#683
Closes projectbluefin/lab#684
Closes projectbluefin/lab#685