### PR TITLE
fix(argo): forward image-digest parameter to bluefin-qa-pipeline in pr-poller

### DIFF
--- a/argo/workflow-templates/pr-poller.yaml
+++ b/argo/workflow-templates/pr-poller.yaml
@@ -560,6 +560,8 @@ spec:
                             value: "${ARGO_OPEN}workflow.parameters.image${ARGO_CLOSE}"
                           - name: image-tag
                             value: "${ARGO_OPEN}workflow.parameters.image-tag${ARGO_CLOSE}"
+                          - name: image-digest
+                            value: "${ARGO_OPEN}workflow.parameters.image-digest${ARGO_CLOSE}"
                           - name: suites
                             value: "${ARGO_OPEN}workflow.parameters.suites${ARGO_CLOSE}"
                           - name: variant

--- a/tests/unit/test_container_only_qa_workflows.py
+++ b/tests/unit/test_container_only_qa_workflows.py
@@ -1440,6 +1440,20 @@ def test_pr_poller_carries_image_digest_into_dakota_qa_workflow():
     assert "dakota-qa-pipeline" in dakota_block
 
 
+def test_pr_poller_carries_image_digest_into_bluefin_qa_workflow():
+    poller = (ROOT / "argo/workflow-templates/pr-poller.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    bluefin_block = poller.split("name: qa-bluefin", 1)[1].split("name: report-final", 1)[0]
+    assert "- name: image-digest" in bluefin_block
+    assert (
+        'value: "${ARGO_OPEN}workflow.parameters.image-digest${ARGO_CLOSE}"'
+        in bluefin_block
+    )
+    assert "bluefin-qa-pipeline" in bluefin_block
+
+
 def test_caller_contract_requires_forked_testsuite_repo_and_branch():
     contract = (ROOT / "docs/skills/argo-workflows/authoring.md").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Fixes #750

### Summary

In `argo/workflow-templates/pr-poller.yaml`, the inline `pr-pipeline` DAG invokes `bluefin-qa-pipeline` via `templateRef` for bluefin PR validation. However, while `image-digest` was passed to `qa-dakota`, it was omitted from the arguments for `qa-bluefin`.

Because `bluefin-qa-pipeline`'s `pipeline` template defines `image-digest` and passes `{{inputs.parameters.image-digest}}` to each `test-lane` (`run-container-tests`), missing this argument causes template resolution issues during the DAG execution.

This PR:
1. Passes `image-digest` (`${ARGO_OPEN}workflow.parameters.image-digest${ARGO_CLOSE}`) to `qa-bluefin` in `pr-poller.yaml`.
2. Adds a regression unit test in `tests/unit/test_container_only_qa_workflows.py` ensuring `image-digest` is wired for `qa-bluefin` matching the existing test for `qa-dakota`.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `cd88791a6`