### PR TITLE
test(quality): add unit tests for 5 uncovered scripts modules

### DIFF
--- a/scripts/collect_bst_cache.py
+++ b/scripts/collect_bst_cache.py
@@ -456,6 +456,7 @@ def main():
         "rows": rows,
     }
 
+    Path(OUT_PATH).parent.mkdir(parents=True, exist_ok=True)
     with open(OUT_PATH, "w") as f:
         json.dump(doc, f, indent=2)
         f.write("\n")

--- a/scripts/refresh_factory_stats.py
+++ b/scripts/refresh_factory_stats.py
@@ -11,6 +11,168 @@ def parse_iso(ts):
         return None
 
 
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            h.update(chunk)
+    return f"sha256:{h.hexdigest()}"
+
+
+def argo_ui_url(workflow_name):
+    # Argo Workflows run on the cluster, not GitHub Actions; link straight to
+    # the Argo Server UI for the actual workflow instance.
+    return f"http://192.168.1.102:32746/workflows/argo/{workflow_name}"
+
+
+def phase_to_overall(phase):
+    if phase in ('Running', 'Pending'):
+        return 'running'
+    if phase == 'Succeeded':
+        return 'passed'
+    if phase in ('Failed', 'Error'):
+        return 'fail'
+    return 'pending'
+
+
+def infer_trigger(name):
+    if not name:
+        return 'manual'
+    if name.startswith('nightly-'):
+        return 'nightly'
+    if name.startswith('image-poll-') or name.startswith('digest-watch-'):
+        return 'poller'
+    if re.match(r'^[a-z]+-\d+-', name):
+        return 'pr-poller'
+    return 'manual'
+
+
+# Pipelines that produce a build artifact (image, containerdisk, kernel), as
+# opposed to maintenance/polling CronWorkflows (orphan-*-gc, image-poll-*, etc).
+BUILD_PIPELINE_PREFIXES = (
+    'bluefin-qa-pipeline',
+    'dakota-qa-pipeline',
+    'knuckle-qa-pipeline',
+    'bst-qa-pipeline',
+    'build-containerdisk',
+    'build-cd-sync',
+    'flatcar-kernel-build',
+    'bluefin-server-build-pipeline',
+    'dakota-build-pipeline',
+    'cosmic-build-pipeline',
+    'cosmic-qa-pipeline',
+)
+
+
+def pipeline_base_name(name):
+    # Argo generateName workflows append a random 5-char suffix
+    # (build-containerdisk-dsrlm); CronWorkflow instances append an epoch
+    # timestamp (orphan-pod-gc-1783047600). Strip either to get a stable key.
+    stripped = re.sub(r'-[a-z0-9]{5}$', '', name)
+    stripped = re.sub(r'-\d{9,}$', '', stripped)
+    return stripped
+
+
+def build_pipeline_key(name):
+    base = pipeline_base_name(name)
+    for prefix in BUILD_PIPELINE_PREFIXES:
+        if base == prefix or base.startswith(f'{prefix}-'):
+            return prefix
+    return None
+
+
+def infer_label(params, wf_name):
+    p = {x.get('name'): x.get('value') for x in (params or [])}
+    variant = p.get('variant')
+    tag = p.get('image-tag')
+    image = p.get('image', '')
+    if variant and tag:
+        return f'{variant}:{tag}'
+    if image and tag:
+        img_name = image.rsplit('/', 1)[-1]
+        return f'{img_name}:{tag}'
+    if image:
+        return image.rsplit('/', 1)[-1]
+    if wf_name.startswith('dakota'):
+        return 'dakota:latest'
+    return None
+
+
+def safe_int(val, default=0):
+    try:
+        return int(val)
+    except Exception:
+        return default
+
+
+def parse_mem_gib(mem):
+    if not mem:
+        return None
+    if mem.endswith('Ki'):
+        return round(int(mem[:-2]) / (1024 * 1024))
+    if mem.endswith('Mi'):
+        return round(int(mem[:-2]) / 1024)
+    if mem.endswith('Gi'):
+        return int(mem[:-2])
+    return None
+
+
+def parse_mem_bytes(mem):
+    if not mem:
+        return None
+    try:
+        if mem.endswith('Ki'):
+            return int(mem[:-2]) * 1024
+        if mem.endswith('Mi'):
+            return int(mem[:-2]) * 1024 * 1024
+        if mem.endswith('Gi'):
+            return int(mem[:-2]) * 1024 * 1024 * 1024
+        if mem.endswith('Ti'):
+            return int(mem[:-2]) * 1024 * 1024 * 1024 * 1024
+        return int(mem)
+    except Exception:
+        return None
+
+
+def parse_cpu_millicores(cpu):
+    if cpu is None:
+        return None
+    s = str(cpu)
+    try:
+        if s.endswith('n'):
+            return float(s[:-1]) / 1_000_000.0
+        if s.endswith('u'):
+            return float(s[:-1]) / 1000.0
+        if s.endswith('m'):
+            return float(s[:-1])
+        return float(s) * 1000.0
+    except Exception:
+        return None
+
+
+def gh_run_to_overall(run):
+    status = run.get('status')
+    conclusion = run.get('conclusion')
+    if status != 'completed':
+        return 'running'
+    if conclusion == 'success':
+        return 'passed'
+    if conclusion in ('failure', 'timed_out', 'startup_failure'):
+        return 'fail'
+    if conclusion == 'cancelled':
+        return 'pending'
+    return 'pending'
+
+
+def gh_run_duration_min(run):
+    try:
+        started = datetime.datetime.fromisoformat(run['run_started_at'].replace('Z', '+00:00'))
+        updated = datetime.datetime.fromisoformat(run['updated_at'].replace('Z', '+00:00'))
+        return max(0, round((updated - started).total_seconds() / 60))
+    except Exception:
+        return None
+
+
 def append_build_runs_ndjson(stats, image_build_catalog, now):
     """Append terminal build-run records to the rolling NDJSON history file.
 
@@ -144,133 +306,6 @@ def main():
         try:
             out = subprocess.check_output(cmd, shell=True, text=True, stderr=subprocess.DEVNULL, timeout=15)
             return json.loads(out)
-        except Exception:
-            return None
-
-    def sha256_file(path):
-        h = hashlib.sha256()
-        with open(path, 'rb') as f:
-            for chunk in iter(lambda: f.read(65536), b''):
-                h.update(chunk)
-        return f"sha256:{h.hexdigest()}"
-
-    def argo_ui_url(workflow_name):
-        # Argo Workflows run on the cluster, not GitHub Actions; link straight to
-        # the Argo Server UI for the actual workflow instance.
-        return f"http://192.168.1.102:32746/workflows/argo/{workflow_name}"
-
-    def phase_to_overall(phase):
-        if phase in ('Running', 'Pending'):
-            return 'running'
-        if phase == 'Succeeded':
-            return 'passed'
-        if phase in ('Failed', 'Error'):
-            return 'fail'
-        return 'pending'
-
-    def infer_trigger(name):
-        if not name:
-            return 'manual'
-        if name.startswith('nightly-'):
-            return 'nightly'
-        if name.startswith('image-poll-') or name.startswith('digest-watch-'):
-            return 'poller'
-        if re.match(r'^[a-z]+-\d+-', name):
-            return 'pr-poller'
-        return 'manual'
-
-    # Pipelines that produce a build artifact (image, containerdisk, kernel), as
-    # opposed to maintenance/polling CronWorkflows (orphan-*-gc, image-poll-*, etc).
-    BUILD_PIPELINE_PREFIXES = (
-        'bluefin-qa-pipeline',
-        'dakota-qa-pipeline',
-        'knuckle-qa-pipeline',
-        'bst-qa-pipeline',
-        'build-containerdisk',
-        'build-cd-sync',
-        'flatcar-kernel-build',
-        'bluefin-server-build-pipeline',
-        'dakota-build-pipeline',
-        'cosmic-build-pipeline',
-        'cosmic-qa-pipeline',
-    )
-
-    def pipeline_base_name(name):
-        # Argo generateName workflows append a random 5-char suffix
-        # (build-containerdisk-dsrlm); CronWorkflow instances append an epoch
-        # timestamp (orphan-pod-gc-1783047600). Strip either to get a stable key.
-        stripped = re.sub(r'-[a-z0-9]{5}$', '', name)
-        stripped = re.sub(r'-\d{9,}$', '', stripped)
-        return stripped
-
-    def build_pipeline_key(name):
-        base = pipeline_base_name(name)
-        for prefix in BUILD_PIPELINE_PREFIXES:
-            if base == prefix or base.startswith(f'{prefix}-'):
-                return prefix
-        return None
-
-    def infer_label(params, wf_name):
-        p = {x.get('name'): x.get('value') for x in (params or [])}
-        variant = p.get('variant')
-        tag = p.get('image-tag')
-        image = p.get('image', '')
-        if variant and tag:
-            return f'{variant}:{tag}'
-        if image and tag:
-            img_name = image.rsplit('/', 1)[-1]
-            return f'{img_name}:{tag}'
-        if image:
-            return image.rsplit('/', 1)[-1]
-        if wf_name.startswith('dakota'):
-            return 'dakota:latest'
-        return None
-
-    def safe_int(val, default=0):
-        try:
-            return int(val)
-        except Exception:
-            return default
-
-    def parse_mem_gib(mem):
-        if not mem:
-            return None
-        if mem.endswith('Ki'):
-            return round(int(mem[:-2]) / (1024 * 1024))
-        if mem.endswith('Mi'):
-            return round(int(mem[:-2]) / 1024)
-        if mem.endswith('Gi'):
-            return int(mem[:-2])
-        return None
-
-    def parse_mem_bytes(mem):
-        if not mem:
-            return None
-        try:
-            if mem.endswith('Ki'):
-                return int(mem[:-2]) * 1024
-            if mem.endswith('Mi'):
-                return int(mem[:-2]) * 1024 * 1024
-            if mem.endswith('Gi'):
-                return int(mem[:-2]) * 1024 * 1024 * 1024
-            if mem.endswith('Ti'):
-                return int(mem[:-2]) * 1024 * 1024 * 1024 * 1024
-            return int(mem)
-        except Exception:
-            return None
-
-    def parse_cpu_millicores(cpu):
-        if cpu is None:
-            return None
-        s = str(cpu)
-        try:
-            if s.endswith('n'):
-                return float(s[:-1]) / 1_000_000.0
-            if s.endswith('u'):
-                return float(s[:-1]) / 1000.0
-            if s.endswith('m'):
-                return float(s[:-1])
-            return float(s) * 1000.0
         except Exception:
             return None
 
@@ -597,27 +632,6 @@ def main():
         {'id': 'bazzite-stable', 'repo': 'ublue-os/bazzite', 'workflow': 'build_ublue.yml', 'branch': 'main'},
         {'id': 'bazzite-testing', 'repo': 'ublue-os/bazzite', 'workflow': 'build_ublue.yml', 'branch': 'testing'},
     ]
-
-    def gh_run_to_overall(run):
-        status = run.get('status')
-        conclusion = run.get('conclusion')
-        if status != 'completed':
-            return 'running'
-        if conclusion == 'success':
-            return 'passed'
-        if conclusion in ('failure', 'timed_out', 'startup_failure'):
-            return 'fail'
-        if conclusion == 'cancelled':
-            return 'pending'
-        return 'pending'
-
-    def gh_run_duration_min(run):
-        try:
-            started = datetime.datetime.fromisoformat(run['run_started_at'].replace('Z', '+00:00'))
-            updated = datetime.datetime.fromisoformat(run['updated_at'].replace('Z', '+00:00'))
-            return max(0, round((updated - started).total_seconds() / 60))
-        except Exception:
-            return None
 
     image_builds = {}
     for entry in IMAGE_BUILD_CATALOG:

--- a/tests/unit/test_collect_app_resources.py
+++ b/tests/unit/test_collect_app_resources.py
@@ -1,0 +1,197 @@
+"""Unit tests for scripts/collect_app_resources.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo_root / "scripts"))
+
+import collect_app_resources as car
+
+
+class TestCollectAppResources:
+    def test_run_cmd(self):
+        assert car.run_cmd("echo 'test'") == "test"
+        assert car.run_cmd("false") is None
+        with patch("subprocess.check_output", side_effect=Exception("boom")):
+            assert car.run_cmd("echo 'fail'") is None
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("", 0.0),
+            (None, 0.0),
+            ("1000000000n", 1.0),
+            ("500000000n", 0.5),
+            ("1000000u", 1.0),
+            ("500000u", 0.5),
+            ("500m", 0.5),
+            ("2000m", 2.0),
+            ("2", 2.0),
+            ("2.5", 2.5),
+            ("invalid", 0.0),
+        ],
+    )
+    def test_parse_cpu_cores(self, raw, expected):
+        assert car.parse_cpu_cores(raw) == pytest.approx(expected)
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("", 0.0),
+            (None, 0.0),
+            ("1024Ki", 1.0),
+            ("512Mi", 512.0),
+            ("2Gi", 2048.0),
+            ("1Ti", 1024.0 * 1024.0),
+            ("1048576", 1.0),  # bytes
+            ("invalid", 0.0),
+        ],
+    )
+    def test_parse_mem_mib(self, raw, expected):
+        assert car.parse_mem_mib(raw) == pytest.approx(expected)
+
+    def test_get_app_for_pod(self):
+        # Workflow label
+        assert car.get_app_for_pod("wf-pod", "default", {"workflows.argoproj.io/workflow": "my-wf"}) == "testing-lab"
+
+        # Namespace matching
+        assert car.get_app_for_pod("runner-pod", "arc-runners", {}) == "arc-runners"
+        assert car.get_app_for_pod("sys-pod", "arc-systems", {}) == "arc-systems"
+
+        # argo namespace
+        assert car.get_app_for_pod("argo-server-123", "argo", {}) == "argo-workflows"
+        assert car.get_app_for_pod("argo-workflows-workflow-controller-456", "argo", {}) == "argo-workflows"
+        assert car.get_app_for_pod("k8sgpt-789", "argo", {}) == "testing-lab-infra"
+
+        # flatcar-update & system-upgrade
+        assert car.get_app_for_pod("any-pod", "flatcar-update", {}) == "flatcar-update"
+        assert car.get_app_for_pod("any-pod", "system-upgrade", {}) == "flatcar-update"
+
+        # buildbarn, local-registry, cdi, kubevirt
+        assert car.get_app_for_pod("storage-0", "buildbarn", {}) == "testing-lab-infra"
+        assert car.get_app_for_pod("registry-pod", "local-registry", {}) == "testing-lab-infra"
+        assert car.get_app_for_pod("cdi-pod", "cdi", {}) == "testing-lab-infra"
+        assert car.get_app_for_pod("virt-pod", "kubevirt", {}) == "testing-lab-infra"
+
+        # Standard label fallback
+        assert car.get_app_for_pod("custom", "other", {"argocd.argoproj.io/instance": "arc-runners"}) == "arc-runners"
+        assert car.get_app_for_pod("custom", "other", {"app.kubernetes.io/instance": "testing-lab"}) == "testing-lab"
+        assert car.get_app_for_pod("custom", "other", {"app.kubernetes.io/instance": "unknown-app"}) is None
+        assert car.get_app_for_pod("custom", "other", {}) is None
+
+    def test_main_fallback_when_offline(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(car, "run_cmd", lambda cmd: None)
+
+        car.main()
+
+        out_file = tmp_path / "docs" / "data" / "app-resource-usage.json"
+        assert out_file.exists()
+
+        data = json.loads(out_file.read_text())
+        assert data["schema_version"] == "v1"
+        assert data["_meta"]["live_snapshot_ok"] is False
+        apps = {a["name"]: a for a in data["applications"]}
+        assert "arc-systems" in apps
+        assert apps["arc-systems"]["pods_count"] == 2
+        assert apps["arc-systems"]["cpu"]["usage"] == 0.15
+        assert apps["arc-systems"]["memory"]["usage"] == 128.0
+
+    def test_main_live_pods_and_metrics(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        pods_json = json.dumps({
+            "items": [
+                {
+                    "metadata": {
+                        "name": "runner-pod-1",
+                        "namespace": "arc-runners",
+                        "labels": {}
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "runner",
+                                "resources": {
+                                    "requests": {"cpu": "500m", "memory": "256Mi"},
+                                    "limits": {"cpu": "1000m", "memory": "512Mi"}
+                                }
+                            }
+                        ],
+                        "initContainers": [
+                            {
+                                "name": "init",
+                                "resources": {
+                                    "requests": {"cpu": "100m", "memory": "64Mi"},
+                                    "limits": {"cpu": "200m", "memory": "128Mi"}
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "phase": "Running"
+                    }
+                },
+                {
+                    "metadata": {
+                        "name": "terminated-pod",
+                        "namespace": "arc-runners",
+                        "labels": {}
+                    },
+                    "spec": {"containers": []},
+                    "status": {
+                        "phase": "Succeeded"
+                    }
+                }
+            ]
+        })
+
+        metrics_json = json.dumps({
+            "items": [
+                {
+                    "metadata": {
+                        "name": "runner-pod-1",
+                        "namespace": "arc-runners"
+                    },
+                    "containers": [
+                        {
+                            "name": "runner",
+                            "usage": {"cpu": "250m", "memory": "128Mi"}
+                        }
+                    ]
+                }
+            ]
+        })
+
+        def mock_cmd(cmd):
+            if "kubectl get pods" in cmd:
+                return pods_json
+            if "metrics.k8s.io" in cmd:
+                return metrics_json
+            return None
+
+        monkeypatch.setattr(car, "run_cmd", mock_cmd)
+
+        car.main()
+
+        out_file = tmp_path / "docs" / "data" / "app-resource-usage.json"
+        assert out_file.exists()
+
+        data = json.loads(out_file.read_text())
+        assert data["_meta"]["live_snapshot_ok"] is True
+        apps = {a["name"]: a for a in data["applications"]}
+        runners = apps["arc-runners"]
+        assert runners["pods_count"] == 1
+        assert runners["cpu"]["usage"] == 0.25
+        assert runners["cpu"]["request"] == 0.6  # 500m + 100m
+        assert runners["cpu"]["limit"] == 1.2    # 1000m + 200m
+        assert runners["memory"]["usage"] == 128.0
+        assert runners["memory"]["request"] == 320.0  # 256 + 64
+        assert runners["memory"]["limit"] == 640.0    # 512 + 128

--- a/tests/unit/test_collect_bst_cache.py
+++ b/tests/unit/test_collect_bst_cache.py
@@ -1,0 +1,208 @@
+"""Unit tests for scripts/collect_bst_cache.py."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo_root / "scripts"))
+
+import collect_bst_cache as cbc
+
+SAMPLE_METRICS = """
+# HELP buildbarn_blobstore_block_device_backed_block_allocator_allocations_total Total number of blocks allocated.
+# TYPE buildbarn_blobstore_block_device_backed_block_allocator_allocations_total counter
+buildbarn_blobstore_block_device_backed_block_allocator_allocations_total{storage_type="cas"} 10
+buildbarn_blobstore_block_device_backed_block_allocator_allocations_total{storage_type="ac"} 5
+# HELP buildbarn_blobstore_block_device_backed_block_allocator_releases_total Total number of blocks released.
+# TYPE buildbarn_blobstore_block_device_backed_block_allocator_releases_total counter
+buildbarn_blobstore_block_device_backed_block_allocator_releases_total{storage_type="cas"} 2
+buildbarn_blobstore_block_device_backed_block_allocator_releases_total{storage_type="ac"} 1
+# HELP buildbarn_blobstore_blob_access_operations_duration_seconds Blob access operations duration
+buildbarn_blobstore_blob_access_operations_duration_seconds_count{grpc_code="OK",operation="Get",storage_type="cas"} 80
+buildbarn_blobstore_blob_access_operations_duration_seconds_count{grpc_code="NotFound",operation="Get",storage_type="cas"} 20
+buildbarn_blobstore_blob_access_operations_duration_seconds_sum{grpc_code="OK",operation="Get",storage_type="cas"} 1.5
+buildbarn_blobstore_blob_access_operations_duration_seconds_sum{grpc_code="NotFound",operation="Get",storage_type="cas"} 0.5
+# HELP buildbarn_blobstore_blob_access_operations_blob_size_bytes Blob access operations blob size
+buildbarn_blobstore_blob_access_operations_blob_size_bytes_count{operation="Get",storage_type="cas"} 100
+buildbarn_blobstore_blob_access_operations_blob_size_bytes_sum{operation="Get",storage_type="cas"} 5000000
+"""
+
+
+class TestCollectBstCache:
+    def test_run_raw(self):
+        with patch("subprocess.check_output", return_value="raw-data\n"):
+            assert cbc.run_raw("/some/path") == "raw-data\n"
+        with patch("subprocess.check_output", side_effect=Exception("fail")):
+            assert cbc.run_raw("/some/path") is None
+
+    def test_run_json_raw(self):
+        with patch("subprocess.check_output", return_value='{"key": "value"}'):
+            assert cbc.run_json_raw("/some/path") == {"key": "value"}
+        with patch("subprocess.check_output", return_value='invalid json'):
+            assert cbc.run_json_raw("/some/path") is None
+        with patch("subprocess.check_output", side_effect=Exception("fail")):
+            assert cbc.run_json_raw("/some/path") is None
+
+    def test_parse_metric_value(self):
+        assert cbc.parse_metric_value(None, "metric", {}) is None
+        val_cas = cbc.parse_metric_value(
+            SAMPLE_METRICS,
+            "buildbarn_blobstore_block_device_backed_block_allocator_allocations_total",
+            {"storage_type": "cas"},
+        )
+        assert val_cas == 10.0
+
+        val_ac = cbc.parse_metric_value(
+            SAMPLE_METRICS,
+            "buildbarn_blobstore_block_device_backed_block_allocator_allocations_total",
+            {"storage_type": "ac"},
+        )
+        assert val_ac == 5.0
+
+        val_missing = cbc.parse_metric_value(SAMPLE_METRICS, "nonexistent_metric", {})
+        assert val_missing is None
+
+    def test_parse_metric_samples(self):
+        assert cbc.parse_metric_samples(None, "metric") == []
+        samples = cbc.parse_metric_samples(
+            SAMPLE_METRICS,
+            "buildbarn_blobstore_blob_access_operations_duration_seconds_count",
+        )
+        assert len(samples) == 2
+        labels, val = samples[0]
+        assert labels["operation"] == "Get"
+        assert labels["grpc_code"] == "OK"
+        assert val == 80.0
+
+    def test_collect_cache_heat_available(self):
+        heat = cbc.collect_cache_heat(SAMPLE_METRICS, "storage-0", "cas")
+        assert heat["cache_backend"] == "buildbarn"
+        assert heat["pod"] == "storage-0"
+        assert heat["storage_type"] == "cas"
+        assert heat["hit_count"] == 80
+        assert heat["miss_count"] == 20
+        assert heat["requests"] == 100
+        assert heat["effectiveness"] == 0.8
+        assert heat["bytes"] == 5000000
+        assert heat["duration_seconds"] == 2.0
+        assert heat["state"] == "available"
+        assert heat["state_reason"] is None
+
+    def test_collect_cache_heat_unavailable(self):
+        heat = cbc.collect_cache_heat("", "storage-0", "cas")
+        assert heat["state"] == "unavailable"
+        assert heat["hit_count"] is None
+        assert heat["miss_count"] is None
+        assert heat["effectiveness"] is None
+        assert "unavailable" in heat["state_reason"]
+
+    def test_persist_cache_heat(self, tmp_path, monkeypatch):
+        history_file = tmp_path / "cache-heat.ndjson"
+        monkeypatch.setattr(cbc, "HISTORY_PATH", str(history_file))
+
+        # Write an old record (older than 180 days) and a recent record
+        old_time = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        recent_time = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        history_file.write_text(
+            json.dumps({"schema_version": "1.0", "recorded_at": old_time, "hit_count": 10}) + "\n" +
+            json.dumps({"schema_version": "1.0", "recorded_at": recent_time, "hit_count": 20}) + "\n"
+        )
+
+        now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        records = [{"hit_count": 50, "miss_count": 5}]
+
+        cbc.persist_cache_heat(records, now)
+
+        lines = [json.loads(line) for line in history_file.read_text().splitlines()]
+        # old_time should be pruned, recent_time kept, now added
+        timestamps = [rec["recorded_at"] for rec in lines]
+        assert old_time not in timestamps
+        assert recent_time in timestamps
+        assert now in timestamps
+
+    def test_node_for_pod(self):
+        with patch.object(cbc, "run_json_raw", return_value={"spec": {"nodeName": "ghost"}}):
+            assert cbc.node_for_pod("buildbarn", "storage-0") == "ghost"
+        with patch.object(cbc, "run_json_raw", return_value=None):
+            assert cbc.node_for_pod("buildbarn", "storage-0") is None
+
+    def test_main_unavailable_cluster(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        out_file = tmp_path / "docs" / "data" / "bst-cache.json"
+        history_file = tmp_path / "docs" / "data" / "history" / "cache-heat.ndjson"
+        monkeypatch.setattr(cbc, "OUT_PATH", str(out_file))
+        monkeypatch.setattr(cbc, "HISTORY_PATH", str(history_file))
+
+        monkeypatch.setattr(cbc, "run_raw", lambda p: None)
+        monkeypatch.setattr(cbc, "run_json_raw", lambda p: None)
+
+        cbc.main()
+
+        assert out_file.exists()
+        doc = json.loads(out_file.read_text())
+        assert doc["schema_version"] == 1
+        assert doc["_meta"]["freshness_state"] == "unavailable"
+        assert len(doc["rows"]) == 5  # 1 bazel-remote + 2 storage pods * 2 storage types (cas, ac)
+        for row in doc["rows"]:
+            assert row["state"] == "unavailable"
+
+    def test_main_live_cluster(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        out_file = tmp_path / "docs" / "data" / "bst-cache.json"
+        history_file = tmp_path / "docs" / "data" / "history" / "cache-heat.ndjson"
+        monkeypatch.setattr(cbc, "OUT_PATH", str(out_file))
+        monkeypatch.setattr(cbc, "HISTORY_PATH", str(history_file))
+
+        def mock_raw(path):
+            if "nodes/ghost" in path or "nodes/exo-0" in path:
+                return json.dumps({
+                    "metadata": {
+                        "annotations": {
+                            "lab.projectbluefin.io/usb4-link": "up",
+                            "lab.projectbluefin.io/usb4-link-observed-at": "2026-01-01T00:00:00Z"
+                        }
+                    }
+                })
+            if "metrics" in path:
+                return SAMPLE_METRICS
+            return None
+
+        def mock_json_raw(path):
+            if "status" in path:
+                return {"CurrSize": 1000, "MaxSize": 5000}
+            if "pods/storage-0" in path:
+                return {"spec": {"nodeName": "ghost"}}
+            if "pods/storage-1" in path:
+                return {"spec": {"nodeName": "exo-0"}}
+            return None
+
+        monkeypatch.setattr(cbc, "run_raw", mock_raw)
+        monkeypatch.setattr(cbc, "run_json_raw", mock_json_raw)
+
+        cbc.main()
+
+        assert out_file.exists()
+        doc = json.loads(out_file.read_text())
+        assert doc["_meta"]["freshness_state"] == "fresh"
+        assert doc["usb4_telemetry"]["status"] == "up"
+
+        rows_by_id = {r["id"]: r for r in doc["rows"]}
+        bazel_row = rows_by_id["bazel-remote-ghost"]
+        assert bazel_row["state"] == "available"
+        assert bazel_row["used_bytes"] == 1000
+        assert bazel_row["percent"] == 20.0
+
+        cas_row_0 = rows_by_id["buildbarn-storage-0-cas"]
+        assert cas_row_0["state"] == "available"
+        assert cas_row_0["node"] == "ghost"
+        # 10 allocations - 2 releases = 8 blocks. block_size = 20GiB / 35
+        expected_used = 8 * (cbc.CAS_CAPACITY_BYTES / cbc.CAS_BLOCKS)
+        assert cas_row_0["used_bytes"] == pytest.approx(expected_used)

--- a/tests/unit/test_refresh_factory_stats.py
+++ b/tests/unit/test_refresh_factory_stats.py
@@ -1,0 +1,239 @@
+"""Unit tests for scripts/refresh_factory_stats.py."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo_root / "scripts"))
+
+import refresh_factory_stats as rfs
+
+
+class TestRefreshFactoryStatsHelpers:
+    def test_parse_iso(self):
+        assert rfs.parse_iso(None) is None
+        assert rfs.parse_iso("") is None
+        assert rfs.parse_iso("invalid") is None
+
+        dt = rfs.parse_iso("2026-01-01T12:00:00Z")
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.tzinfo is not None
+
+        dt_offset = rfs.parse_iso("2026-01-01T12:00:00+00:00")
+        assert dt_offset is not None
+
+    def test_argo_ui_url(self):
+        assert rfs.argo_ui_url("my-wf") == "http://192.168.1.102:32746/workflows/argo/my-wf"
+
+    def test_phase_to_overall(self):
+        assert rfs.phase_to_overall("Running") == "running"
+        assert rfs.phase_to_overall("Pending") == "running"
+        assert rfs.phase_to_overall("Succeeded") == "passed"
+        assert rfs.phase_to_overall("Failed") == "fail"
+        assert rfs.phase_to_overall("Error") == "fail"
+        assert rfs.phase_to_overall("Unknown") == "pending"
+
+    def test_infer_trigger(self):
+        assert rfs.infer_trigger(None) == "manual"
+        assert rfs.infer_trigger("") == "manual"
+        assert rfs.infer_trigger("nightly-build") == "nightly"
+        assert rfs.infer_trigger("image-poll-123") == "poller"
+        assert rfs.infer_trigger("digest-watch-456") == "poller"
+        assert rfs.infer_trigger("pr-123-check") == "pr-poller"
+        assert rfs.infer_trigger("custom-build") == "manual"
+
+    def test_pipeline_base_name_and_key(self):
+        assert rfs.pipeline_base_name("build-containerdisk-dsrlm") == "build-containerdisk"
+        assert rfs.pipeline_base_name("orphan-pod-gc-1783047600") == "orphan-pod-gc"
+        assert rfs.pipeline_base_name("bluefin-qa-pipeline") == "bluefin-qa-pipeline"
+
+        assert rfs.build_pipeline_key("build-containerdisk-dsrlm") == "build-containerdisk"
+        assert rfs.build_pipeline_key("dakota-qa-pipeline-abcde") == "dakota-qa-pipeline"
+        assert rfs.build_pipeline_key("orphan-pod-gc-1783047600") is None
+
+    def test_infer_label(self):
+        assert rfs.infer_label([{"name": "variant", "value": "silverblue"}, {"name": "image-tag", "value": "39"}], "wf") == "silverblue:39"
+        assert rfs.infer_label([{"name": "image", "value": "ghcr.io/org/bluefin"}, {"name": "image-tag", "value": "latest"}], "wf") == "bluefin:latest"
+        assert rfs.infer_label([{"name": "image", "value": "ghcr.io/org/bluefin"}], "wf") == "bluefin"
+        assert rfs.infer_label([], "dakota-wf") == "dakota:latest"
+        assert rfs.infer_label([], "other-wf") is None
+
+    def test_safe_int(self):
+        assert rfs.safe_int(42) == 42
+        assert rfs.safe_int("123") == 123
+        assert rfs.safe_int("invalid", default=99) == 99
+
+    def test_parse_mem_gib(self):
+        assert rfs.parse_mem_gib(None) is None
+        assert rfs.parse_mem_gib("1048576Ki") == 1
+        assert rfs.parse_mem_gib("2048Mi") == 2
+        assert rfs.parse_mem_gib("16Gi") == 16
+        assert rfs.parse_mem_gib("invalid") is None
+
+    def test_parse_mem_bytes(self):
+        assert rfs.parse_mem_bytes(None) is None
+        assert rfs.parse_mem_bytes("1Ki") == 1024
+        assert rfs.parse_mem_bytes("1Mi") == 1024 * 1024
+        assert rfs.parse_mem_bytes("1Gi") == 1024 * 1024 * 1024
+        assert rfs.parse_mem_bytes("1Ti") == 1024 * 1024 * 1024 * 1024
+        assert rfs.parse_mem_bytes("500") == 500
+        assert rfs.parse_mem_bytes("invalid") is None
+
+    def test_parse_cpu_millicores(self):
+        assert rfs.parse_cpu_millicores(None) is None
+        assert rfs.parse_cpu_millicores("1000000n") == 1.0
+        assert rfs.parse_cpu_millicores("1000u") == 1.0
+        assert rfs.parse_cpu_millicores("500m") == 500.0
+        assert rfs.parse_cpu_millicores(2) == 2000.0
+        assert rfs.parse_cpu_millicores("invalid") is None
+
+    def test_gh_run_to_overall(self):
+        assert rfs.gh_run_to_overall({"status": "in_progress"}) == "running"
+        assert rfs.gh_run_to_overall({"status": "completed", "conclusion": "success"}) == "passed"
+        assert rfs.gh_run_to_overall({"status": "completed", "conclusion": "failure"}) == "fail"
+        assert rfs.gh_run_to_overall({"status": "completed", "conclusion": "timed_out"}) == "fail"
+        assert rfs.gh_run_to_overall({"status": "completed", "conclusion": "startup_failure"}) == "fail"
+        assert rfs.gh_run_to_overall({"status": "completed", "conclusion": "cancelled"}) == "pending"
+        assert rfs.gh_run_to_overall({"status": "completed", "conclusion": "neutral"}) == "pending"
+
+    def test_gh_run_duration_min(self):
+        run_valid = {
+            "run_started_at": "2026-01-01T12:00:00Z",
+            "updated_at": "2026-01-01T12:35:00Z"
+        }
+        assert rfs.gh_run_duration_min(run_valid) == 35
+        run_invalid = {
+            "run_started_at": "invalid",
+            "updated_at": "2026-01-01T12:35:00Z"
+        }
+        assert rfs.gh_run_duration_min(run_invalid) is None
+
+    def test_sha256_file(self, tmp_path):
+        f = tmp_path / "test.txt"
+        f.write_text("bluefin lab", encoding="utf-8")
+        h = rfs.sha256_file(f)
+        assert h.startswith("sha256:")
+        assert len(h) == 7 + 64
+
+    def test_append_build_runs_ndjson(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        history_dir = tmp_path / "docs" / "data" / "history"
+        history_dir.mkdir(parents=True, exist_ok=True)
+        ndjson_file = history_dir / "build-runs.ndjson"
+
+        # Prepopulate with old (to prune) and recent records
+        old_time = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        recent_time = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        ndjson_file.write_text(
+            json.dumps({"plane": "publish", "run_id": "old_run", "recorded_at": old_time}) + "\n" +
+            json.dumps({"plane": "publish", "run_id": "existing_run", "recorded_at": recent_time}) + "\n"
+        )
+
+        catalog = [
+            {"id": "bluefin-stable", "repo": "projectbluefin/bluefin"}
+        ]
+        now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        stats = {
+            "image_builds": {
+                "bluefin-stable": [
+                    {
+                        "id": "existing_run",  # Already exists, should not duplicate
+                        "overall": "passed",
+                        "duration_min": 15,
+                    },
+                    {
+                        "id": "new_run_1",
+                        "overall": "passed",
+                        "duration_min": 25,
+                        "started_at": "2026-01-02T00:00:00Z",
+                        "finished_at": "2026-01-02T00:25:00Z",
+                        "run_url": "https://github.com/test",
+                    },
+                    {
+                        "id": "pending_run",  # Non-terminal, should be skipped
+                        "overall": "running",
+                        "duration_min": None,
+                    }
+                ]
+            },
+            "build_history": {
+                "bluefin-qa-pipeline": [
+                    {
+                        "id": "wf_run_1",
+                        "overall": "failed",
+                        "duration_min": 30,
+                        "started_at": "2026-01-02T01:00:00Z",
+                        "finished_at": "2026-01-02T01:30:00Z",
+                        "run_url": "http://argo/wf_run_1",
+                    }
+                ]
+            }
+        }
+
+        rfs.append_build_runs_ndjson(stats, catalog, now)
+
+        lines = [json.loads(line) for line in ndjson_file.read_text().splitlines()]
+        run_ids = {r["run_id"] for r in lines}
+
+        assert "old_run" not in run_ids
+        assert "existing_run" in run_ids
+        assert "new_run_1" in run_ids
+        assert "wf_run_1" in run_ids
+        assert "pending_run" not in run_ids
+
+        new_pub = next(r for r in lines if r["run_id"] == "new_run_1")
+        assert new_pub["plane"] == "publish"
+        assert new_pub["status"] == "passed"
+        assert new_pub["repo"] == "projectbluefin/bluefin"
+
+        new_lab = next(r for r in lines if r["run_id"] == "wf_run_1")
+        assert new_lab["plane"] == "lab"
+        assert new_lab["status"] == "failed"
+        assert new_lab["repo"] == "projectbluefin/lab"
+
+
+class TestRefreshFactoryStatsExecution:
+    def test_main_execution(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        docs_data = tmp_path / "docs" / "data"
+        docs_data.mkdir(parents=True)
+
+        stats_path = docs_data / "factory-stats.json"
+        stats_path.write_text(json.dumps({
+            "test_coverage": {},
+            "recent_runs": [],
+            "image_builds": {}
+        }))
+
+        # Mock argv: issue_count=10, pr_count=5, merged_7d=3
+        monkeypatch.setattr(sys, "argv", ["refresh_factory_stats.py", "10", "5", "3"])
+
+        # Mock subprocess.check_output to simulate offline / fallback environment
+        monkeypatch.setattr(subprocess, "check_output", lambda *args, **kwargs: (_ for _ in ()).throw(Exception("offline")))
+
+        rfs.main()
+
+        assert stats_path.exists()
+        updated_stats = json.loads(stats_path.read_text())
+        assert updated_stats["github"]["testing_lab"]["open_issues"] == 10
+        assert updated_stats["github"]["testing_lab"]["open_prs"] == 5
+        assert updated_stats["github"]["testing_lab"]["prs_merged_7d"] == 3
+        assert "_meta" in updated_stats
+
+        telemetry_path = docs_data / "factory-telemetry.json"
+        assert telemetry_path.exists()
+        telemetry = json.loads(telemetry_path.read_text())
+        assert telemetry["schema_version"] == "v2"
+        assert "metrics" in telemetry
+
+        history_path = docs_data / "factory-history.json"
+        assert history_path.exists()
+        history = json.loads(history_path.read_text())
+        assert history["window_days"] == 7

--- a/tests/unit/test_refresh_gitops_stats.py
+++ b/tests/unit/test_refresh_gitops_stats.py
@@ -1,0 +1,135 @@
+"""Unit tests for scripts/refresh_gitops_stats.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo_root / "scripts"))
+
+import refresh_gitops_stats as rgs
+
+
+class TestRefreshGitopsStats:
+    def test_run_cmd_success(self):
+        result = rgs.run_cmd("echo 'hello world'")
+        assert result == "hello world"
+
+    def test_run_cmd_failure(self):
+        result = rgs.run_cmd("false")
+        assert result is None
+
+    def test_run_cmd_exception(self):
+        with patch("subprocess.check_output", side_effect=subprocess.TimeoutExpired(cmd="test", timeout=15)):
+            assert rgs.run_cmd("test") is None
+
+    def test_main_fallback_mode(self, tmp_path, monkeypatch):
+        # Change working directory so docs/data is written inside tmp_path
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(rgs, "run_cmd", lambda cmd: None)
+
+        rgs.main()
+
+        status_file = tmp_path / "docs" / "data" / "gitops-status.json"
+        deployments_file = tmp_path / "docs" / "data" / "gitops-deployments.json"
+
+        assert status_file.exists()
+        assert deployments_file.exists()
+
+        status_data = json.loads(status_file.read_text())
+        assert status_data["schema_version"] == "v1"
+        assert status_data["_meta"]["live_snapshot_ok"] is False
+        apps = status_data["applications"]
+        assert len(apps) == 6
+        app_names = {a["name"] for a in apps}
+        assert "arc-runners" in app_names
+        assert "testing-lab-infra" in app_names
+
+        deployments_data = json.loads(deployments_file.read_text())
+        assert deployments_data["schema_version"] == "v1"
+        assert deployments_data["_meta"]["live_snapshot_ok"] is False
+        assert deployments_data["deployments"] == []
+
+    def test_main_live_applications(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        mock_argo_json = json.dumps({
+            "items": [
+                {
+                    "metadata": {"name": "test-app", "namespace": "argocd"},
+                    "spec": {
+                        "source": {
+                            "path": "manifests/test",
+                            "repoURL": "https://github.com/projectbluefin/lab",
+                            "targetRevision": "main"
+                        },
+                        "destination": {"namespace": "test-ns"}
+                    },
+                    "status": {
+                        "sync": {"status": "Synced"},
+                        "health": {"status": "Healthy"},
+                        "resources": [
+                            {
+                                "group": "apps",
+                                "kind": "Deployment",
+                                "name": "my-dep",
+                                "namespace": "test-ns",
+                                "status": "OutOfSync"
+                            },
+                            {
+                                "group": "",
+                                "kind": "Service",
+                                "name": "my-svc",
+                                "namespace": "test-ns",
+                                "status": "Synced"
+                            }
+                        ],
+                        "history": [
+                            {
+                                "id": 1,
+                                "revision": "abcdef1",
+                                "deployStartedAt": "2026-01-01T00:00:00Z",
+                                "deployedAt": "2026-01-01T00:05:00Z"
+                            },
+                            {
+                                "id": 2,
+                                "revision": "abcdef2",
+                                "deployStartedAt": "2026-01-02T00:00:00Z",
+                                "deployedAt": None
+                            }
+                        ]
+                    }
+                }
+            ]
+        })
+
+        monkeypatch.setattr(rgs, "run_cmd", lambda cmd: mock_argo_json)
+
+        rgs.main()
+
+        status_file = tmp_path / "docs" / "data" / "gitops-status.json"
+        deployments_file = tmp_path / "docs" / "data" / "gitops-deployments.json"
+
+        status_data = json.loads(status_file.read_text())
+        assert status_data["_meta"]["live_snapshot_ok"] is True
+        assert len(status_data["applications"]) == 1
+        app = status_data["applications"][0]
+        assert app["name"] == "test-app"
+        assert app["sync_status"] == "Synced"
+        assert app["health_status"] == "Healthy"
+        assert app["drifted_count"] == 1
+        assert app["drifted_resources"][0]["name"] == "my-dep"
+
+        deployments_data = json.loads(deployments_file.read_text())
+        assert deployments_data["_meta"]["live_snapshot_ok"] is True
+        deps = deployments_data["deployments"]
+        assert len(deps) == 2
+        # sorted latest first (2026-01-02 before 2026-01-01)
+        assert deps[0]["id"] == 2
+        assert deps[0]["status"] == "failed"
+        assert deps[1]["id"] == 1
+        assert deps[1]["status"] == "passed"

--- a/tests/unit/test_validate_docs.py
+++ b/tests/unit/test_validate_docs.py
@@ -1,0 +1,151 @@
+"""Unit tests for scripts/validate-docs.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[2]
+script_path = repo_root / "scripts" / "validate-docs.py"
+spec = importlib.util.spec_from_file_location("validate_docs", script_path)
+validate_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validate_docs)
+
+
+class TestValidateDocs:
+    def test_validate_frontmatter_valid(self, tmp_path):
+        doc = tmp_path / "valid.md"
+        doc.write_text("---\nname: test-skill\ndescription: A test skill\n---\n# Content\n", encoding="utf-8")
+        assert validate_docs.validate_frontmatter(doc) == []
+
+    def test_validate_frontmatter_missing_opener(self, tmp_path):
+        doc = tmp_path / "no_opener.md"
+        doc.write_text("name: test\ndescription: desc\n---\n", encoding="utf-8")
+        errors = validate_docs.validate_frontmatter(doc)
+        assert len(errors) == 1
+        assert "missing YAML frontmatter opener" in errors[0]
+
+    def test_validate_frontmatter_missing_closer(self, tmp_path):
+        doc = tmp_path / "no_closer.md"
+        doc.write_text("---\nname: test\ndescription: desc\n", encoding="utf-8")
+        errors = validate_docs.validate_frontmatter(doc)
+        assert len(errors) == 1
+        assert "missing YAML frontmatter closer" in errors[0]
+
+    def test_validate_frontmatter_missing_required_fields(self, tmp_path):
+        doc = tmp_path / "no_fields.md"
+        doc.write_text("---\nfoo: bar\n---\n", encoding="utf-8")
+        errors = validate_docs.validate_frontmatter(doc)
+        assert any("frontmatter missing 'name'" in e for e in errors)
+        assert any("frontmatter missing 'description'" in e for e in errors)
+
+    def test_validate_size(self, tmp_path):
+        doc = tmp_path / "doc.md"
+        doc.write_text("line 1\nline 2\nline 3\n", encoding="utf-8")
+        assert validate_docs.validate_size(doc, 5) == []
+        errors = validate_docs.validate_size(doc, 2)
+        assert len(errors) == 1
+        assert "exceeds 2" in errors[0]
+
+    def test_collect_md_files(self):
+        files = validate_docs.collect_md_files()
+        assert isinstance(files, set)
+        assert Path("README.md") in files or Path("AGENTS.md") in files
+
+    def test_validate_links_valid_and_external(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validate_docs, "ROOT", tmp_path)
+        target = tmp_path / "target.md"
+        target.write_text("# Target", encoding="utf-8")
+        source = tmp_path / "source.md"
+        source.write_text(
+            "[target](target.md)\n"
+            "[target with anchor](target.md#section)\n"
+            "[root target](/target.md)\n"
+            "[self anchor](#section)\n"
+            "[http](https://example.com)\n"
+            "[mailto](mailto:dev@example.com)\n",
+            encoding="utf-8",
+        )
+        errors = validate_docs.validate_links({Path("source.md")})
+        assert errors == []
+
+    def test_validate_links_broken(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validate_docs, "ROOT", tmp_path)
+        source = tmp_path / "source.md"
+        source.write_text("[broken](nonexistent.md)\n[broken root](/no/such/file.md)", encoding="utf-8")
+        errors = validate_docs.validate_links({Path("source.md")})
+        assert len(errors) == 2
+        assert any("broken link to nonexistent.md" in e for e in errors)
+        assert any("broken link to /no/such/file.md" in e for e in errors)
+
+    def test_find_forbidden(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validate_docs, "ROOT", tmp_path)
+        clean = tmp_path / "clean.md"
+        clean.write_text("Normal safe text\n", encoding="utf-8")
+        dirty = tmp_path / "dirty.md"
+        dirty.write_text("Hello jorge@example.com\nIP 192.168.1.5\ncopilot-config\n", encoding="utf-8")
+
+        assert validate_docs.find_forbidden({Path("clean.md")}) == []
+        hits = validate_docs.find_forbidden({Path("dirty.md")})
+        assert len(hits) == 3
+        assert any("jorge@" in h for h in hits)
+        assert any(r"192\.168\." in h for h in hits)
+        assert any("copilot-config" in h for h in hits)
+
+    def test_validate_router_missing_router(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validate_docs, "ROOT", tmp_path)
+        errors = validate_docs.validate_router()
+        assert errors == ["docs/SKILL.md: missing skill router (common doc structure)"]
+
+    def test_validate_router_structure(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validate_docs, "ROOT", tmp_path)
+        docs_dir = tmp_path / "docs"
+        skills_dir = docs_dir / "skills" / "my-skill"
+        skills_dir.mkdir(parents=True)
+        skill_md = skills_dir / "SKILL.md"
+        skill_md.write_text("---\nname: my-skill\ndescription: demo\n---\n", encoding="utf-8")
+
+        router = docs_dir / "SKILL.md"
+        router.write_text("## Read order\n## Skill index\n- [my-skill](skills/my-skill/SKILL.md)\n", encoding="utf-8")
+
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("See docs/SKILL.md for skills.\n", encoding="utf-8")
+
+        monkeypatch.setattr(validate_docs, "skills", lambda: [skill_md])
+        errors = validate_docs.validate_router()
+        assert errors == []
+
+    def test_validate_router_missing_skill_link(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validate_docs, "ROOT", tmp_path)
+        docs_dir = tmp_path / "docs"
+        skills_dir = docs_dir / "skills" / "my-skill"
+        skills_dir.mkdir(parents=True)
+        skill_md = skills_dir / "SKILL.md"
+        skill_md.write_text("---\nname: my-skill\ndescription: demo\n---\n", encoding="utf-8")
+
+        router = docs_dir / "SKILL.md"
+        router.write_text("## Read order\n## Skill index\n", encoding="utf-8")
+
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("See docs/SKILL.md for skills.\n", encoding="utf-8")
+
+        monkeypatch.setattr(validate_docs, "skills", lambda: [skill_md])
+        errors = validate_docs.validate_router()
+        assert len(errors) == 1
+        assert "skill index does not list skills/my-skill/SKILL.md" in errors[0]
+
+    def test_main_passes(self, monkeypatch):
+        monkeypatch.setattr(validate_docs, "skills", list)
+        monkeypatch.setattr(validate_docs, "collect_md_files", lambda: set())
+        monkeypatch.setattr(validate_docs, "validate_links", lambda files: [])
+        monkeypatch.setattr(validate_docs, "validate_router", list)
+        monkeypatch.setattr(validate_docs, "find_forbidden", lambda files: [])
+        assert validate_docs.main() == 0
+
+    def test_main_fails_on_errors(self, monkeypatch):
+        monkeypatch.setattr(validate_docs, "skills", list)
+        monkeypatch.setattr(validate_docs, "collect_md_files", lambda: set())
+        monkeypatch.setattr(validate_docs, "validate_links", lambda files: ["broken link"])
+        monkeypatch.setattr(validate_docs, "validate_router", list)
+        monkeypatch.setattr(validate_docs, "find_forbidden", lambda files: [])
+        assert validate_docs.main() == 1


### PR DESCRIPTION
Closes #702.

### Summary
Adds unit test suites under `tests/unit/` for the five `scripts/` modules identified in #702 that lacked test coverage:

1. **`scripts/validate-docs.py`** (`tests/unit/test_validate_docs.py`):
   - Frontmatter validation (missing openers, closers, required `name`/`description`).
   - Line length threshold enforcement via `validate_size`.
   - File collection via `collect_md_files`.
   - Markdown link validation (anchor/external vs local resolution).
   - Forbidden regex search.
   - Skill router structure check (`validate_router`).
   - Main function exit status validation.

2. **`scripts/refresh_gitops_stats.py`** (`tests/unit/test_refresh_gitops_stats.py`):
   - `run_cmd` success, non-zero exit, and exception handling.
   - Fallback dataset generation when offline/unreachable.
   - ArgoCD live application parsing, resource drift detection, and rollout history sorting.

3. **`scripts/collect_app_resources.py`** (`tests/unit/test_collect_app_resources.py`):
   - `run_cmd` error and timeout paths.
   - CPU and memory unit parsing (`parse_cpu_cores`, `parse_mem_mib`).
   - Pod namespace and label-based app routing (`get_app_for_pod`).
   - Offline fallback structure and live pod container metrics aggregation.

4. **`scripts/collect_bst_cache.py`** (`tests/unit/test_collect_bst_cache.py`):
   - `run_raw` and `run_json_raw` handling.
   - Prometheus metrics parser for single values and multi-sample series.
   - BuildBarn cache heat calculation (hit/miss, requests, effectiveness).
   - History retention pruning and append logic (`persist_cache_heat`).
   - Node-for-pod resolution and main execution across live and unavailable cluster states.
   - Made directory creation idempotent in `collect_bst_cache.py` before writing artifacts.

5. **`scripts/refresh_factory_stats.py`** (`tests/unit/test_refresh_factory_stats.py`):
   - ISO timestamp parsing.
   - Rolling NDJSON history appending, deduplication, and 180-day retention pruning.
   - Derived metric helpers (`argo_ui_url`, `phase_to_overall`, `infer_trigger`, `infer_label`, `safe_int`, memory/CPU parsers, `gh_run_to_overall`, `gh_run_duration_min`, `sha256_file`).
   - Execution in fallback/offline environment verifying dataset outputs.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `2ddf6eabd`