### PR TITLE
ci: wire workflows to .python-scope check scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'tests/**'
       - 'scripts/**'
+      - '.python-scope'
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/ci.yml'
@@ -16,6 +17,7 @@ on:
     paths:
       - 'tests/**'
       - 'scripts/**'
+      - '.python-scope'
       - 'requirements.txt'
       - 'pyproject.toml'
 
@@ -50,5 +52,7 @@ jobs:
         run: python -m pytest --collect-only tests/
 
       - name: Lint check with ruff
-        run: python -m ruff check tests/
+        run: |
+          mapfile -t TREES < <(grep -vE '^[[:space:]]*(#|$)' .python-scope)
+          python -m ruff check "${TREES[@]}"
         continue-on-error: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -99,7 +99,8 @@ jobs:
       - name: Validate Python syntax
         run: |
           echo "Checking Python syntax..."
-          find tests/ -name '*.py' -print0 | xargs -0 python -m py_compile
+          mapfile -t TREES < <(grep -vE '^[[:space:]]*(#|$)' .python-scope)
+          find "${TREES[@]}" -name '*.py' -print0 | xargs -0 python -m py_compile
 
       - name: Check pytest collection
         run: |

--- a/.python-scope
+++ b/.python-scope
@@ -5,20 +5,15 @@
 # CI step (`pytest tests/unit/` in .github/workflows/ci.yml), so the scope is a
 # real gate without any workflow needing to restate the tree list.
 #
-# ALSO CONSUMED BY: `just check-python` (local syntax + advisory ruff run over
-# exactly these trees, so local matches CI).
+# ALSO CONSUMED BY:
+# - .github/workflows/lint.yaml ("Validate Python syntax", blocking)
+# - .github/workflows/ci.yml ("Lint check with ruff", advisory)
+# - `just check-python` (local syntax + advisory ruff run over exactly these
+#   trees, so local matches CI).
 #
 # Adding a new tree of first-party Python means adding one line here -- nowhere
 # else. test_every_tree_with_first_party_python_is_in_scope fails if a tree with
 # .py files is not declared.
-#
-# STILL TO WIRE: .github/workflows/lint.yaml ("Validate Python syntax") and
-# .github/workflows/ci.yml ("Lint check with ruff") each hardcode `tests/`.
-# Both are now redundant subsets of this file rather than the scope itself;
-# rewiring them to read this file needs a token with `workflows` permission.
-# See projectbluefin/lab#693. Until then
-# test_workflow_syntax_check_does_not_exceed_the_declared_scope keeps them from
-# drifting outside this scope.
 #
 # NOTE: this is the *check* scope, not the *coverage* scope. .coveragerc
 # deliberately measures a narrower set (the shared helper modules the unit gate

--- a/tests/unit/test_python_check_scope.py
+++ b/tests/unit/test_python_check_scope.py
@@ -91,24 +91,25 @@ def test_every_tree_with_first_party_python_is_in_scope():
 
 
 def test_workflow_syntax_check_does_not_exceed_the_declared_scope():
-    """A workflow may check a subset of the scope, never a tree outside it.
-
-    lint.yaml still hardcodes `find tests/` today (rewiring it to read
-    .python-scope needs a token with `workflows` permission -- see #693). That
-    is safe only while the tree it names is inside the declared scope; this test
-    fails the moment the two diverge.
-    """
+    """lint.yaml must read .python-scope and never hardcode python trees."""
     lint_yaml = (ROOT / ".github/workflows/lint.yaml").read_text(encoding="utf-8")
-    trees = set(_scope_trees())
 
-    if ".python-scope" in lint_yaml:
-        return  # already reading the single source of truth
+    assert ".python-scope" in lint_yaml, "lint.yaml must read .python-scope"
 
     hardcoded = [t for t in ("tests", "scripts") if f"find {t}/ -name '*.py'" in lint_yaml]
-    outside = [t for t in hardcoded if t not in trees]
+    assert not hardcoded, (
+        "lint.yaml syntax-checks hardcoded tree(s) instead of reading .python-scope: "
+        + ", ".join(hardcoded)
+    )
 
-    assert not outside, (
-        "lint.yaml syntax-checks tree(s) not declared in .python-scope: " + ", ".join(outside)
+
+def test_workflow_ruff_check_uses_the_scope_file():
+    """ci.yml ruff check step must read .python-scope rather than hardcoding trees."""
+    ci_yml = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert ".python-scope" in ci_yml, "ci.yml must read .python-scope"
+    assert "ruff check tests/" not in ci_yml, (
+        "ci.yml hardcodes 'ruff check tests/' instead of reading .python-scope"
     )
 
 


### PR DESCRIPTION
## Summary

Completes the scope consolidation started in #694 by rewiring `.github/workflows/lint.yaml` and `.github/workflows/ci.yml` to consume the single source of truth declared in `.python-scope`.

Closes #693

### Changes

- **`.github/workflows/lint.yaml`**: Rewire "Validate Python syntax" to read trees declared in `.python-scope` rather than hardcoding `find tests/`. All declared trees (including `scripts/`) are now syntax-checked.
- **`.github/workflows/ci.yml`**:
  - Rewire "Lint check with ruff" to read trees declared in `.python-scope`. Advisory semantics are preserved (`continue-on-error: true`).
  - Add `.python-scope` to path triggers so changes to the declared check scope run CI.
- **`.python-scope`**: Update header documentation to reflect that both workflows consume the file.
- **`tests/unit/test_python_check_scope.py`**: Update invariant tests to assert that `lint.yaml` and `ci.yml` read `.python-scope` and do not hardcode check trees.

### Validation

- `pytest tests/unit/test_python_check_scope.py` (8 passed)
- `pytest --cov-config=.coveragerc --cov=tests/shared --cov=tests/service_catalog/shared --cov-fail-under=60 tests/unit/` (541 passed, coverage 70%)
- `just check-python` (all syntax checks pass; ruff runs over all scoped trees)

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `7784d2600`