### PR TITLE
ci: expose SHA-pinned on-demand Dakota lab validation

### DIFF
--- a/.github/workflows/dakota-validation-dispatch.yml
+++ b/.github/workflows/dakota-validation-dispatch.yml
@@ -1,0 +1,60 @@
+name: Dakota lab validation dispatch
+
+on:
+  repository_dispatch:
+    types: [dakota-validation, dakota-bst-qa]
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Target repository (must be projectbluefin/dakota)"
+        required: true
+        default: "projectbluefin/dakota"
+      validation_class:
+        description: "Validation class (must be dakota-bst-qa)"
+        required: true
+        default: "dakota-bst-qa"
+      pr_number:
+        description: "Pull request number"
+        required: true
+      sha:
+        description: "Exact 40-character current head commit SHA"
+        required: true
+      rerun:
+        description: "Allow explicit rerun of terminal validation (true/false)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  submit-dakota-validation:
+    name: Submit Dakota validation to Argo
+    runs-on: ghost-runners
+    timeout-minutes: 30
+    container:
+      image: ghcr.io/projectbluefin/arc-runner:latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate and submit Dakota lab validation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.event.client_payload.repository || github.event.inputs.repository || 'projectbluefin/dakota' }}
+          VALIDATION_CLASS: ${{ github.event.client_payload.validation_class || github.event.client_payload.class || github.event.inputs.validation_class || 'dakota-bst-qa' }}
+          PR_NUMBER: ${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}
+          SHA: ${{ github.event.client_payload.sha || github.event.inputs.sha }}
+          RERUN: ${{ github.event.client_payload.rerun || github.event.inputs.rerun || 'false' }}
+        run: |
+          set -euo pipefail
+          RERUN_FLAG=""
+          if [[ "${RERUN}" == "true" ]]; then
+            RERUN_FLAG="--rerun"
+          fi
+          python3 scripts/dakota_validation.py request \
+            --repo "${REPO}" \
+            --validation-class "${VALIDATION_CLASS}" \
+            --pr-number "${PR_NUMBER}" \
+            --sha "${SHA}" \
+            ${RERUN_FLAG}

--- a/Justfile
+++ b/Justfile
@@ -274,6 +274,25 @@ run-kernel-args:
 
 # ── Dakota BST builds ────────────────────────────────────────────────────────
 
+# Request on-demand Dakota lab validation for a PR and exact head SHA
+# Usage: just dakota-validate-request pr_number sha [validation_class=dakota-bst-qa]
+dakota-validate-request pr_number sha validation_class="dakota-bst-qa" *args:
+    python3 scripts/dakota_validation.py request \
+      --repo projectbluefin/dakota \
+      --validation-class "{{ validation_class }}" \
+      --pr-number {{ pr_number }} \
+      --sha {{ sha }} \
+      {{ args }}
+
+# Query on-demand Dakota lab validation status for a PR and exact SHA
+# Usage: just dakota-validate-status pr_number sha [validation_class=dakota-bst-qa]
+dakota-validate-status pr_number sha validation_class="dakota-bst-qa":
+    python3 scripts/dakota_validation.py status \
+      --repo projectbluefin/dakota \
+      --validation-class "{{ validation_class }}" \
+      --pr-number {{ pr_number }} \
+      --sha {{ sha }}
+
 # Show the MergeRaptor-owned lab Check Run for a PR head commit.
 # Usage: just lab-check-status <repo> <pr_number>
 lab-check-status repo pr_number:

--- a/argo/workflow-templates/dakota-bst-qa.yaml
+++ b/argo/workflow-templates/dakota-bst-qa.yaml
@@ -1,0 +1,154 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: dakota-bst-qa
+  namespace: argo
+  annotations:
+    description: |
+      On-demand SHA-pinned Dakota lab validation pipeline.
+      Executes the existing Dakota BuildStream build followed by full container QA
+      for the exact commit SHA, publishing lifecycle evidence back to GitHub.
+  labels:
+    app.kubernetes.io/component: dakota-bst-qa
+    app.kubernetes.io/part-of: bluefin-test-suite
+spec:
+  serviceAccountName: argo
+  workflowMetadata:
+    labels:
+      bluefin.io/evidence-contract: qa-run-v1
+      bluefin.io/trigger: on-demand
+      bluefin.io/validation-class: dakota-bst-qa
+      bluefin.io/bst-workload: "true"
+  activeDeadlineSeconds: 90000
+  entrypoint: pipeline
+  onExit: report-final
+  arguments:
+    parameters:
+      - name: repository
+        value: "projectbluefin/dakota"
+      - name: pr-number
+        value: ""
+      - name: commit-sha
+        value: ""
+      - name: validation-class
+        value: "dakota-bst-qa"
+      - name: ref
+        value: "testing"
+      - name: repo
+        value: "https://github.com/projectbluefin/dakota.git"
+      - name: image-tag
+        value: ""
+      - name: registry
+        value: "192.168.1.102:30500"
+      - name: build-mode
+        value: "re"
+      - name: lock-key
+        value: "bst-build"
+      - name: image
+        value: "192.168.1.102:30500/dakota"
+      - name: suites
+        value: "smoke,common,developer,software,system"
+      - name: variant
+        value: "dakota"
+      - name: branch
+        value: "main"
+      - name: testsuite-branch
+        value: "main"
+      - name: testsuite-repo
+        value: "https://github.com/projectbluefin/testsuite"
+      - name: workflow-url
+        value: ""
+
+  templates:
+    - name: pipeline
+      dag:
+        tasks:
+          - name: report-start
+            templateRef:
+              name: github-status-reporter
+              template: send
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{workflow.parameters.repository}}"
+                - name: sha
+                  value: "{{workflow.parameters.commit-sha}}"
+                - name: pr-number
+                  value: "{{workflow.parameters.pr-number}}"
+                - name: state
+                  value: in_progress
+                - name: conclusion
+                  value: ""
+                - name: workflow-name
+                  value: "{{workflow.name}}"
+                - name: workflow-url
+                  value: "http://192.168.1.102:2746/workflows/argo/{{workflow.name}}"
+                - name: title
+                  value: "Dakota lab validation is running"
+                - name: summary
+                  value: "The lab admitted Dakota PR #{{workflow.parameters.pr-number}} at commit {{workflow.parameters.commit-sha}}."
+
+          - name: build
+            depends: "(report-start.Succeeded || report-start.Failed || report-start.Errored)"
+            templateRef:
+              name: dakota-build-pipeline
+              template: build
+            arguments:
+              parameters:
+                - name: ref
+                  value: "{{workflow.parameters.ref}}"
+                - name: commit-sha
+                  value: "{{workflow.parameters.commit-sha}}"
+                - name: repo
+                  value: "{{workflow.parameters.repo}}"
+                - name: image-tag
+                  value: "{{workflow.parameters.commit-sha}}"
+                - name: registry
+                  value: "{{workflow.parameters.registry}}"
+                - name: build-mode
+                  value: "{{workflow.parameters.build-mode}}"
+                - name: lock-key
+                  value: "{{workflow.parameters.lock-key}}"
+
+          - name: qa-dakota
+            depends: "build.Succeeded"
+            templateRef:
+              name: dakota-qa-pipeline
+              template: pipeline
+            arguments:
+              parameters:
+                - name: image
+                  value: "{{workflow.parameters.image}}"
+                - name: image-tag
+                  value: "{{workflow.parameters.commit-sha}}"
+                - name: image-digest
+                  value: ""
+                - name: suites
+                  value: "{{workflow.parameters.suites}}"
+                - name: variant
+                  value: "{{workflow.parameters.variant}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+                - name: testsuite-branch
+                  value: "{{workflow.parameters.testsuite-branch}}"
+                - name: testsuite-repo
+                  value: "{{workflow.parameters.testsuite-repo}}"
+
+    - name: report-final
+      steps:
+        - - name: status-report
+            templateRef:
+              name: github-status-reporter
+              template: final
+            arguments:
+              parameters:
+                - name: repository
+                  value: "{{workflow.parameters.repository}}"
+                - name: sha
+                  value: "{{workflow.parameters.commit-sha}}"
+                - name: pr-number
+                  value: "{{workflow.parameters.pr-number}}"
+                - name: final-status
+                  value: "{{workflow.status}}"
+                - name: workflow-url
+                  value: "http://192.168.1.102:2746/workflows/argo/{{workflow.name}}"

