### PR TITLE
fix(ci): measure scripts in coverage gate

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,16 @@
 # Coverage contract for the unit-test gate.
 #
-# This is the *coverage* scope and it is deliberately NARROWER than the *check*
-# scope in .python-scope. .python-scope names every tree whose Python must at
-# minimum parse and be linted (scripts/ + tests/); the list below names only the
-# modules the unit gate actually exercises and can therefore hold to a coverage
-# floor. The difference is intentional — do not "sync" the two files.
+# The scripts tree is included so changes to production automation affect the
+# measured result instead of being hidden behind coverage of test helpers alone.
+# Keep the floor in ci.yml at the measured repository baseline and ratchet it as
+# script coverage improves.
 #
 # The unit suite exercises the shared helper modules below.  Other
 # tests/service_catalog/shared helpers are validated by the service-catalog
 # lane integration tests, not by this unit gate, so they are omitted here.
 [run]
 source =
+    scripts
     tests/shared
     tests/service_catalog/shared
 omit =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run unit tests with coverage
         # .coveragerc defines the intended unit-test coverage contract.
-        run: python -m pytest --cov-config=.coveragerc --cov=tests/shared --cov=tests/service_catalog/shared --cov-report=term-missing --cov-fail-under=60 tests/unit/
+        run: python -m pytest --cov-config=.coveragerc --cov=scripts --cov=tests/shared --cov=tests/service_catalog/shared --cov-report=term-missing --cov-fail-under=57 tests/unit/
 
       - name: Pytest discovery check
         run: python -m pytest --collect-only tests/

--- a/tests/unit/test_python_check_scope.py
+++ b/tests/unit/test_python_check_scope.py
@@ -120,10 +120,10 @@ def test_justfile_check_python_uses_the_scope_file():
     assert ".python-scope" in recipe, "just check-python must read .python-scope"
 
 
-def test_coverage_scope_stays_distinct_from_check_scope():
-    """.coveragerc is intentionally narrower; keep that documented, not accidental."""
+def test_scripts_tree_is_in_coverage_scope():
+    """Production scripts must contribute to the blocking coverage result."""
     coveragerc = (ROOT / ".coveragerc").read_text(encoding="utf-8")
+    ci_yaml = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
-    assert ".python-scope" in coveragerc, (
-        ".coveragerc must document why its scope differs from .python-scope"
-    )
+    assert "    scripts" in coveragerc, ".coveragerc must measure scripts/"
+    assert "--cov=scripts" in ci_yaml, "CI must report coverage for scripts/"


### PR DESCRIPTION
## Summary

- include `scripts/` in the coverage source set and pytest coverage invocation
- reset the initial coverage ratchet to the measured 57% baseline
- add a regression assertion that production scripts remain covered by CI

Closes #682

## Validation

- `python3 -m pytest --cov-config=.coveragerc --cov=scripts --cov=tests/shared --cov=tests/service_catalog/shared --cov-report=term-missing --cov-fail-under=57 tests/unit/` (548 passed, 1 skipped; 57.26%)
- `./actionlint .github/workflows/ci.yml`
- `git diff --check`
---
🐝 **Hive Agent**: `contributor` | **SHA:** `a8cc6b0a3`

— hive: backend=codex codex=codex-cli 0.153.4