### PR TITLE
fix(bst): publish usb4-link node label and enforce admission gate in pipelines (#639)

### DIFF
--- a/argo/workflow-templates/bluefin-server-build-pipeline.yaml
+++ b/argo/workflow-templates/bluefin-server-build-pipeline.yaml
@@ -224,12 +224,15 @@ spec:
           MAX_AGE_SECONDS=60
           NOW="$(date -u +%s)"
           for NODE in ghost exo-0; do
-            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.labels.lab\.projectbluefin\.io/usb4-link}')"
+            if [[ -z "${LINK}" ]]; then
+              LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            fi
             OBSERVED_AT="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link-observed-at}')"
             READY="$(kubectl get node "${NODE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
 
             if [[ "${LINK}" != "up" || ! "${OBSERVED_AT}" =~ ^[0-9]+$ || "${READY}" != "True" ]]; then
-              echo "USB4 BuildBarn gate rejected ${NODE}: link=${LINK:-missing} observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
+              echo "USB4 BuildBarn gate rejected ${NODE}: link=${LINK:-missing} (label/annotation lab.projectbluefin.io/usb4-link) observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
               exit 1
             fi
             if (( NOW - OBSERVED_AT > MAX_AGE_SECONDS )); then

--- a/argo/workflow-templates/bst-cache-warm.yaml
+++ b/argo/workflow-templates/bst-cache-warm.yaml
@@ -160,12 +160,15 @@ spec:
           MAX_AGE_SECONDS=60
           NOW="$(date -u +%s)"
           for NODE in ghost exo-0; do
-            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.labels.lab\.projectbluefin\.io/usb4-link}')"
+            if [[ -z "${LINK}" ]]; then
+              LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            fi
             OBSERVED_AT="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link-observed-at}')"
             READY="$(kubectl get node "${NODE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
 
             if [[ "${LINK}" != "up" || ! "${OBSERVED_AT}" =~ ^[0-9]+$ || "${READY}" != "True" ]]; then
-              echo "Cache warmup rejected ${NODE}: link=${LINK:-missing} observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
+              echo "Cache warmup rejected ${NODE}: link=${LINK:-missing} (label/annotation lab.projectbluefin.io/usb4-link) observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
               exit 1
             fi
             if (( NOW - OBSERVED_AT > MAX_AGE_SECONDS )); then

--- a/argo/workflow-templates/bst-qa-pipeline.yaml
+++ b/argo/workflow-templates/bst-qa-pipeline.yaml
@@ -32,7 +32,7 @@ spec:
       - name: remote-execution-service
         value: "grpc://frontend.buildbarn.svc.cluster.local:8980"
 
-  entrypoint: build
+  entrypoint: pipeline
   metrics:
     prometheus:
       - name: lab_build_workflow_completed_total
@@ -56,6 +56,72 @@ spec:
           value: "{{workflow.duration}}"
 
   templates:
+
+    - name: pipeline
+      steps:
+        - - name: check-admission
+            template: check-admission
+        - - name: run-build
+            template: build
+            arguments:
+              parameters:
+                - name: repo
+                  value: "{{workflow.parameters.repo}}"
+                - name: ref
+                  value: "{{workflow.parameters.ref}}"
+                - name: project-subdir
+                  value: "{{workflow.parameters.project-subdir}}"
+                - name: element
+                  value: "{{workflow.parameters.element}}"
+                - name: remote-execution-service
+                  value: "{{workflow.parameters.remote-execution-service}}"
+
+    - name: check-admission
+      script:
+        image: cgr.dev/chainguard/kubectl:latest-dev
+        command: [bash]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+        source: |
+          set -euo pipefail
+
+          MAX_AGE_SECONDS=60
+          NOW="$(date -u +%s)"
+          for NODE in ghost exo-0; do
+            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.labels.lab\.projectbluefin\.io/usb4-link}')"
+            if [[ -z "${LINK}" ]]; then
+              LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            fi
+            OBSERVED_AT="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link-observed-at}')"
+            READY="$(kubectl get node "${NODE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
+
+            if [[ "${LINK}" != "up" || ! "${OBSERVED_AT}" =~ ^[0-9]+$ || "${READY}" != "True" ]]; then
+              echo "USB4 BuildBarn gate rejected ${NODE}: link=${LINK:-missing} (label/annotation lab.projectbluefin.io/usb4-link) observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
+              exit 1
+            fi
+            if (( NOW - OBSERVED_AT > MAX_AGE_SECONDS )); then
+              echo "USB4 BuildBarn gate rejected ${NODE}: observation is stale ($((NOW - OBSERVED_AT))s old)" >&2
+              exit 1
+            fi
+          done
+
+          # Match the BuildBarn worker containers by name, not by container
+          # count: the DaemonSet also runs preparation sidecars whose readiness
+          # is a separate health boundary from outer remote execution.
+          WORKERS="$(kubectl get pods -n buildbarn -l app=worker -o jsonpath='{range .items[*]}{.spec.nodeName}{"|"}{.status.phase}{"|worker="}{range .status.containerStatuses[?(@.name=="worker")]}{.ready}{end}{"|runner="}{range .status.containerStatuses[?(@.name=="runner")]}{.ready}{end}{"\n"}{end}')"
+          for NODE in ghost exo-0; do
+            if ! grep -Eq "^${NODE}\|Running\|worker=true\|runner=true$" <<<"${WORKERS}"; then
+              echo "USB4 BuildBarn gate rejected: no Ready worker on ${NODE}" >&2
+              exit 1
+            fi
+          done
+
+          echo "USB4-backed BuildBarn remote execution admitted"
 
     - name: build
       inputs:

--- a/argo/workflow-templates/cosmic-build-pipeline.yaml
+++ b/argo/workflow-templates/cosmic-build-pipeline.yaml
@@ -198,12 +198,15 @@ spec:
           MAX_AGE_SECONDS=60
           NOW="$(date -u +%s)"
           for NODE in ghost exo-0; do
-            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.labels.lab\.projectbluefin\.io/usb4-link}')"
+            if [[ -z "${LINK}" ]]; then
+              LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            fi
             OBSERVED_AT="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link-observed-at}')"
             READY="$(kubectl get node "${NODE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
 
             if [[ "${LINK}" != "up" || ! "${OBSERVED_AT}" =~ ^[0-9]+$ || "${READY}" != "True" ]]; then
-              echo "USB4 BuildBarn gate rejected ${NODE}: link=${LINK:-missing} observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
+              echo "USB4 BuildBarn gate rejected ${NODE}: link=${LINK:-missing} (label/annotation lab.projectbluefin.io/usb4-link) observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
               exit 1
             fi
             if (( NOW - OBSERVED_AT > MAX_AGE_SECONDS )); then

--- a/argo/workflow-templates/dakota-build-pipeline.yaml
+++ b/argo/workflow-templates/dakota-build-pipeline.yaml
@@ -311,12 +311,15 @@ spec:
           MAX_AGE_SECONDS=60
           NOW="$(date -u +%s)"
           for NODE in ghost exo-0; do
-            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.labels.lab\.projectbluefin\.io/usb4-link}')"
+            if [[ -z "${LINK}" ]]; then
+              LINK="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link}')"
+            fi
             OBSERVED_AT="$(kubectl get node "${NODE}" -o jsonpath='{.metadata.annotations.lab\.projectbluefin\.io/usb4-link-observed-at}')"
             READY="$(kubectl get node "${NODE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
 
             if [[ "${LINK}" != "up" || ! "${OBSERVED_AT}" =~ ^[0-9]+$ || "${READY}" != "True" ]]; then
-              echo "USB4 BuildBarn gate rejected ${NODE}: link=${LINK:-missing} observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
+              echo "USB4 BuildBarn gate rejected ${NODE}: link=${LINK:-missing} (label/annotation lab.projectbluefin.io/usb4-link) observed-at=${OBSERVED_AT:-missing} ready=${READY:-unknown}" >&2
               exit 1
             fi
             if (( NOW - OBSERVED_AT > MAX_AGE_SECONDS )); then

--- a/docs/ops/architecture.md
+++ b/docs/ops/architecture.md
@@ -48,7 +48,7 @@ standard Ethernet only — none currently have a physical USB4/Thunderbolt link 
 - Intended for pod-to-pod (East-West) traffic between these two nodes specifically:
   build artifact transfer, cache I/O.
 - Live link state and its Unix observation time are published as
-  `lab.projectbluefin.io/usb4-link: up|down` and
+  `lab.projectbluefin.io/usb4-link: up|down` (both as a node label and annotation) and
   `lab.projectbluefin.io/usb4-link-observed-at` by the `usb4-link-monitor`
   DaemonSet (`manifests/usb4-link-monitor.yaml`). Every BST pipeline admits
   BuildBarn remote execution only when both node observations are fresh and

--- a/docs/skills/cluster-tooling/buildstream.md
+++ b/docs/skills/cluster-tooling/buildstream.md
@@ -30,13 +30,27 @@ remote-cache-only run is not an acceptable substitute.
   Kubernetes selects a schedulable node and the local-path provisioner binds
   the PVC below that node's configured data mount. Do not select a node or
   bind-mount a cache path to influence placement.
-- **BST lane policy:** Dakota, COSMIC, and Bluefin Server accept only
+- **BST lane policy:** Dakota, COSMIC, Bluefin Server, and QA pipelines accept only
   `build-mode=re`. Before admission, every lane requires a fresh USB4 `up`
-  annotation and a Ready BuildBarn worker on both `ghost` and `exo-0`.
+  label and annotation (`lab.projectbluefin.io/usb4-link=up`, timestamp within 60s)
+  and a Ready BuildBarn worker on both `ghost` and `exo-0`.
   Runner-local, cache-only, Ethernet-backed, automatic fallback, and
   remote-cache-only execution are prohibited. Before treating a run as
   distributed, verify its generated `projects.<name>.remote-execution`
   configuration, BuildStream RE startup, and current worker action activity.
+  Pipelines fail closed immediately with an explicit rejection when the USB4
+  link is unavailable or stale rather than queueing indefinitely in the scheduler.
+- **Verifying USB4 admission state:** The `usb4-link-monitor` DaemonSet evaluates
+  link health every 15s and publishes both the node label `lab.projectbluefin.io/usb4-link=up|down`
+  and annotations (`lab.projectbluefin.io/usb4-link` and timestamp
+  `lab.projectbluefin.io/usb4-link-observed-at`). Check state before submitting:
+  ```bash
+  kubectl get nodes -L lab.projectbluefin.io/usb4-link
+  ```
+  or verify the label directly:
+  ```bash
+  kubectl get nodes --show-labels | grep -o 'usb4-link=[a-z]*'
+  ```
   Dakota uses a two-slot `bst-build` semaphore and workflow-owned 200Gi
   `local-path` cache PVCs. The distributed workflow builds both `oci/bluefin.bst`
   (`dakota:testing`) and `oci/bluefin-nvidia.bst` (`dakota-nvidia:testing`). NVIDIA

--- a/manifests/usb4-link-monitor.yaml
+++ b/manifests/usb4-link-monitor.yaml
@@ -1,10 +1,10 @@
-# USB4 link monitor — annotates ghost and exo-0 with the live state of the
-# point-to-point thunderbolt0 data-plane link. BuildStream pipelines admit
-# distributed remote execution only while both observations are fresh and up.
+# USB4 link monitor — annotates and labels ghost and exo-0 with the live state
+# of the point-to-point thunderbolt0 data-plane link. BuildStream pipelines
+# admit distributed remote execution only while both observations are fresh and up.
 #
-# Annotations:
-# - lab.projectbluefin.io/usb4-link = up | down
-# - lab.projectbluefin.io/usb4-link-observed-at = Unix epoch seconds
+# Labels and Annotations:
+# - lab.projectbluefin.io/usb4-link = up | down (node label and annotation)
+# - lab.projectbluefin.io/usb4-link-observed-at = Unix epoch seconds (annotation)
 # "up" requires operstate=up AND carrier=1 AND a TCP probe of the peer's
 # kubelet port over the tb subnet (10.99.0.0/30) — proving end-to-end
 # reachability, not just local link state.
@@ -150,11 +150,14 @@ spec:
                 if kubectl annotate node "${NODE_NAME}" \
                      "lab.projectbluefin.io/usb4-link=${STATE}" \
                      "lab.projectbluefin.io/usb4-link-observed-at=${OBSERVED_AT}" \
+                     --overwrite >/dev/null \
+                   && kubectl label node "${NODE_NAME}" \
+                     "lab.projectbluefin.io/usb4-link=${STATE}" \
                      --overwrite >/dev/null; then
                   [[ "${STATE}" != "${LAST}" ]] && echo "usb4-link -> ${STATE}"
                   LAST="${STATE}"
                 else
-                  echo "annotate failed, will retry" >&2
+                  echo "annotate/label failed, will retry" >&2
                 fi
                 sleep 15
               done

--- a/scripts/collect_bst_cache.py
+++ b/scripts/collect_bst_cache.py
@@ -230,7 +230,8 @@ def main():
         if ghost_link:
             ghost_doc = json.loads(ghost_link)
             ann = ghost_doc.get("metadata", {}).get("annotations", {})
-            ghost_link_val = ann.get("lab.projectbluefin.io/usb4-link")
+            lbl = ghost_doc.get("metadata", {}).get("labels", {})
+            ghost_link_val = lbl.get("lab.projectbluefin.io/usb4-link") or ann.get("lab.projectbluefin.io/usb4-link")
             ghost_obs_val = ann.get("lab.projectbluefin.io/usb4-link-observed-at")
             if ghost_link_val:
                 ghost_link = ghost_link_val
@@ -241,7 +242,8 @@ def main():
         if exo0_raw:
             exo0_doc = json.loads(exo0_raw)
             ann0 = exo0_doc.get("metadata", {}).get("annotations", {})
-            exo0_link_val = ann0.get("lab.projectbluefin.io/usb4-link")
+            lbl0 = exo0_doc.get("metadata", {}).get("labels", {})
+            exo0_link_val = lbl0.get("lab.projectbluefin.io/usb4-link") or ann0.get("lab.projectbluefin.io/usb4-link")
             exo0_obs_val = ann0.get("lab.projectbluefin.io/usb4-link-observed-at")
             if exo0_link_val:
                 exo0_link = exo0_link_val

--- a/tests/unit/test_workflow_defaults.py
+++ b/tests/unit/test_workflow_defaults.py
@@ -61,6 +61,7 @@ def test_bst_pipelines_require_fresh_usb4_backed_remote_execution():
         "dakota-build-pipeline.yaml",
         "cosmic-build-pipeline.yaml",
         "bluefin-server-build-pipeline.yaml",
+        "bst-qa-pipeline.yaml",
     ):
         pipeline = (ROOT / "argo/workflow-templates" / filename).read_text(
             encoding="utf-8"
@@ -93,6 +94,7 @@ def test_usb4_monitor_publishes_a_fresh_observation_on_every_probe():
 
     assert "lab.projectbluefin.io/usb4-link-observed-at" in monitor
     assert "date -u +%s" in monitor
+    assert "kubectl label node" in monitor
     assert "N % 20" not in monitor
 
 


### PR DESCRIPTION
Resolves #639

### Problem
BuildStream pipelines require the USB4 link to be up for distributed remote execution over BuildBarn. When the link is unavailable or down, builds queue indefinitely in the scheduler with idle workers rather than failing closed immediately. Furthermore, `usb4-link-monitor` only published node annotations (`metadata.annotations`), leaving nodes without the `lab.projectbluefin.io/usb4-link` label (`metadata.labels`), so label-based queries such as `kubectl get nodes --show-labels` reported no label.

### Solution
1. **Publish Node Labels**: Updated `manifests/usb4-link-monitor.yaml` to publish the live state as both a node label (`lab.projectbluefin.io/usb4-link=up|down`) and annotations, enabling `kubectl get nodes --show-labels | grep -o 'usb4-link=[a-z]*'` and node selectors/affinities to observe the link state.
2. **Enforce Admission Gates Across Pipelines**: Updated admission checks across `bluefin-server-build-pipeline.yaml`, `cosmic-build-pipeline.yaml`, `dakota-build-pipeline.yaml`, and `bst-cache-warm.yaml` to check both node labels and annotations with explicit error messages naming the missing/unhealthy link state upon rejection. Added the admission check step to `bst-qa-pipeline.yaml` so QA builds fail fast instead of hanging when the USB4 link is unavailable.
3. **Telemetry & Tooling**: Updated `scripts/collect_bst_cache.py` to support reading link state from either node labels or annotations.
4. **Documentation & Testing**: Clarified label and annotation verification in `docs/skills/cluster-tooling/buildstream.md` and `docs/ops/architecture.md`. Added test coverage for node labeling and QA pipeline gating in `tests/unit/test_workflow_defaults.py`.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `cebbc9080`