### PR TITLE
fix(verdict): map in-flight builds to pending instead of failed

### DIFF
--- a/scripts/collect_release_verdict.py
+++ b/scripts/collect_release_verdict.py
@@ -118,6 +118,81 @@ def latest_build(image_builds, key):
     return max(dated, key=lambda r: r["started_at"])
 
 
+def build_input(build):
+    """Compute build input status and reason for a lane's release verdict (ADR 0002).
+
+    Rules:
+    - Missing build -> status: "unavailable"
+    - In-flight / non-terminal (finished_at is None, status != "completed",
+      conclusion/overall in ("running", "pending")) -> status: "pending"
+    - Succeeded (conclusion == "success", or overall == "passed") -> status: "passed", reason: None
+    - Failed (conclusion in ("failure", "timed_out", "startup_failure"), or overall in ("fail", "failed"))
+      -> status: "failed"
+    - Any other conclusion (e.g., cancelled, skipped) -> status: "pending"
+    """
+    if not build:
+        return {
+            "status": "unavailable",
+            "reason": "no publishing workflow runs tracked in factory-stats.json for this lane",
+            "run_url": None,
+            "finished_at": None,
+        }
+
+    run_url = build.get("run_url")
+    finished_at = build.get("finished_at")
+    status = build.get("status")
+    conclusion = build.get("conclusion")
+    overall = build.get("overall")
+
+    # In-flight / non-terminal runs must never be marked failed (or passed)
+    if (
+        finished_at is None
+        or (status is not None and status != "completed")
+        or conclusion in ("running", "pending")
+        or overall in ("running", "pending")
+    ):
+        if overall == "running":
+            reason = "latest publishing run is running"
+        elif status in ("in_progress", "queued", "waiting"):
+            reason = f"latest publishing run is {status}"
+        elif finished_at is None or (status is not None and status != "completed"):
+            reason = "latest publishing run is in flight"
+        else:
+            reason = f"latest publishing run concluded {conclusion or overall or 'pending'}"
+        return {
+            "status": "pending",
+            "reason": reason,
+            "run_url": run_url,
+            "finished_at": finished_at,
+        }
+
+    # Completed runs
+    if conclusion == "success" or (conclusion is None and overall == "passed"):
+        return {
+            "status": "passed",
+            "reason": None,
+            "run_url": run_url,
+            "finished_at": finished_at,
+        }
+
+    if conclusion in ("failure", "timed_out", "startup_failure") or (
+        conclusion is None and overall in ("fail", "failed")
+    ):
+        return {
+            "status": "failed",
+            "reason": f"latest publishing run concluded {conclusion or overall}",
+            "run_url": run_url,
+            "finished_at": finished_at,
+        }
+
+    return {
+        "status": "pending",
+        "reason": f"latest publishing run concluded {conclusion or overall or 'pending'}",
+        "run_url": run_url,
+        "finished_at": finished_at,
+    }
+
+
 def _qa_substatus(rows, build_finished_at, current_digest, label):
     """Compute a pass/fail/pending/unavailable status for a subset of QA rows."""
     if not rows:
@@ -257,22 +332,10 @@ def main():
 
         # -- input 1: build ------------------------------------------------
         build = latest_build(image_builds, build_key)
-        if build:
-            build_input = {
-                "status": "passed" if build.get("overall") == "passed" else "failed",
-                "reason": None if build.get("overall") == "passed" else f"latest publishing run concluded {build.get('overall')}",
-                "run_url": build.get("run_url"),
-                "finished_at": build.get("finished_at"),
-            }
-        else:
-            build_input = {
-                "status": "unavailable",
-                "reason": "no publishing workflow runs tracked in factory-stats.json for this lane",
-                "run_url": None, "finished_at": None,
-            }
+        b_input = build_input(build)
 
         # -- input 2: qa ----------------------------------------------------
-        qa = qa_input(tests_rows, variant, branch, build_input.get("finished_at"), digest)
+        qa = qa_input(tests_rows, variant, branch, b_input.get("finished_at"), digest)
 
         # -- input 3: signature (cached by digest) ---------------------------
         prev_row = prev_rows.get(lane_id) or {}