--- a/argo/workflow-templates/github-status-reporter.yaml
+++ b/argo/workflow-templates/github-status-reporter.yaml
@@ -96,7 +96,7 @@ spec:
           # Explicit allowlist: the lab token must never write statuses to an
           # arbitrary repository derived from workflow parameters.
           case "${REPOSITORY}" in
-            projectbluefin/testsuite|projectbluefin/server) ;;
+            projectbluefin/testsuite|projectbluefin/server|projectbluefin/dakota) ;;
             *) echo "Refusing status for ${REPOSITORY}" >&2; exit 1 ;;
           esac
           [[ "${SHA}" =~ ^[0-9a-f]{40}$ ]] ||

--- a/docs/reference/WORKFLOWS.md
+++ b/docs/reference/WORKFLOWS.md
@@ -457,6 +457,43 @@ just run-dakota-validate              # bst show only, ~5 min
 just run-dakota-build                 # default + nvidia variants
 ```
 
+### `dakota-bst-qa` (On-Demand SHA-Pinned Dakota Validation)
+
+Exposes on-demand, SHA-bound Dakota lab validation to reviewers and repository
+automation (`review`) without requiring cluster credentials. Executes the
+full Dakota BuildStream build followed by container QA against local Zot.
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `repository` | `projectbluefin/dakota` | Fixed target repository. |
+| `pr-number` | *(required)* | Open Dakota PR number. |
+| `commit-sha` | *(required)* | Exact 40-character commit SHA matching current PR head. |
+| `validation-class` | `dakota-bst-qa` | Fixed validation class. |
+| `ref` | `testing` | Dakota branch ref. |
+| `build-mode` | `re` | BuildStream remote execution mode. |
+
+```bash
+# Request on-demand validation
+just dakota-validate-request <pr_number> <sha>
+
+# Query validation status
+just dakota-validate-status <pr_number> <sha>
+```
+
+Contract rules:
+- **Preflight rejection**: Rejects requests for unsupported repo, unsupported class,
+  malformed SHA, closed PRs, or head SHA mismatch before submitting to the cluster.
+- **Deduplication**: Active (`queued` or `running`) requests for the same PR and SHA
+  are deduped rather than launching duplicate workflows.
+- **Terminal rerun**: Terminal workflows (`success`, `failure`, `cancelled`, `timeout`)
+  can be rerun explicitly with `--rerun`.
+- **SHA isolation**: Evidence from SHA A never applies to SHA B; queries for SHA B
+  report `unavailable` if SHA B has not been validated.
+- **Reporting states**: Exactly 8 canonical lifecycle states:
+  `unavailable`, `rejected`, `queued`, `running`, `success`, `failure`, `cancelled`, `timeout`.
+- **GitHub evidence**: Publishes `testing-lab/dakota-bst-qa` commit status and optional
+  `lab-check` repository dispatch on admission, execution, and exit.
+
 ### Dakota durable build/publish records
 
 `scripts/publish_dakota_run.py` is the workflow-independent producer for

--- a/docs/skills/dakota-pr-review/SKILL.md
+++ b/docs/skills/dakota-pr-review/SKILL.md
@@ -32,9 +32,9 @@ Dakota PR review is a lab-backed admission process. GitHub Actions status is adv
 
 1. Confirm the PR number, target branch, head SHA, and that it is still open and mergeable.
 2. Do not treat `pr/needs-review`, `automerge`, or `chore/deps` labels as approval. Verify maintainer approval when the repository policy requires it.
-3. Build the exact PR head SHA with `dakota-build-pipeline` in distributed (`re`) mode. Use the live WorkflowTemplate parameters; do not guess them.
-4. Test the resulting image with `dakota-container-qa-pipeline` (image smoke checks) and, when the image supports it, `dakota-qa-pipeline`/`run-container-tests` for the full containerized BDD/GUI suites.
-5. Keep each build serialized by the `bst-build` semaphore. Never start competing Dakota BST builds; queue them and process one PR at a time.
+3. Request or dispatch on-demand SHA-pinned lab validation via validation class `dakota-bst-qa` (using `dakota-validation` dispatch via GitHub Actions if cluster credentials are not available, or `just dakota-validate-request <pr> <sha>`).
+4. Build the exact PR head SHA with `dakota-build-pipeline` in distributed (`re`) mode, followed by `dakota-qa-pipeline` for containerized acceptance suites.
+5. Keep each build serialized by the `bst-build` semaphore. Never start competing Dakota BST builds; queue them and process one PR at a time. Active requests for the same SHA are automatically deduped.
 6. Capture Argo workflow names, exact SHAs, build mode, test result, and failure logs. A pass must be tied to the same commit that will be merged.
 7. If build and E2E pass, recheck the PR head and mergeability, then merge directly. Do not use GitHub merge queue for this process: queue promotion has historically evaluated the wrong/stale commit when GHA is failing.
 8. If lab validation fails, do not merge. Classify infrastructure failures separately from source/test failures and rerun only after the blocker is fixed.

--- a/scripts/dakota_validation.py
+++ b/scripts/dakota_validation.py
@@ -1,0 +1,759 @@
+#!/usr/bin/env python3
+"""On-demand SHA-pinned Dakota lab validation.
+
+Provides a bounded request, deduplication, submission, lifecycle tracking,
+and reporting contract for projectbluefin/dakota pull requests under
+validation class dakota-bst-qa.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+SUPPORTED_REPOSITORY = "projectbluefin/dakota"
+SUPPORTED_VALIDATION_CLASS = "dakota-bst-qa"
+STATUS_CONTEXT = "testing-lab/dakota-bst-qa"
+ARGO_NAMESPACE = "argo"
+DEFAULT_ARGO_URL_BASE = "http://192.168.1.102:2746/workflows/argo"
+
+VALID_STATUSES = {
+    "unavailable",
+    "rejected",
+    "queued",
+    "running",
+    "success",
+    "failure",
+    "cancelled",
+    "timeout",
+}
+TERMINAL_STATUSES = {"success", "failure", "cancelled", "timeout", "rejected"}
+ACTIVE_STATUSES = {"queued", "running"}
+
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class ValidationError(ValueError):
+    """Raised when request validation fails."""
+
+
+def validate_request_parameters(
+    repository: str,
+    validation_class: str,
+    pr_number: int | str,
+    sha: str,
+) -> tuple[bool, str]:
+    """Validate request parameters before contacting external APIs."""
+    if repository != SUPPORTED_REPOSITORY:
+        return False, f"unsupported repository: {repository!r} (expected {SUPPORTED_REPOSITORY!r})"
+    if validation_class != SUPPORTED_VALIDATION_CLASS:
+        return (
+            False,
+            f"unsupported validation class: {validation_class!r} (expected {SUPPORTED_VALIDATION_CLASS!r})",
+        )
+    if not isinstance(sha, str) or not SHA_RE.match(sha):
+        return False, f"malformed commit SHA: {sha!r} (expected 40-character hexadecimal SHA)"
+    try:
+        pr_num = int(pr_number)
+        if pr_num <= 0:
+            return False, f"invalid PR number: {pr_number} (must be positive integer)"
+    except (ValueError, TypeError):
+        return False, f"invalid PR number: {pr_number} (must be positive integer)"
+    return True, ""
+
+
+def check_live_pr_head(
+    repository: str,
+    pr_number: int,
+    sha: str,
+    token: str | None = None,
+    api_base: str = "https://api.github.com",
+    fetcher: Callable[[str, dict[str, str]], tuple[int, dict[str, Any]]] | None = None,
+) -> tuple[bool, str, dict[str, Any]]:
+    """Validate that the PR exists on GitHub, is open, and head SHA matches requested SHA."""
+    pr_url = f"{api_base}/repos/{repository}/pulls/{pr_number}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "bluefin-lab-dakota-validation",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    if fetcher is not None:
+        status_code, data = fetcher(pr_url, headers)
+    else:
+        req = urllib.request.Request(pr_url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                status_code = resp.status
+                data = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            status_code = exc.code
+            try:
+                data = json.loads(exc.read().decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                data = {}
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            return False, f"network error fetching PR #{pr_number}: {exc}", {}
+
+    if status_code == 404:
+        return False, f"PR #{pr_number} not found in {repository}", data
+    if status_code != 200:
+        return (
+            False,
+            f"GitHub API error fetching PR #{pr_number}: HTTP {status_code} ({data.get('message', '')})",
+            data,
+        )
+
+    state = data.get("state", "").lower()
+    if state != "open":
+        return False, f"closed PR: PR #{pr_number} is {state}", data
+
+    live_sha = data.get("head", {}).get("sha", "")
+    if live_sha.lower() != sha.lower():
+        return (
+            False,
+            f"head mismatch: requested SHA {sha.lower()} does not match current PR head SHA {live_sha.lower()}",
+            data,
+        )
+
+    return True, "", data
+
+
+def parse_workflow_status(wf: dict[str, Any]) -> str:
+    """Map an Argo workflow dictionary to one of the 8 canonical statuses."""
+    status_obj = wf.get("status", {})
+    phase = status_obj.get("phase", "")
+    shutdown = wf.get("spec", {}).get("shutdown", "")
+
+    if shutdown == "Stop":
+        return "cancelled"
+
+    if phase == "Succeeded":
+        return "success"
+    if phase in ("Failed", "Error"):
+        message = status_obj.get("message", "").lower()
+        for node in status_obj.get("nodes", {}).values():
+            if "deadline exceeded" in node.get("message", "").lower():
+                return "timeout"
+        if "deadline exceeded" in message or "timeout" in message:
+            return "timeout"
+        if "stopped" in message or "shutdown" in message:
+            return "cancelled"
+        return "failure"
+    if phase == "Running":
+        return "running"
+    if phase in ("Pending", ""):
+        return "queued"
+    return "running"
+
+
+def get_existing_workflows(
+    pr_number: int,
+    sha: str,
+    repository: str = SUPPORTED_REPOSITORY,
+    runner: Callable[[list[str]], str] | None = None,
+) -> list[dict[str, Any]]:
+    """Query Argo workflows matching this repository, PR number, and exact SHA."""
+    product = repository.split("/")[-1]
+    sha12 = sha[:12].lower()
+
+    if runner is not None:
+        cmd = [
+            "kubectl",
+            "get",
+            "workflows",
+            "-n",
+            ARGO_NAMESPACE,
+            "-l",
+            f"bluefin.io/repository={product},bluefin.io/pr-number={pr_number},bluefin.io/pr-sha={sha12}",
+            "-o",
+            "json",
+        ]
+        raw_output = runner(cmd)
+    else:
+        cmd = [
+            "kubectl",
+            "get",
+            "workflows",
+            "-n",
+            ARGO_NAMESPACE,
+            "-l",
+            f"bluefin.io/repository={product},bluefin.io/pr-number={pr_number},bluefin.io/pr-sha={sha12}",
+            "-o",
+            "json",
+        ]
+        try:
+            res = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+            raw_output = res.stdout
+        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+            return []
+
+    try:
+        data = json.loads(raw_output)
+    except json.JSONDecodeError:
+        return []
+
+    matching = []
+    for item in data.get("items", []):
+        # Strict validation: commit-sha parameter MUST match exact full SHA
+        item_sha = ""
+        params = (
+            item.get("spec", {}).get("arguments", {}).get("parameters", [])
+        )
+        for param in params:
+            if param.get("name") == "commit-sha":
+                item_sha = param.get("value", "")
+                break
+        if not item_sha:
+            item_sha = item.get("metadata", {}).get("labels", {}).get("bluefin.io/pr-sha", "")
+
+        # Only match if commit-sha matches exact 40-character SHA
+        # (or prefix if full sha not stored in legacy wfs)
+        if item_sha.lower() == sha.lower():
+            matching.append(item)
+    return matching
+
+
+def render_workflow_manifest(
+    repository: str,
+    pr_number: int,
+    sha: str,
+    validation_class: str = SUPPORTED_VALIDATION_CLASS,
+) -> dict[str, Any]:
+    """Render the Argo Workflow manifest for on-demand Dakota validation."""
+    product = repository.split("/")[-1]
+    sha12 = sha[:12].lower()
+    return {
+        "apiVersion": "argoproj.io/v1alpha1",
+        "kind": "Workflow",
+        "metadata": {
+            "generateName": f"dakota-val-{pr_number}-{sha12}-",
+            "namespace": ARGO_NAMESPACE,
+            "labels": {
+                "bluefin.io/trigger": "on-demand",
+                "bluefin.io/validation-class": validation_class,
+                "bluefin.io/repository": product,
+                "bluefin.io/pr-number": str(pr_number),
+                "bluefin.io/pr-sha": sha12,
+                "bluefin.io/bst-workload": "true",
+            },
+        },
+        "spec": {
+            "serviceAccountName": "argo",
+            "activeDeadlineSeconds": 90000,
+            "workflowTemplateRef": {"name": validation_class},
+            "arguments": {
+                "parameters": [
+                    {"name": "repository", "value": repository},
+                    {"name": "pr-number", "value": str(pr_number)},
+                    {"name": "commit-sha", "value": sha},
+                    {"name": "validation-class", "value": validation_class},
+                ]
+            },
+        },
+    }
+
+
+def publish_github_evidence(
+    repository: str,
+    sha: str,
+    pr_number: int,
+    status: str,
+    token: str | None = None,
+    workflow_name: str = "",
+    workflow_url: str = "",
+    message: str = "",
+    api_base: str = "https://api.github.com",
+    poster: Callable[[str, str, dict[str, Any]], tuple[int, str]] | None = None,
+) -> tuple[bool, str]:
+    """Publish commit status and optional repository dispatch evidence against the exact SHA."""
+    if not token and poster is None:
+        return False, "no GitHub token available to publish evidence"
+
+    state_map = {
+        "queued": "pending",
+        "running": "pending",
+        "success": "success",
+        "failure": "failure",
+        "rejected": "failure",
+        "cancelled": "error",
+        "timeout": "error",
+    }
+    gh_state = state_map.get(status, "error")
+
+    if not message:
+        message_map = {
+            "queued": f"Dakota lab validation queued for PR #{pr_number}",
+            "running": f"Dakota lab validation running in {workflow_name or 'Argo'}",
+            "success": f"Dakota lab validation succeeded for PR #{pr_number}",
+            "failure": f"Dakota lab validation failed for PR #{pr_number}",
+            "rejected": f"Dakota lab validation rejected for PR #{pr_number}",
+            "cancelled": f"Dakota lab validation cancelled for PR #{pr_number}",
+            "timeout": f"Dakota lab validation timed out for PR #{pr_number}",
+        }
+        message = message_map.get(status, f"Dakota lab validation: {status}")
+
+    # Clip description to 140 characters per GitHub Commit Status limit
+    description = message[:140]
+
+    status_payload = {
+        "state": gh_state,
+        "context": STATUS_CONTEXT,
+        "description": description,
+    }
+    if workflow_url and workflow_url.startswith(("http://", "https://")):
+        status_payload["target_url"] = workflow_url
+
+    status_url = f"{api_base}/repos/{repository}/statuses/{sha}"
+
+    if poster is not None:
+        http_code, resp_body = poster("POST", status_url, status_payload)
+    else:
+        req = urllib.request.Request(
+            status_url,
+            data=json.dumps(status_payload).encode("utf-8"),
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "Content-Type": "application/json",
+                "User-Agent": "bluefin-lab-dakota-validation",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                http_code = resp.status
+                resp_body = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            http_code = exc.code
+            resp_body = exc.read().decode("utf-8")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            return False, f"network error publishing status: {exc}"
+
+    if http_code not in (200, 201):
+        return False, f"GitHub commit status returned HTTP {http_code}: {resp_body}"
+
+    # Also attempt dispatching MergeRaptor lab-check event if receiver is active
+    dispatch_payload = {
+        "event_type": "lab-check",
+        "client_payload": {
+            "repository": repository,
+            "sha": sha,
+            "check": {
+                "pr_number": str(pr_number),
+                "state": "in_progress" if status == "running" else ("completed" if status in TERMINAL_STATUSES else "queued"),
+                "conclusion": "success" if status == "success" else ("failure" if status in ("failure", "rejected") else ("timed_out" if status == "timeout" else ("cancelled" if status == "cancelled" else ""))),
+                "external_id": workflow_name,
+                "details_url": workflow_url,
+                "title": f"Dakota lab validation: {status}",
+                "summary": description,
+                "text": "",
+                "started_at": "",
+                "completed_at": "",
+            },
+        },
+    }
+    dispatch_url = f"{api_base}/repos/{repository}/dispatches"
+    if poster is not None:
+        poster("POST", dispatch_url, dispatch_payload)
+    else:
+        try:
+            d_req = urllib.request.Request(
+                dispatch_url,
+                data=json.dumps(dispatch_payload).encode("utf-8"),
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {token}",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    "Content-Type": "application/json",
+                    "User-Agent": "bluefin-lab-dakota-validation",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(d_req, timeout=30):
+                pass
+        except (urllib.error.URLError, TimeoutError, OSError):
+            # Advisory dispatch: receiver may be disabled, status write succeeded
+            pass
+
+    return True, "published"
+
+
+def submit_validation_request(
+    repository: str,
+    validation_class: str,
+    pr_number: int | str,
+    sha: str,
+    rerun: bool = False,
+    token: str | None = None,
+    runner: Callable[[list[str]], str] | None = None,
+    creator: Callable[[dict[str, Any]], str] | None = None,
+    fetcher: Callable[[str, dict[str, str]], tuple[int, dict[str, Any]]] | None = None,
+    poster: Callable[[str, str, dict[str, Any]], tuple[int, str]] | None = None,
+    api_base: str = "https://api.github.com",
+    publish: bool = True,
+) -> dict[str, Any]:
+    """Execute the full preflight, deduplication, admission, submission, and reporting contract."""
+    # 1. Parameter syntax and scope check
+    valid, err = validate_request_parameters(repository, validation_class, pr_number, sha)
+    if not valid:
+        result = {
+            "status": "rejected",
+            "repository": repository,
+            "validation_class": validation_class,
+            "pr_number": pr_number,
+            "sha": sha,
+            "message": f"Request rejected: {err}",
+            "reason": err,
+        }
+        if publish and token:
+            publish_github_evidence(
+                repository, sha, int(pr_number) if str(pr_number).isdigit() else 0,
+                "rejected", token, message=err, api_base=api_base, poster=poster
+            )
+        return result
+
+    pr_num = int(pr_number)
+
+    # 2. Live PR head validation before submission
+    valid_head, head_err, _pr_data = check_live_pr_head(
+        repository, pr_num, sha, token=token, api_base=api_base, fetcher=fetcher
+    )
+    if not valid_head:
+        result = {
+            "status": "rejected",
+            "repository": repository,
+            "validation_class": validation_class,
+            "pr_number": pr_num,
+            "sha": sha,
+            "message": f"Request rejected: {head_err}",
+            "reason": head_err,
+        }
+        if publish and token:
+            publish_github_evidence(
+                repository, sha, pr_num, "rejected", token, message=head_err,
+                api_base=api_base, poster=poster
+            )
+        return result
+
+    # 3. Deduplication and terminal rerun inspection
+    existing = get_existing_workflows(pr_num, sha, repository=repository, runner=runner)
+
+    active_wf = None
+    terminal_wf = None
+    for wf in existing:
+        wf_status = parse_workflow_status(wf)
+        if wf_status in ACTIVE_STATUSES:
+            active_wf = (wf, wf_status)
+            break
+        if wf_status in TERMINAL_STATUSES:
+            terminal_wf = (wf, wf_status)
+
+    # Dedupe identical active requests
+    if active_wf is not None:
+        wf, wf_status = active_wf
+        wf_name = wf.get("metadata", {}).get("name", "")
+        wf_url = f"{DEFAULT_ARGO_URL_BASE}/{wf_name}"
+        return {
+            "status": wf_status,
+            "repository": repository,
+            "validation_class": validation_class,
+            "pr_number": pr_num,
+            "sha": sha,
+            "workflow_name": wf_name,
+            "workflow_url": wf_url,
+            "deduped": True,
+            "rerun": False,
+            "message": f"Active validation workflow {wf_name} already running for PR #{pr_num} at {sha}",
+        }
+
+    # Allow explicit terminal rerun
+    if terminal_wf is not None and not rerun:
+        wf, wf_status = terminal_wf
+        wf_name = wf.get("metadata", {}).get("name", "")
+        wf_url = f"{DEFAULT_ARGO_URL_BASE}/{wf_name}"
+        return {
+            "status": wf_status,
+            "repository": repository,
+            "validation_class": validation_class,
+            "pr_number": pr_num,
+            "sha": sha,
+            "workflow_name": wf_name,
+            "workflow_url": wf_url,
+            "deduped": True,
+            "rerun": False,
+            "message": f"Terminal validation workflow {wf_name} exists for PR #{pr_num} at {sha} ({wf_status}). Pass rerun=true to rerun.",
+        }
+
+    # 4. Submit new workflow for this exact SHA
+    manifest = render_workflow_manifest(repository, pr_num, sha, validation_class)
+    if creator is not None:
+        wf_name = creator(manifest)
+    else:
+        cmd = ["kubectl", "create", "-f", "-", "-o", "jsonpath={.metadata.name}"]
+        try:
+            res = subprocess.run(
+                cmd,
+                input=json.dumps(manifest),
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            wf_name = res.stdout.strip()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            return {
+                "status": "failure",
+                "repository": repository,
+                "validation_class": validation_class,
+                "pr_number": pr_num,
+                "sha": sha,
+                "message": f"Failed to submit workflow to Argo: {exc}",
+            }
+
+    wf_url = f"{DEFAULT_ARGO_URL_BASE}/{wf_name}"
+
+    # 5. Publish queued evidence against exact SHA
+    if publish and token:
+        publish_github_evidence(
+            repository, sha, pr_num, "queued", token,
+            workflow_name=wf_name, workflow_url=wf_url,
+            message=f"Dakota lab validation queued as {wf_name}",
+            api_base=api_base, poster=poster,
+        )
+
+    return {
+        "status": "queued",
+        "repository": repository,
+        "validation_class": validation_class,
+        "pr_number": pr_num,
+        "sha": sha,
+        "workflow_name": wf_name,
+        "workflow_url": wf_url,
+        "deduped": False,
+        "rerun": rerun,
+        "message": f"Dispatched Dakota lab validation workflow {wf_name} for PR #{pr_num} at {sha}",
+    }
+
+
+def query_validation_status(
+    repository: str,
+    validation_class: str,
+    pr_number: int | str,
+    sha: str,
+    runner: Callable[[list[str]], str] | None = None,
+    token: str | None = None,
+    api_base: str = "https://api.github.com",
+    fetcher: Callable[[str, dict[str, str]], tuple[int, dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Query validation status for a PR and SHA. Returns one of the 8 canonical statuses."""
+    valid, err = validate_request_parameters(repository, validation_class, pr_number, sha)
+    if not valid:
+        return {
+            "status": "rejected",
+            "repository": repository,
+            "validation_class": validation_class,
+            "pr_number": pr_number,
+            "sha": sha,
+            "message": err,
+        }
+
+    pr_num = int(pr_number)
+
+    # 1. Search cluster workflows for exact PR and exact SHA
+    existing = get_existing_workflows(pr_num, sha, repository=repository, runner=runner)
+    if existing:
+        # Latest workflow for this SHA wins
+        latest = existing[-1]
+        st = parse_workflow_status(latest)
+        wf_name = latest.get("metadata", {}).get("name", "")
+        wf_url = f"{DEFAULT_ARGO_URL_BASE}/{wf_name}"
+        return {
+            "status": st,
+            "repository": repository,
+            "validation_class": validation_class,
+            "pr_number": pr_num,
+            "sha": sha,
+            "workflow_name": wf_name,
+            "workflow_url": wf_url,
+            "message": f"Workflow {wf_name} is {st}",
+        }
+
+    # 2. If not found in cluster, check GitHub commit statuses for this exact SHA
+    if token or fetcher is not None:
+        status_url = f"{api_base}/repos/{repository}/commits/{sha}/statuses"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "bluefin-lab-dakota-validation",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        if fetcher is not None:
+            code, statuses = fetcher(status_url, headers)
+        else:
+            try:
+                req = urllib.request.Request(status_url, headers=headers)
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    code = resp.status
+                    statuses = json.loads(resp.read().decode("utf-8"))
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+                code, statuses = 500, []
+
+        if code == 200 and isinstance(statuses, list):
+            for item in statuses:
+                if item.get("context") == STATUS_CONTEXT:
+                    gh_state = item.get("state")
+                    desc = item.get("description", "").lower()
+                    target_url = item.get("target_url", "")
+                    if gh_state == "pending":
+                        st = "queued" if "queued" in desc else "running"
+                    elif gh_state == "success":
+                        st = "success"
+                    elif gh_state == "failure":
+                        st = "rejected" if "rejected" in desc else "failure"
+                    elif gh_state == "error":
+                        if "cancelled" in desc:
+                            st = "cancelled"
+                        elif "timed out" in desc or "timeout" in desc:
+                            st = "timeout"
+                        else:
+                            st = "failure"
+                    else:
+                        st = "unavailable"
+                    return {
+                        "status": st,
+                        "repository": repository,
+                        "validation_class": validation_class,
+                        "pr_number": pr_num,
+                        "sha": sha,
+                        "workflow_name": target_url.rsplit("/", 1)[-1] if target_url else "",
+                        "workflow_url": target_url,
+                        "message": item.get("description", ""),
+                    }
+
+    # Evidence from SHA A never applies to SHA B. If no evidence exists for this SHA:
+    return {
+        "status": "unavailable",
+        "repository": repository,
+        "validation_class": validation_class,
+        "pr_number": pr_num,
+        "sha": sha,
+        "message": f"No validation evidence found for SHA {sha}",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="On-demand SHA-pinned Dakota lab validation tool."
+    )
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+
+    # Subcommand: request
+    req_parser = subparsers.add_parser("request", help="Submit or dedupe a validation request.")
+    req_parser.add_argument("--repo", default=SUPPORTED_REPOSITORY, help="Repository")
+    req_parser.add_argument(
+        "--validation-class", default=SUPPORTED_VALIDATION_CLASS, help="Validation class"
+    )
+    req_parser.add_argument("--pr-number", required=True, help="PR number")
+    req_parser.add_argument("--sha", required=True, help="Exact 40-character commit SHA")
+    req_parser.add_argument(
+        "--rerun", action="store_true", default=False, help="Allow explicit rerun of terminal runs"
+    )
+    req_parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"),
+        help="GitHub token",
+    )
+    req_parser.add_argument(
+        "--no-publish", dest="publish", action="store_false", default=True, help="Disable GitHub evidence publishing"
+    )
+
+    # Subcommand: status
+    stat_parser = subparsers.add_parser("status", help="Query validation status for a PR and SHA.")
+    stat_parser.add_argument("--repo", default=SUPPORTED_REPOSITORY, help="Repository")
+    stat_parser.add_argument(
+        "--validation-class", default=SUPPORTED_VALIDATION_CLASS, help="Validation class"
+    )
+    stat_parser.add_argument("--pr-number", required=True, help="PR number")
+    stat_parser.add_argument("--sha", required=True, help="Exact 40-character commit SHA")
+    stat_parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"),
+        help="GitHub token",
+    )
+
+    # Subcommand: publish
+    pub_parser = subparsers.add_parser("publish", help="Publish validation evidence for a SHA.")
+    pub_parser.add_argument("--repo", default=SUPPORTED_REPOSITORY, help="Repository")
+    pub_parser.add_argument("--pr-number", required=True, help="PR number")
+    pub_parser.add_argument("--sha", required=True, help="Commit SHA")
+    pub_parser.add_argument(
+        "--status", required=True, choices=sorted(VALID_STATUSES), help="Validation status"
+    )
+    pub_parser.add_argument("--workflow-name", default="", help="Argo workflow name")
+    pub_parser.add_argument("--workflow-url", default="", help="Argo workflow URL")
+    pub_parser.add_argument("--message", default="", help="Status description")
+    pub_parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"),
+        help="GitHub token",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.subcommand == "request":
+        res = submit_validation_request(
+            repository=args.repo,
+            validation_class=args.validation_class,
+            pr_number=args.pr_number,
+            sha=args.sha,
+            rerun=args.rerun,
+            token=args.token,
+            publish=args.publish,
+        )
+        print(json.dumps(res, indent=2))
+        return 1 if res.get("status") == "rejected" else 0
+
+    if args.subcommand == "status":
+        res = query_validation_status(
+            repository=args.repo,
+            validation_class=args.validation_class,
+            pr_number=args.pr_number,
+            sha=args.sha,
+            token=args.token,
+        )
+        print(json.dumps(res, indent=2))
+        return 0
+
+    if args.subcommand == "publish":
+        ok, msg = publish_github_evidence(
+            repository=args.repo,
+            sha=args.sha,
+            pr_number=int(args.pr_number),
+            status=args.status,
+            token=args.token,
+            workflow_name=args.workflow_name,
+            workflow_url=args.workflow_url,
+            message=args.message,
+        )
+        print(json.dumps({"success": ok, "message": msg}, indent=2))
+        return 0 if ok else 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_dakota_validation.py
+++ b/tests/unit/test_dakota_validation.py
@@ -1,0 +1,559 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import dakota_validation as dv
+
+
+def mock_pr_data(number=101, sha="a" * 40, state="open"):
+    return {
+        "number": number,
+        "state": state,
+        "head": {
+            "sha": sha,
+            "ref": "feature-branch",
+        },
+    }
+
+
+def make_workflow(name, pr, sha, phase="Running", shutdown=None, message=""):
+    wf = {
+        "metadata": {
+            "name": name,
+            "labels": {
+                "bluefin.io/trigger": "on-demand",
+                "bluefin.io/validation-class": "dakota-bst-qa",
+                "bluefin.io/repository": "dakota",
+                "bluefin.io/pr-number": str(pr),
+                "bluefin.io/pr-sha": sha[:12],
+            },
+        },
+        "spec": {
+            "arguments": {
+                "parameters": [
+                    {"name": "repository", "value": "projectbluefin/dakota"},
+                    {"name": "pr-number", "value": str(pr)},
+                    {"name": "commit-sha", "value": sha},
+                    {"name": "validation-class", "value": "dakota-bst-qa"},
+                ]
+            }
+        },
+        "status": {
+            "phase": phase,
+            "message": message,
+        },
+    }
+    if shutdown:
+        wf["spec"]["shutdown"] = shutdown
+    return wf
+
+
+# --- Acceptance Criteria 1: Rejection tests ---
+
+def test_rejects_unsupported_repository():
+    valid, err = dv.validate_request_parameters(
+        repository="projectbluefin/bluefin",
+        validation_class="dakota-bst-qa",
+        pr_number=100,
+        sha="a" * 40,
+    )
+    assert not valid
+    assert "unsupported repository" in err
+
+    result = dv.submit_validation_request(
+        repository="projectbluefin/bluefin",
+        validation_class="dakota-bst-qa",
+        pr_number=100,
+        sha="a" * 40,
+        publish=False,
+    )
+    assert result["status"] == "rejected"
+    assert "unsupported repository" in result["reason"]
+
+
+def test_rejects_unsupported_validation_class():
+    valid, err = dv.validate_request_parameters(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-qa",
+        pr_number=100,
+        sha="a" * 40,
+    )
+    assert not valid
+    assert "unsupported validation class" in err
+
+    result = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="arbitrary-class",
+        pr_number=100,
+        sha="a" * 40,
+        publish=False,
+    )
+    assert result["status"] == "rejected"
+    assert "unsupported validation class" in result["reason"]
+
+
+@pytest.mark.parametrize(
+    "bad_sha",
+    [
+        "a" * 39,
+        "a" * 41,
+        "xyz" + "0" * 37,
+        "main",
+        "HEAD",
+        "",
+        "   ",
+    ],
+)
+def test_rejects_malformed_sha(bad_sha):
+    valid, err = dv.validate_request_parameters(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=100,
+        sha=bad_sha,
+    )
+    assert not valid
+    assert "malformed commit SHA" in err
+
+    result = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=100,
+        sha=bad_sha,
+        publish=False,
+    )
+    assert result["status"] == "rejected"
+    assert "malformed commit SHA" in result["reason"]
+
+
+@pytest.mark.parametrize("bad_pr", [0, -1, "abc", ""])
+def test_rejects_invalid_pr_number(bad_pr):
+    valid, err = dv.validate_request_parameters(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=bad_pr,
+        sha="a" * 40,
+    )
+    assert not valid
+    assert "invalid PR number" in err
+
+
+def test_rejects_closed_pr():
+    sha = "b" * 40
+    pr_num = 120
+
+    def fake_fetcher(url, headers):
+        return 200, mock_pr_data(number=pr_num, sha=sha, state="closed")
+
+    valid_head, head_err, _ = dv.check_live_pr_head(
+        repository="projectbluefin/dakota",
+        pr_number=pr_num,
+        sha=sha,
+        fetcher=fake_fetcher,
+    )
+    assert not valid_head
+    assert "closed PR" in head_err
+
+    result = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        fetcher=fake_fetcher,
+        publish=False,
+    )
+    assert result["status"] == "rejected"
+    assert "closed PR" in result["reason"]
+
+
+def test_rejects_head_mismatch():
+    requested_sha = "c" * 40
+    live_sha = "d" * 40
+    pr_num = 121
+
+    def fake_fetcher(url, headers):
+        return 200, mock_pr_data(number=pr_num, sha=live_sha, state="open")
+
+    valid_head, head_err, _ = dv.check_live_pr_head(
+        repository="projectbluefin/dakota",
+        pr_number=pr_num,
+        sha=requested_sha,
+        fetcher=fake_fetcher,
+    )
+    assert not valid_head
+    assert "head mismatch" in head_err
+    assert requested_sha in head_err
+    assert live_sha in head_err
+
+    result = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=requested_sha,
+        fetcher=fake_fetcher,
+        publish=False,
+    )
+    assert result["status"] == "rejected"
+    assert "head mismatch" in result["reason"]
+
+
+# --- Acceptance Criteria 2: Canonical reporting statuses ---
+
+def test_reports_all_canonical_statuses():
+    # 8 required statuses:
+    # unavailable, rejected, queued, running, success, failure, cancelled, timeout
+    assert dv.VALID_STATUSES == {
+        "unavailable",
+        "rejected",
+        "queued",
+        "running",
+        "success",
+        "failure",
+        "cancelled",
+        "timeout",
+    }
+
+    sha = "e" * 40
+    pr_num = 130
+
+    # 1. unavailable: query without any workflows or commit statuses
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        runner=lambda cmd: json.dumps({"items": []}),
+        fetcher=lambda url, h: (200, []),
+    )
+    assert res["status"] == "unavailable"
+
+    # 2. rejected: invalid SHA
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha="bad-sha",
+    )
+    assert res["status"] == "rejected"
+
+    # 3. queued
+    wf_queued = make_workflow("wf-queued", pr_num, sha, phase="Pending")
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        runner=lambda cmd: json.dumps({"items": [wf_queued]}),
+    )
+    assert res["status"] == "queued"
+
+    # 4. running
+    wf_running = make_workflow("wf-running", pr_num, sha, phase="Running")
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        runner=lambda cmd: json.dumps({"items": [wf_running]}),
+    )
+    assert res["status"] == "running"
+
+    # 5. success
+    wf_succeeded = make_workflow("wf-succeeded", pr_num, sha, phase="Succeeded")
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        runner=lambda cmd: json.dumps({"items": [wf_succeeded]}),
+    )
+    assert res["status"] == "success"
+
+    # 6. failure
+    wf_failed = make_workflow("wf-failed", pr_num, sha, phase="Failed", message="build step error")
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        runner=lambda cmd: json.dumps({"items": [wf_failed]}),
+    )
+    assert res["status"] == "failure"
+
+    # 7. cancelled
+    wf_cancelled = make_workflow("wf-cancelled", pr_num, sha, phase="Running", shutdown="Stop")
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        runner=lambda cmd: json.dumps({"items": [wf_cancelled]}),
+    )
+    assert res["status"] == "cancelled"
+
+    # 8. timeout
+    wf_timeout = make_workflow(
+        "wf-timeout", pr_num, sha, phase="Failed", message="activeDeadlineSeconds exceeded (timeout)"
+    )
+    res = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        runner=lambda cmd: json.dumps({"items": [wf_timeout]}),
+    )
+    assert res["status"] == "timeout"
+
+
+# --- Acceptance Criteria 3: Deduplication of identical active requests ---
+
+def test_dedupes_identical_active_requests():
+    sha = "f" * 40
+    pr_num = 140
+
+    def fake_fetcher(url, headers):
+        return 200, mock_pr_data(number=pr_num, sha=sha, state="open")
+
+    active_wf = make_workflow("wf-active-140", pr_num, sha, phase="Running")
+
+    def fake_runner(cmd):
+        return json.dumps({"items": [active_wf]})
+
+    created = []
+    def fake_creator(manifest):
+        created.append(manifest)
+        return "should-not-be-created"
+
+    result = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        fetcher=fake_fetcher,
+        runner=fake_runner,
+        creator=fake_creator,
+        publish=False,
+    )
+
+    assert result["status"] == "running"
+    assert result["deduped"] is True
+    assert result["workflow_name"] == "wf-active-140"
+    assert len(created) == 0, "must not submit a duplicate active workflow"
+
+
+# --- Acceptance Criteria 4: Allow explicit terminal rerun ---
+
+def test_allows_explicit_terminal_rerun():
+    sha = "1" * 40
+    pr_num = 150
+
+    def fake_fetcher(url, headers):
+        return 200, mock_pr_data(number=pr_num, sha=sha, state="open")
+
+    terminal_wf = make_workflow("wf-terminal-150", pr_num, sha, phase="Failed", message="error")
+
+    def fake_runner(cmd):
+        return json.dumps({"items": [terminal_wf]})
+
+    created = []
+    def fake_creator(manifest):
+        created.append(manifest)
+        return "wf-rerun-150"
+
+    # Without rerun=True: dedupes terminal run, does not create new workflow
+    result1 = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        rerun=False,
+        fetcher=fake_fetcher,
+        runner=fake_runner,
+        creator=fake_creator,
+        publish=False,
+    )
+    assert result1["status"] == "failure"
+    assert result1["deduped"] is True
+    assert len(created) == 0
+
+    # With rerun=True: submits a new workflow
+    result2 = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha,
+        rerun=True,
+        fetcher=fake_fetcher,
+        runner=fake_runner,
+        creator=fake_creator,
+        publish=False,
+    )
+    assert result2["status"] == "queued"
+    assert result2["deduped"] is False
+    assert result2["rerun"] is True
+    assert result2["workflow_name"] == "wf-rerun-150"
+    assert len(created) == 1
+
+
+# --- Acceptance Criteria 5: Independent requests for multiple PRs ---
+
+def test_independent_requests_for_multiple_prs():
+    sha1 = "2" * 40
+    sha2 = "3" * 40
+    pr1 = 201
+    pr2 = 202
+
+    def fake_fetcher(url, headers):
+        if str(pr1) in url:
+            return 200, mock_pr_data(number=pr1, sha=sha1)
+        if str(pr2) in url:
+            return 200, mock_pr_data(number=pr2, sha=sha2)
+        return 404, {}
+
+    active_wf_pr1 = make_workflow("wf-pr1", pr1, sha1, phase="Running")
+
+    def fake_runner(cmd):
+        # Runner filters by pr-number
+        cmd_str = " ".join(cmd)
+        if f"bluefin.io/pr-number={pr1}" in cmd_str:
+            return json.dumps({"items": [active_wf_pr1]})
+        return json.dumps({"items": []})
+
+    created = []
+    def fake_creator(manifest):
+        created.append(manifest)
+        return "wf-pr2"
+
+    # PR 1 is active -> deduped
+    res1 = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr1,
+        sha=sha1,
+        fetcher=fake_fetcher,
+        runner=fake_runner,
+        creator=fake_creator,
+        publish=False,
+    )
+    assert res1["status"] == "running"
+    assert res1["deduped"] is True
+    assert len(created) == 0
+
+    # PR 2 is submitted independently
+    res2 = dv.submit_validation_request(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr2,
+        sha=sha2,
+        fetcher=fake_fetcher,
+        runner=fake_runner,
+        creator=fake_creator,
+        publish=False,
+    )
+    assert res2["status"] == "queued"
+    assert res2["deduped"] is False
+    assert len(created) == 1
+    assert res2["workflow_name"] == "wf-pr2"
+
+
+# --- Acceptance Criteria 6: Evidence from SHA A never applies to SHA B ---
+
+def test_evidence_from_sha_a_never_applies_to_sha_b():
+    sha_a = "4" * 40
+    sha_b = "5" * 40
+    pr_num = 300
+
+    wf_sha_a = make_workflow("wf-sha-a", pr_num, sha_a, phase="Succeeded")
+
+    def fake_runner(cmd):
+        cmd_str = " ".join(cmd)
+        if sha_a[:12] in cmd_str:
+            return json.dumps({"items": [wf_sha_a]})
+        return json.dumps({"items": []})
+
+    # Query for SHA A reports success
+    res_a = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha_a,
+        runner=fake_runner,
+        fetcher=lambda u, h: (404, {}),
+    )
+    assert res_a["status"] == "success"
+    assert res_a["sha"] == sha_a
+
+    # Query for SHA B reports unavailable (never leaks SHA A's evidence)
+    res_b = dv.query_validation_status(
+        repository="projectbluefin/dakota",
+        validation_class="dakota-bst-qa",
+        pr_number=pr_num,
+        sha=sha_b,
+        runner=fake_runner,
+        fetcher=lambda u, h: (404, {}),
+    )
+    assert res_b["status"] == "unavailable"
+    assert res_b["sha"] == sha_b
+
+
+# --- Integration & Manifest verification ---
+
+def test_dakota_bst_qa_workflow_template_contract():
+    tmpl_path = ROOT / "argo/workflow-templates/dakota-bst-qa.yaml"
+    assert tmpl_path.exists()
+    doc = yaml.safe_load(tmpl_path.read_text(encoding="utf-8"))
+
+    assert doc["metadata"]["name"] == "dakota-bst-qa"
+    assert doc["spec"]["entrypoint"] == "pipeline"
+    assert doc["spec"]["onExit"] == "report-final"
+
+    templates = {t["name"]: t for t in doc["spec"]["templates"]}
+    assert {"pipeline", "report-final"} <= templates.keys()
+
+    tasks = {t["name"]: t for t in templates["pipeline"]["dag"]["tasks"]}
+    assert {"report-start", "build", "qa-dakota"} <= tasks.keys()
+
+    # Build must invoke dakota-build-pipeline with exact SHA parameters
+    build_task = tasks["build"]
+    assert build_task["templateRef"]["name"] == "dakota-build-pipeline"
+    assert build_task["templateRef"]["template"] == "build"
+    build_params = {p["name"]: p["value"] for p in build_task["arguments"]["parameters"]}
+    assert build_params["commit-sha"] == "{{workflow.parameters.commit-sha}}"
+    assert build_params["image-tag"] == "{{workflow.parameters.commit-sha}}"
+    assert build_params["build-mode"] == "{{workflow.parameters.build-mode}}"
+
+    # QA must invoke dakota-qa-pipeline after build succeeds
+    qa_task = tasks["qa-dakota"]
+    assert qa_task["depends"] == "build.Succeeded"
+    assert qa_task["templateRef"]["name"] == "dakota-qa-pipeline"
+    assert qa_task["templateRef"]["template"] == "pipeline"
+    qa_params = {p["name"]: p["value"] for p in qa_task["arguments"]["parameters"]}
+    assert qa_params["image-tag"] == "{{workflow.parameters.commit-sha}}"
+
+
+def test_github_status_reporter_allowlist_includes_dakota():
+    reporter_path = ROOT / "argo/workflow-templates/github-status-reporter.yaml"
+    content = reporter_path.read_text(encoding="utf-8")
+    assert "projectbluefin/dakota" in content
+
+
+def test_dakota_validation_dispatch_workflow():
+    wf_path = ROOT / ".github/workflows/dakota-validation-dispatch.yml"
+    assert wf_path.exists()
+    doc = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+
+    triggers = doc.get("on") or doc.get(True)
+    assert "repository_dispatch" in triggers
+    assert "workflow_dispatch" in triggers
+    assert "dakota-validation" in triggers["repository_dispatch"]["types"]
+    assert "dakota-bst-qa" in triggers["repository_dispatch"]["types"]
+
+    job = doc["jobs"]["submit-dakota-validation"]
+    assert job["runs-on"] == "ghost-runners"
+    assert job["container"]["image"] == "ghcr.io/projectbluefin/arc-runner:latest"


### PR DESCRIPTION
## Summary

Exposes an on-demand, SHA-bound validation contract for `projectbluefin/dakota` pull requests under validation class `dakota-bst-qa`. This provides review automation (`review`) and operators with a reliable, bounded mechanism to request lab validation without cluster credentials.

## Scope & Implementation

- **GitHub-authenticated dispatch**: Added `.github/workflows/dakota-validation-dispatch.yml` supporting `repository_dispatch` (types: `dakota-validation`, `dakota-bst-qa`) and `workflow_dispatch` running on `ghost-runners`.
- **Preflight validation**: Implemented `scripts/dakota_validation.py` to validate requests and query live PR head state before cluster submission. Rejects unsupported repo/class, closed PRs, malformed SHAs, and head mismatches.
- **Deduplication & terminal rerun**: Identical active requests (`queued` or `running`) are deduped; explicit terminal rerun (`--rerun`) is permitted for completed runs.
- **SHA isolation**: Requests and evidence are strictly bound to the requested exact commit SHA (evidence from SHA A never applies to SHA B).
- **Execution**: Added `argo/workflow-templates/dakota-bst-qa.yaml` to run the existing Dakota BuildStream build and container QA pipelines.
- **Reporting**: Reports across the 8 canonical lifecycle states (`unavailable`, `rejected`, `queued`, `running`, `success`, `failure`, `cancelled`, `timeout`) and publishes `testing-lab/dakota-bst-qa` commit status evidence back to GitHub.
- **CLI & Justfile**: Added `dakota-validate-request` and `dakota-validate-status` recipes to `Justfile`.
- **Documentation**: Updated `docs/reference/WORKFLOWS.md` and `docs/skills/dakota-pr-review/SKILL.md`.

Closes #638

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `7c072e4ec`