@@ -294,7 +357,7 @@ def main():
                 sig_status, sig_reason = "unavailable", detail
 
         # -- verdict ---------------------------------------------------------
-        inputs = (build_input["status"], qa["status"], sig_status)
+        inputs = (b_input["status"], qa["status"], sig_status)
         if all(s == "passed" for s in inputs):
             verdict = "good"
         elif "failed" in inputs:
@@ -311,7 +374,12 @@ def main():
             "image_ref": image_ref,
             "digest": digest,
             "verdict": verdict,
-            "build": {"status": build_input["status"], "reason": build_input["reason"], "run_url": build_input["run_url"], "finished_at": build_input["finished_at"]},
+            "build": {
+                "status": b_input["status"],
+                "reason": b_input["reason"],
+                "run_url": b_input["run_url"],
+                "finished_at": b_input["finished_at"],
+            },
             "qa": {
                 "status": qa["status"],
                 "reason": qa["reason"],
@@ -340,7 +408,7 @@ def main():
             "lane": lane_id,
             "digest": digest,
             "verdict": verdict,
-            "build": build_input["status"],
+            "build": b_input["status"],
             "qa": qa["status"],
             "signature": sig_status,
         })

--- a/scripts/refresh_factory_stats.py
+++ b/scripts/refresh_factory_stats.py
@@ -631,6 +631,8 @@ def main():
                 runs.append({
                     'id': str(run.get('id')),
                     'overall': gh_run_to_overall(run),
+                    'status': run.get('status'),
+                    'conclusion': run.get('conclusion'),
                     'started_at': run.get('run_started_at') or run.get('created_at'),
                     'finished_at': run.get('updated_at') if run.get('status') == 'completed' else None,
                     'duration_min': gh_run_duration_min(run) if run.get('status') == 'completed' else None,

--- a/tests/unit/test_collect_release_verdict.py
+++ b/tests/unit/test_collect_release_verdict.py
@@ -2,7 +2,7 @@
 
 Covers the pure verdict logic invoked by
 .github/workflows/update-test-results.yml: load_json, now_iso, latest_build,
-_qa_substatus, qa_input, append_history and the cosign_verify no-binary path.
+build_input, _qa_substatus, qa_input, append_history and the cosign_verify no-binary path.
 Network (ghcr_digest) and main() I/O are out of scope.
 """
 
@@ -66,6 +66,128 @@ def test_latest_build_ignores_runs_without_started_at():
 def test_latest_build_unavailable_for_unknown_or_undated_lane():
     assert verdict.latest_build({}, "lane") is None
     assert verdict.latest_build({"lane": [{"id": "undated"}]}, "lane") is None
+
+
+def test_build_input_unavailable_when_none():
+    result = verdict.build_input(None)
+    assert result["status"] == "unavailable"
+    assert "no publishing workflow runs" in result["reason"]
+    assert result["run_url"] is None
+    assert result["finished_at"] is None
+
+
+def test_build_input_passed_when_conclusion_is_success():
+    build = {
+        "id": "123",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-01T00:00:00Z",
+        "finished_at": "2026-08-01T00:30:00Z",
+        "run_url": "https://github.com/org/repo/actions/runs/123",
+    }
+    result = verdict.build_input(build)
+    assert result["status"] == "passed"
+    assert result["reason"] is None
+    assert result["finished_at"] == "2026-08-01T00:30:00Z"
+    assert result["run_url"] == "https://github.com/org/repo/actions/runs/123"
+
+
+def test_build_input_passed_when_overall_is_passed_and_finished():
+    build = {
+        "id": "123",
+        "overall": "passed",
+        "started_at": "2026-08-01T00:00:00Z",
+        "finished_at": "2026-08-01T00:30:00Z",
+    }
+    result = verdict.build_input(build)
+    assert result["status"] == "passed"
+    assert result["reason"] is None
+
+
+def test_build_input_failed_for_failure_conclusions():
+    for conclusion in ("failure", "timed_out", "startup_failure"):
+        build = {
+            "id": "123",
+            "status": "completed",
+            "conclusion": conclusion,
+            "overall": "fail",
+            "started_at": "2026-08-01T00:00:00Z",
+            "finished_at": "2026-08-01T00:30:00Z",
+        }
+        result = verdict.build_input(build)
+        assert result["status"] == "failed"
+        assert conclusion in result["reason"]
+        assert result["finished_at"] == "2026-08-01T00:30:00Z"
+
+
+def test_build_input_failed_for_overall_fail_and_failed():
+    for overall in ("fail", "failed"):
+        build = {
+            "id": "123",
+            "overall": overall,
+            "started_at": "2026-08-01T00:00:00Z",
+            "finished_at": "2026-08-01T00:30:00Z",
+        }
+        result = verdict.build_input(build)
+        assert result["status"] == "failed"
+        assert overall in result["reason"]
+
+
+def test_build_input_pending_when_finished_at_is_null_never_failed():
+    # Regression test for projectbluefin/lab#616:
+    # A run with finished_at: null is in flight and must never yield build.status: "failed".
+    in_flight_builds = [
+        {"overall": "running", "finished_at": None},
+        {"overall": "fail", "finished_at": None},
+        {"overall": "passed", "finished_at": None},
+        {"status": "in_progress", "conclusion": None, "finished_at": None},
+        {"status": "queued", "conclusion": None, "finished_at": None},
+        {"status": "completed", "conclusion": "failure", "finished_at": None},
+        {"status": "completed", "conclusion": "timed_out", "finished_at": None},
+        {"finished_at": None},
+    ]
+    for build in in_flight_builds:
+        result = verdict.build_input(build)
+        assert result["status"] != "failed", f"Expected non-failed status for in-flight build: {build}"
+        assert result["status"] == "pending", f"Expected pending status for in-flight build: {build}"
+
+
+def test_build_input_pending_when_status_is_not_completed():
+    for status in ("in_progress", "queued", "waiting"):
+        build = {
+            "id": "123",
+            "status": status,
+            "started_at": "2026-08-01T00:00:00Z",
+            "finished_at": None,
+        }
+        result = verdict.build_input(build)
+        assert result["status"] == "pending"
+
+
+def test_build_input_pending_when_conclusion_or_overall_is_running_or_pending():
+    # Dakota-testing live case: run concluded cancelled/pending with finished_at set
+    build_cancelled = {
+        "id": "123",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "overall": "pending",
+        "started_at": "2026-08-01T00:00:00Z",
+        "finished_at": "2026-08-01T00:30:00Z",
+    }
+    result = verdict.build_input(build_cancelled)
+    assert result["status"] == "pending"
+    assert "latest publishing run concluded cancelled" in result["reason"]
+
+    build_pending_overall = {
+        "id": "123",
+        "overall": "pending",
+        "started_at": "2026-08-01T00:00:00Z",
+        "finished_at": "2026-08-01T00:30:00Z",
+    }
+    result = verdict.build_input(build_pending_overall)
+    assert result["status"] == "pending"
+    assert "latest publishing run concluded pending" in result["reason"]
+
 
 
 def test_qa_substatus_unavailable_when_no_rows_tracked():


### PR DESCRIPTION
## Summary

Fixes #616 by explicitly mapping GitHub Actions workflow run conclusions and overall statuses in `scripts/collect_release_verdict.py`, ensuring non-terminal and in-flight runs (`finished_at: null`, `status != "completed"`, or `conclusion`/`overall` is `running`/`pending`/`cancelled`) map to `status: "pending"` rather than falling through to `"failed"`.

## Changes

- Defined `build_input(build)` in `scripts/collect_release_verdict.py` adhering to ADR 0002:
  - `conclusion == "success"` or `overall == "passed"` (with completed status) → `passed`
  - `conclusion in ("failure", "timed_out", "startup_failure")` or `overall in ("fail", "failed")` → `failed`
  - Incomplete/in-flight runs (`finished_at is None`, `status != "completed"`, `conclusion`/`overall` is running or pending) → `pending`
- Preserved `status` and `conclusion` attributes on `image_builds` entries in `scripts/refresh_factory_stats.py`.
- Added unit tests in `tests/unit/test_collect_release_verdict.py`, including regression tests asserting that runs with `finished_at: null` never yield `build.status: "failed"`.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `f99b4e72b`